### PR TITLE
Propagate `CAPIO_VERSION` from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ find_package(Threads REQUIRED)
 #####################################
 # Definitions
 #####################################
+add_compile_definitions(CAPIO_VERSION="${CMAKE_PROJECT_VERSION}")
+
 IF(CAPIO_LOG)
     message(STATUS "Enabling CAPIO logger")
     add_compile_definitions(CAPIOLOG)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ across different distributed applications (e.g. MPI-app1 -> MPI-app2).
 
 CAPIO depends on the following software:
 
-- `cmake >=3.11`
+- `cmake >=3.15`
 - `c++17` or newer
 - `openmpi`
 - `pthreads`
@@ -51,7 +51,7 @@ the first is optional).
    want to execute your program (one daemon for each node). If you desire to specify a custom folder
    for capio, set `CAPIO_DIR` as a environment variable.
    ```bash
-   [CAPIO_DIR=your_capiodir] mpiexec -N 1 --hostfile your_hostfile src/capio_server conf.json 
+   [CAPIO_DIR=your_capiodir] mpiexec -N 1 --hostfile your_hostfile src/capio_server -c conf.json 
    ```
 
 > [!NOTE] 
@@ -129,8 +129,8 @@ documentation about the configuration file!
 
 The [examples](examples) folder contains some examples that shows how to use mpi_io with CAPIO. 
 There are also examples on how to write JSON configuration files:
-- [on_close](https://github.com/High-Performance-IO/capio/wiki/Examples#noupdate-semantic): A pipeline composed by a producer and a consumer with "on_close" semantics
-- [noupdate](https://github.com/High-Performance-IO/capio/wiki/Examples#on_close-semantics): A pipeline composed by a producer and a consumer with "update" semantics
+- [on_close](https://github.com/High-Performance-IO/capio/wiki/Examples#on_close-semantic): A pipeline composed by a producer and a consumer with "on_close" semantics
+- [noupdate](https://github.com/High-Performance-IO/capio/wiki/Examples#noupdate-semantics): A pipeline composed by a producer and a consumer with "noupdate" semantics
 - [mix_semantics](https://github.com/High-Performance-IO/capio/wiki/Examples#mixed-semantics): A pipeline composed by a producer and a consumer with mix semantics
 
 ## CAPIO Team

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -3,8 +3,6 @@
 
 #include <sys/types.h>
 
-#define CAPIO_VERSION "0.0.1"
-
 constexpr size_t DIR_INITIAL_SIZE = 1024L * 1024 * 1024;
 
 constexpr int DNAME_LENGTH = 128;


### PR DESCRIPTION
This commit injects the `CMAKE_PROJECT_VERSION` variable as a compiler definition called `CAPIO_VERSION`, enabling its usage from preprocessor macros. This implementation avoids to duplicate the CAPIO version definition.