### PR TITLE
Changed capio server startup behavior

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -59,7 +59,7 @@ jobs:
         env:
           CAPIO_DIR: ${{ github.workspace }}
           CAPIO_LOG_LEVEL: -1
-        run: mpirun -n 1 build/src/server/capio_server &
+        run: mpirun -n 1 build/src/server/capio_server --no-config &
       - name: "Run tests"
         id: run-tests
         env:

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -92,4 +92,6 @@ constexpr char CAPIO_SERVER_ARG_PARSER_LOGILE_OPT_HELP[] =
 constexpr char CAPIO_SERVER_ARG_PARSER_CONFIG_OPT_HELP[] =
     "JSON Configuration file for capio_server";
 
+constexpr char CAPIO_SERVER_ARG_PARSER_CONFIG_NO_CONF_FILE_HELP[] =
+    "If specified, server application will start without a config file, using default settings.";
 #endif // CAPIO_COMMON_CONSTANTS_HPP

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -658,6 +658,8 @@ int parseCLI(int argc, char **argv, int rank) {
                                              CAPIO_SERVER_ARG_PARSER_LOGILE_OPT_HELP, {'l', "log"});
     args::ValueFlag<std::string> config(arguments, "filename",
                                         CAPIO_SERVER_ARG_PARSER_CONFIG_OPT_HELP, {'c', "config"});
+    args::Flag noConfigFile(arguments, "no-config",
+                            CAPIO_SERVER_ARG_PARSER_CONFIG_NO_CONF_FILE_HELP, {"no-config"});
 
     try {
         parser.ParseCLI(argc, argv);
@@ -698,14 +700,25 @@ int parseCLI(int argc, char **argv, int rank) {
                   << std::endl;
     }
 
-    if (config) {
-        std::string token            = args::get(config);
-        const std::string *capio_dir = get_capio_dir();
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "parsing config file: " << token << std::endl;
-        parse_conf_file(token, capio_dir);
+    if (noConfigFile) {
+        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "skipping config file parsing" << std::endl;
     } else {
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "started server with default configuration"
-                  << std::endl;
+        if (config) {
+            std::string token            = args::get(config);
+            const std::string *capio_dir = get_capio_dir();
+            std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "parsing config file: " << token
+                      << std::endl;
+            parse_conf_file(token, capio_dir);
+        } else {
+            std::cout
+                << CAPIO_SERVER_CLI_LOG_SERVER_ERROR
+                << "Error: no config file provided. To skip config file use --no-config option!"
+                << std::endl;
+#ifdef CAPIOLOG
+            log->log("no config file provided, and  --no-config not provided");
+#endif
+            exit(EXIT_FAILURE);
+        }
     }
 
     std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "CAPIO_DIR=" << get_capio_dir()->c_str()


### PR DESCRIPTION
Starting capio_Server with a config file is required by default now. To start the server, it is now required to pass the --no-config option.