### PR TITLE
Improve CAPIO path handling

### DIFF
--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -1,12 +1,14 @@
 #ifndef CAPIO_COMMON_ENV_HPP
 #define CAPIO_COMMON_ENV_HPP
 
+#include <sys/stat.h>
+
 #include <charconv>
 #include <climits>
 #include <cstdlib>
 #include <filesystem>
+#include <iostream>
 
-#include "filesystem.hpp"
 #include "logger.hpp"
 #include "syscall.hpp"
 

--- a/src/common/capio/shm.hpp
+++ b/src/common/capio/shm.hpp
@@ -11,7 +11,6 @@
 void *create_shm(const std::string &shm_name, const long int size) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s, size=%ld)", shm_name.c_str(), size);
 
-    void *p;
     // if we are not creating a new object, mode is equals to 0
     int fd = shm_open(shm_name.c_str(), O_CREAT | O_RDWR,
                       S_IRUSR | S_IWUSR); // to be closed
@@ -21,7 +20,7 @@ void *create_shm(const std::string &shm_name, const long int size) {
     if (ftruncate(fd, size) == -1) {
         ERR_EXIT("ftruncate create_shm %s", shm_name.c_str());
     }
-    p = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    void *p = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (p == MAP_FAILED) {
         ERR_EXIT("mmap create_shm %s", shm_name.c_str());
     }
@@ -34,7 +33,6 @@ void *create_shm(const std::string &shm_name, const long int size) {
 void *get_shm(const std::string &shm_name) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s)", shm_name.c_str());
 
-    void *p;
     // if we are not creating a new object, mode is equals to 0
     int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
     struct stat sb {};
@@ -47,7 +45,7 @@ void *get_shm(const std::string &shm_name) {
     if (fstat(fd, &sb) == -1) {
         ERR_EXIT("fstat %s", shm_name.c_str());
     }
-    p = mmap(nullptr, sb.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    void *p = mmap(nullptr, sb.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (p == MAP_FAILED) {
         ERR_EXIT("mmap get_shm %s", shm_name.c_str());
     }
@@ -60,7 +58,6 @@ void *get_shm(const std::string &shm_name) {
 void *get_shm_if_exist(const std::string &shm_name) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s)", shm_name.c_str());
 
-    void *p;
     // if we are not creating a new object, mode is equals to 0
     int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
     struct stat sb {};
@@ -76,7 +73,7 @@ void *get_shm_if_exist(const std::string &shm_name) {
     if (fstat(fd, &sb) == -1) {
         ERR_EXIT("fstat %s", shm_name.c_str());
     }
-    p = mmap(nullptr, sb.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    void *p = mmap(nullptr, sb.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (p == MAP_FAILED) {
         ERR_EXIT("mmap get_shm %s", shm_name.c_str());
     }

--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -19,9 +19,7 @@ inline int capio_chdir(const std::string *path, long tid) {
         path_to_check = capio_posix_realpath(tid, path, capio_dir, current_dir);
     }
 
-    auto res = std::mismatch(capio_dir->begin(), capio_dir->end(), path_to_check->c_str());
-
-    if (res.first == capio_dir->end()) {
+    if (is_capio_path(*path_to_check)) {
         delete current_dir;
         current_dir = path_to_check;
         return 0;
@@ -33,12 +31,8 @@ inline int capio_chdir(const std::string *path, long tid) {
 int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     std::string path(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(path=%s)", path.c_str());
 
-    const std::string *pathname_abs =
-        capio_posix_realpath(tid, &path, get_capio_dir(), current_dir);
-
-    int res = capio_chdir(pathname_abs, tid);
+    int res = capio_chdir(&path, tid);
 
     if (res != -2) {
         *result = (res < 0 ? -errno : res);

--- a/src/posix/handlers/close.hpp
+++ b/src/posix/handlers/close.hpp
@@ -21,7 +21,6 @@ inline int capio_close(int fd, long tid) {
 int close_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int fd   = static_cast<int>(arg0);
     long tid = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%d)", fd);
 
     int res = capio_close(fd, tid);
     if (res != -2) {

--- a/src/posix/handlers/dup.hpp
+++ b/src/posix/handlers/dup.hpp
@@ -46,7 +46,6 @@ inline int capio_dup2(int fd, int fd2, long tid) {
 int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     long tid = syscall_no_intercept(SYS_gettid);
     int fd   = static_cast<int>(arg0);
-    START_LOG(tid, "call(%d)", fd);
 
     int res = capio_dup(fd, tid);
     if (res != -2) {
@@ -60,7 +59,6 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     long tid = syscall_no_intercept(SYS_gettid);
     int fd   = static_cast<int>(arg0);
     int fd2  = static_cast<int>(arg1);
-    START_LOG(tid, "call(fd=%d, fd2=%d)", fd, fd2);
 
     int res = capio_dup2(fd, fd2, tid);
     if (res != -2) {

--- a/src/posix/handlers/fcntl.hpp
+++ b/src/posix/handlers/fcntl.hpp
@@ -60,7 +60,6 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto cmd = static_cast<int>(arg1);
     auto arg = static_cast<int>(arg2);
     long tid = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%d, cmd=%d, arg=%d)", fd, cmd, arg);
 
     int res = capio_fcntl(fd, cmd, arg, tid);
 

--- a/src/posix/handlers/fgetxattr.hpp
+++ b/src/posix/handlers/fgetxattr.hpp
@@ -25,7 +25,6 @@ int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
     auto *value = reinterpret_cast<void *>(arg2);
     auto size   = static_cast<size_t>(arg3);
     long tid    = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(name=%s, value=0x%08x, size=%ld)", name.c_str(), value, size);
 
     int res = capio_fgetxattr(static_cast<int>(arg0), name, value, size, tid);
 

--- a/src/posix/handlers/fork.hpp
+++ b/src/posix/handlers/fork.hpp
@@ -21,7 +21,6 @@ inline pid_t capio_fork(long parent_tid) {
 
 int fork_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     long tid = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call()");
 
     int res = capio_fork(tid);
     *result = (res < 0 ? -errno : res);

--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -19,7 +19,6 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     std::string buf(reinterpret_cast<char *>(arg0));
     auto size = static_cast<size_t>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(buf=0x%08x, size=%ld)", buf.c_str(), size);
 
     auto rescw = capio_getcwd(&buf, size, tid);
     if (rescw == nullptr) {

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -31,7 +31,7 @@ inline off64_t add_getdents_request(int fd, off64_t count,
 
 // TODO: too similar to capio_read, refactoring needed
 inline ssize_t capio_getdents(int fd, void *buffer, size_t count, bool is_getdents64, long tid) {
-    START_LOG(tid, "call(fd=%d, dirp=0x%08x, count=%ld, is64bit=%s", fd, buffer, count,
+    START_LOG(tid, "call(fd=%d, dirp=0x%08x, count=%ld, is64bit=%s)", fd, buffer, count,
               is_getdents64 ? "true" : "false");
 
     if (files->find(fd) != files->end()) {
@@ -64,8 +64,6 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
     auto *dirp = reinterpret_cast<struct linux_dirent *>(arg1);
     auto count = static_cast<size_t>(arg2);
     long tid   = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%d, dirp=0x%08x, count=%ld, is64bit=%s", fd, dirp, count,
-              is64bit ? "true" : "false");
 
     auto res = capio_getdents(fd, dirp, count, is64bit, tid);
 

--- a/src/posix/handlers/ioctl.hpp
+++ b/src/posix/handlers/ioctl.hpp
@@ -18,7 +18,6 @@ int ioctl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto fd      = static_cast<int>(arg0);
     auto request = static_cast<unsigned long>(arg1);
     long tid     = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%ld, request=%ld)", arg0, arg1);
 
     int res = capio_ioctl(fd, request, tid);
     if (res != -2) {

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -59,7 +59,6 @@ int lseek_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto offset = static_cast<off64_t>(arg1);
     int whence  = static_cast<int>(arg2);
     long tid    = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%d, offset=%ld, whence=%d)", fd, offset, whence);
 
     off64_t res = capio_lseek(fd, offset, whence, tid);
 

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -96,7 +96,6 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
 int creat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     std::string pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(pathname=%s)", pathname.c_str());
 
     int res = capio_openat(AT_FDCWD, &pathname, O_CREAT | O_WRONLY | O_TRUNC, tid);
 
@@ -112,8 +111,6 @@ int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     std::string pathname(reinterpret_cast<const char *>(arg1));
     int flags = static_cast<int>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
-
-    START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%X)", dirfd, pathname.c_str(), flags);
 
     int res = capio_openat(dirfd, &pathname, flags, tid);
 

--- a/src/posix/handlers/read.hpp
+++ b/src/posix/handlers/read.hpp
@@ -29,7 +29,6 @@ int read_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     void *buf  = reinterpret_cast<void *>(arg1);
     auto count = static_cast<off64_t>(arg2);
     long tid   = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%d, buf=0x%08x, count=%ld)", fd, buf, count);
 
     off64_t res = capio_read(fd, buf, count, tid);
 

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -18,7 +18,7 @@ inline off64_t capio_rename(const std::string &oldpath, const std::string &newpa
         oldpath_abs = *capio_posix_realpath(tid, &oldpath, capio_dir, current_dir);
     }
 
-    bool oldpath_capio = is_capio_path(tid, oldpath_abs, *capio_dir);
+    bool oldpath_capio = is_capio_path(oldpath_abs);
 
     if (is_absolute(&newpath)) { // TODO: move this control inside create_absolute_path
         newpath_abs = newpath;
@@ -26,7 +26,7 @@ inline off64_t capio_rename(const std::string &oldpath, const std::string &newpa
         newpath_abs = *capio_posix_realpath(tid, &newpath, capio_dir, current_dir);
     }
 
-    bool newpath_capio = is_capio_path(tid, newpath_abs, *capio_dir);
+    bool newpath_capio = is_capio_path(newpath_abs);
 
     if (is_prefix(oldpath_abs, newpath_abs)) { // TODO: The check is more complex
         errno = EINVAL;
@@ -51,8 +51,6 @@ int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     const std::string oldpath(reinterpret_cast<const char *>(arg0));
     const std::string newpath(reinterpret_cast<const char *>(arg1));
     long tid = syscall_no_intercept(SYS_gettid);
-
-    START_LOG(tid, "call(oldpath=%s, newpath=%s)", oldpath.c_str(), newpath.c_str());
 
     off64_t res = capio_rename(oldpath, newpath, tid);
 

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -55,7 +55,6 @@ int write_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     const auto *buf = reinterpret_cast<const void *>(arg1);
     auto count      = static_cast<off64_t>(arg2);
     long tid        = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%d, buf=0x%08x, count=%ld)", fd, buf, count);
 
     ssize_t res = capio_write(fd, buf, count, tid);
 
@@ -72,8 +71,6 @@ int writev_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     const auto *iov = reinterpret_cast<const struct iovec *>(arg1);
     auto iovcnt     = static_cast<int>(arg2);
     long tid        = syscall_no_intercept(SYS_gettid);
-    START_LOG(tid, "call(fd=%d, iov.iov_base=0x%08x, iov.iov_len=%ld, iovcnt=%d)", fd,
-              iov->iov_base, iov->iov_len, iovcnt);
 
     ssize_t res = capio_writev(fd, iov, iovcnt, tid);
 

--- a/src/posix/utils/filesystem.hpp
+++ b/src/posix/utils/filesystem.hpp
@@ -42,12 +42,4 @@ std::string get_dir_path(int dirfd) {
     }
 }
 
-inline blkcnt_t get_nblocks(off64_t file_size) {
-    if (file_size % 4096 == 0) {
-        return file_size / 512;
-    }
-
-    return file_size / 512 + 8;
-}
-
 #endif // CAPIO_POSIX_UTILS_FILESYSTEM_HPP

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -86,10 +86,9 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool dir, bool is_
             }
         }
     } else {
-        c_file  = init_capio_file(path.data(), false);
-        char *p = c_file.get_buffer();
-        size_t bytes_read;
-        bytes_read = count;
+        c_file            = init_capio_file(path.data(), false);
+        char *p           = c_file.get_buffer();
+        size_t bytes_read = count;
         if (is_getdents) {
             off64_t dir_size  = c_file.get_stored_size();
             off64_t n_entries = dir_size / THEORETICAL_SIZE_DIRENT64;
@@ -232,8 +231,9 @@ inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getden
     std::string_view path        = get_capio_file_path(tid, fd);
     const std::string *capio_dir = get_capio_dir();
     bool is_prod                 = is_producer(tid, path.data());
+    auto file_location_opt       = get_file_location_opt(path.data());
 
-    if (!get_file_location_opt(path.data()) && !is_prod) {
+    if (!file_location_opt && !is_prod) {
         bool found = check_file_location(rank, path.data());
         if (!found) {
             // launch a thread that checks when the file is created
@@ -241,7 +241,7 @@ inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getden
             t.detach();
         }
     }
-    if (is_prod || strcmp(std::get<0>(get_file_location(path.data())), node_name) == 0 ||
+    if (is_prod || strcmp(std::get<0>(file_location_opt->get()), node_name) == 0 ||
         *capio_dir == path) {
         handle_local_read(tid, fd, count, dir, is_getdents, is_prod);
     } else {

--- a/src/server/utils/metadata.hpp
+++ b/src/server/utils/metadata.hpp
@@ -4,6 +4,8 @@
 #include <mutex>
 #include <optional>
 
+#include "capio/filesystem.hpp"
+
 CSFilesMetadata_t files_metadata;
 std::mutex files_metadata_mutex;
 


### PR DESCRIPTION
This commit improves path comparison in CAPIO by relying on the modern `std::filesystem` interface of C++17.