### PR TITLE
Capture `statx` syscall

### DIFF
--- a/src/posix/handlers.hpp
+++ b/src/posix/handlers.hpp
@@ -22,6 +22,8 @@
 #include "handlers/read.hpp"
 #include "handlers/rename.hpp"
 #include "handlers/stat.hpp"
+#include "handlers/statfs.hpp"
+#include "handlers/statx.hpp"
 #include "handlers/unlink.hpp"
 #include "handlers/write.hpp"
 

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -12,33 +12,38 @@ inline blkcnt_t get_nblocks(off64_t file_size) {
     return (file_size % 4096 == 0) ? (file_size / 512) : (file_size / 512 + 8);
 }
 
+inline void fill_statbuf(struct stat *statbuf, off_t file_size, bool is_dir, ino_t inode) {
+    struct timespec time {
+        1, 1
+    };
+    if (is_dir == 0) {
+        statbuf->st_mode = S_IFDIR | S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+        file_size        = 4096;
+    } else {
+        statbuf->st_mode = S_IFREG | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+    }
+    statbuf->st_dev     = 100;
+    statbuf->st_ino     = inode;
+    statbuf->st_nlink   = 1;
+    statbuf->st_uid     = syscall_no_intercept(SYS_getuid);
+    statbuf->st_gid     = syscall_no_intercept(SYS_getgid);
+    statbuf->st_rdev    = 0;
+    statbuf->st_size    = file_size;
+    statbuf->st_blksize = 4096;
+    statbuf->st_blocks  = (file_size < 4096) ? 8 : get_nblocks(file_size);
+    statbuf->st_atim    = time;
+    statbuf->st_mtim    = time;
+    statbuf->st_ctim    = time;
+}
+
 inline int capio_fstat(int fd, struct stat *statbuf, long tid) {
     START_LOG(tid, "call(fd=%d, statbuf=0x%08x)", fd, statbuf);
 
     auto it = files->find(fd);
     if (it != files->end()) {
-        struct timespec time {
-            1, 1
-        };
         auto [file_size, is_dir] = fstat_request(fd, tid);
-        if (is_dir == 0) {
-            statbuf->st_mode = S_IFDIR | S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
-            file_size        = 4096;
-        } else {
-            statbuf->st_mode = S_IFREG | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-        }
-        statbuf->st_dev     = 100;
-        statbuf->st_ino     = std::hash<std::string>{}((*capio_files_descriptors)[fd]);
-        statbuf->st_nlink   = 1;
-        statbuf->st_uid     = syscall_no_intercept(SYS_getuid);
-        statbuf->st_gid     = syscall_no_intercept(SYS_getgid);
-        statbuf->st_rdev    = 0;
-        statbuf->st_size    = file_size;
-        statbuf->st_blksize = 4096;
-        statbuf->st_blocks  = (file_size < 4096) ? 8 : get_nblocks(file_size);
-        statbuf->st_atim    = time;
-        statbuf->st_mtim    = time;
-        statbuf->st_ctim    = time;
+        fill_statbuf(statbuf, file_size, is_dir,
+                     std::hash<std::string>{}((*capio_files_descriptors)[fd]));
         return 0;
     } else {
         return -2;
@@ -49,28 +54,8 @@ inline int capio_lstat(const std::string &absolute_path, struct stat *statbuf, l
     START_LOG(tid, "call(absolute_path=%s, statbuf=0x%08x)", absolute_path.c_str(), statbuf);
 
     if (is_capio_path(absolute_path)) {
-        struct timespec time {
-            1, 1
-        };
         auto [file_size, is_dir] = stat_request(absolute_path, tid);
-        if (is_dir == 0) {
-            statbuf->st_mode = S_IFDIR | S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
-            file_size        = 4096;
-        } else {
-            statbuf->st_mode = S_IFREG | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-        }
-        statbuf->st_dev     = 100;
-        statbuf->st_ino     = std::hash<std::string>{}(absolute_path);
-        statbuf->st_nlink   = 1;
-        statbuf->st_uid     = syscall_no_intercept(SYS_getuid);
-        statbuf->st_gid     = syscall_no_intercept(SYS_getgid);
-        statbuf->st_rdev    = 0;
-        statbuf->st_size    = file_size;
-        statbuf->st_blksize = 4096;
-        statbuf->st_blocks  = (file_size < 4096) ? 8 : get_nblocks(file_size);
-        statbuf->st_atim    = time;
-        statbuf->st_mtim    = time;
-        statbuf->st_ctim    = time;
+        fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path));
         return 0;
     } else {
         return -2;
@@ -140,19 +125,6 @@ inline int capio_fstatat(int dirfd, std::string *pathname, struct stat *statbuf,
     }
 }
 
-inline int capio_fstatfs(int fd, struct statfs *buf, long tid) {
-    START_LOG(tid, "call(fd=%d, buf=0x%08x)", fd, buf);
-
-    if (files->find(fd) != files->end()) {
-        std::string path             = (*capio_files_descriptors)[fd];
-        const std::string *capio_dir = get_capio_dir();
-
-        return statfs(capio_dir->c_str(), buf);
-    } else {
-        return -2;
-    }
-}
-
 int fstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     auto fd   = static_cast<int>(arg0);
     auto *buf = reinterpret_cast<struct stat *>(arg1);
@@ -176,21 +148,6 @@ int fstatat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
     long tid      = syscall_no_intercept(SYS_gettid);
 
     int res = capio_fstatat(dirfd, &pathname, statbuf, flags, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
-}
-
-int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
-                    long *result) {
-    auto fd   = static_cast<int>(arg0);
-    auto *buf = reinterpret_cast<struct statfs *>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
-
-    int res = capio_fstatfs(fd, buf, tid);
 
     if (res != -2) {
         *result = (res < 0 ? -errno : res);

--- a/src/posix/handlers/statfs.hpp
+++ b/src/posix/handlers/statfs.hpp
@@ -1,0 +1,34 @@
+#ifndef CAPIO_POSIX_HANDLERS_STATFS_HPP
+#define CAPIO_POSIX_HANDLERS_STATFS_HPP
+
+#include "globals.hpp"
+
+inline int capio_fstatfs(int fd, struct statfs *buf, long tid) {
+    START_LOG(tid, "call(fd=%d, buf=0x%08x)", fd, buf);
+
+    if (files->find(fd) != files->end()) {
+        std::string path             = (*capio_files_descriptors)[fd];
+        const std::string *capio_dir = get_capio_dir();
+
+        return static_cast<int>(syscall_no_intercept(SYS_statfs, capio_dir->c_str(), buf));
+    } else {
+        return -2;
+    }
+}
+
+int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                    long *result) {
+    auto fd   = static_cast<int>(arg0);
+    auto *buf = reinterpret_cast<struct statfs *>(arg1);
+    long tid  = syscall_no_intercept(SYS_gettid);
+
+    int res = capio_fstatfs(fd, buf, tid);
+
+    if (res != -2) {
+        *result = (res < 0 ? -errno : res);
+        return 0;
+    }
+    return 1;
+}
+
+#endif // CAPIO_POSIX_HANDLERS_STATFS_HPP

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -1,0 +1,101 @@
+#ifndef CAPIO_POSIX_HANDLERS_STATX_HPP
+#define CAPIO_POSIX_HANDLERS_STATX_HPP
+
+inline void fill_statxbuf(struct statx *statxbuf, off_t file_size, bool is_dir, ino_t inode,
+                          int mask) {
+    statx_timestamp time{1, 1};
+    if (is_dir == 0) {
+        statxbuf->stx_mode |= S_IFDIR;
+        statxbuf->stx_mode |= S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+        file_size = 4096;
+    } else {
+        statxbuf->stx_mode |= S_IFREG;
+        statxbuf->stx_mode |= S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+    }
+    statxbuf->stx_mask            = STATX_BASIC_STATS | STATX_BTIME;
+    statxbuf->stx_attributes_mask = 0;
+    statxbuf->stx_blksize         = 4096;
+    statxbuf->stx_nlink           = 1;
+    statxbuf->stx_uid             = syscall_no_intercept(SYS_getuid);
+    statxbuf->stx_gid             = syscall_no_intercept(SYS_getgid);
+    statxbuf->stx_ino             = inode;
+    statxbuf->stx_size            = file_size;
+    statxbuf->stx_blocks          = (file_size < 4096) ? 8 : get_nblocks(file_size);
+    statxbuf->stx_atime           = time;
+    statxbuf->stx_btime           = time;
+    statxbuf->stx_ctime           = time;
+    statxbuf->stx_mtime           = time;
+}
+
+inline int capio_statx(int dirfd, const std::string *pathname, int flags, int mask,
+                       struct statx *statxbuf, long tid) {
+    START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%d, mask=%d, statxbuf=0x%08x)", dirfd,
+              pathname->c_str(), flags, mask, statxbuf);
+
+    const std::string *capio_dir = get_capio_dir();
+    std::string absolute_path    = *pathname;
+    if ((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH) {
+        if (dirfd == AT_FDCWD) { // operate on currdir
+            absolute_path = get_current_dir_name();
+        } else { // operate on dirfd. in this case dirfd can refer to any type of file
+            if (pathname->length() != 0) {
+                if (files->find(dirfd) != files->end()) {
+                    absolute_path = (*capio_files_descriptors)[dirfd];
+                } else {
+                    return -2;
+                }
+            } else {
+                // TODO: set errno
+                return -1;
+            }
+        }
+    } else {
+        if (!is_absolute(pathname)) {
+            if (dirfd == AT_FDCWD) {
+                absolute_path = *capio_posix_realpath(tid, pathname, capio_dir, current_dir);
+            } else {
+                if (!is_directory(dirfd)) {
+                    return -2;
+                }
+                std::string dir_path = get_dir_path(dirfd);
+                if (dir_path.length() == 0) {
+                    return -2;
+                }
+                if (pathname->substr(0, 2) == "./") {
+                    absolute_path = pathname->substr(2, pathname->length() - 1);
+                }
+                if (absolute_path.at(absolute_path.length() - 1) == '.') {
+                    absolute_path = dir_path;
+                } else {
+                    absolute_path = dir_path + "/" + absolute_path;
+                }
+            }
+        }
+        if (!is_capio_path(absolute_path)) {
+            return -2;
+        }
+    }
+
+    auto [file_size, is_dir] = stat_request(absolute_path, tid);
+    fill_statxbuf(statxbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path), mask);
+    return 0;
+}
+
+int statx_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+    auto dirfd = static_cast<int>(arg0);
+    std::string pathname(reinterpret_cast<const char *>(arg1));
+    auto flags = static_cast<int>(arg2);
+    auto mask  = static_cast<int>(arg3);
+    auto *buf  = reinterpret_cast<struct statx *>(arg4);
+    long tid   = syscall_no_intercept(SYS_gettid);
+
+    int res = capio_statx(dirfd, &pathname, flags, mask, buf, tid);
+
+    if (res != -2) {
+        *result = (res < 0 ? -errno : res);
+        return 0;
+    }
+    return 1;
+}
+
+#endif // CAPIO_POSIX_HANDLERS_STATX_HPP

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -74,6 +74,7 @@ static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
     _syscallTable[SYS_read]       = read_handler;
     _syscallTable[SYS_rename]     = rename_handler;
     _syscallTable[SYS_stat]       = lstat_handler;
+    _syscallTable[SYS_statx]      = statx_handler;
     _syscallTable[SYS_unlink]     = unlink_handler;
     _syscallTable[SYS_unlinkat]   = unlinkat_handler;
     _syscallTable[SYS_write]      = write_handler;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,8 +7,9 @@ set(TARGET_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/posix/directory.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/posix/file.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/posix/rename.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/write.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/posix/stat.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/posix/statx.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/posix/write.cpp
 )
 
 #####################################

--- a/tests/posix/stat.cpp
+++ b/tests/posix/stat.cpp
@@ -1,34 +1,202 @@
-#include <semaphore.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <filesystem>
 #include <thread>
-sem_t *sem1;
 
-int write_file_stat(FILE *fp) {
-    constexpr int ARRAY_SIZE = 100;
+void check_statbuf(struct stat &buf, unsigned long st_size) {
+    REQUIRE(buf.st_blocks == 8);
+    REQUIRE(buf.st_gid == getgid());
+    REQUIRE(buf.st_size == static_cast<off_t>(st_size));
+    REQUIRE(buf.st_uid == getuid());
+}
+
+TEST_CASE("Test stat syscall on file", "[posix]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = open(PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    REQUIRE(close(fd) != -1);
+    struct stat statbuf {};
+    REQUIRE(stat(PATHNAME, &statbuf) == 0);
+    check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test stat syscall on folder", "[posix]") {
+    constexpr const char *PATHNAME = "test";
+    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    struct stat statbuf {};
+    REQUIRE(stat(PATHNAME, &statbuf) == 0);
+    check_statbuf(statbuf, 4096);
+    REQUIRE(rmdir(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test fstat syscall on file", "[posix]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = open(PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    struct stat statbuf {};
+    REQUIRE(fstat(fd, &statbuf) == 0);
+    check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(close(fd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test fstat syscall on folder", "[posix]") {
+    constexpr const char *PATHNAME = "test";
+    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    int flags = O_RDONLY | O_DIRECTORY;
+    int fd    = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    struct stat statbuf {};
+    REQUIRE(fstat(fd, &statbuf) == 0);
+    check_statbuf(statbuf, 4096);
+    REQUIRE(close(fd) != -1);
+    REQUIRE(rmdir(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test fstatat syscall on file with AT_FDCWD", "[posix]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = openat(AT_FDCWD, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    REQUIRE(close(fd) != -1);
+    struct stat statbuf {};
+    REQUIRE(fstatat(AT_FDCWD, PATHNAME, &statbuf, 0) == 0);
+    check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test fstatat syscall on folder with AT_FDCWD", "[posix]") {
+    constexpr const char *PATHNAME = "test";
+    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    struct stat statbuf {};
+    REQUIRE(fstatat(AT_FDCWD, PATHNAME, &statbuf, 0) == 0);
+    check_statbuf(statbuf, 4096);
+    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test fstatat syscall on file in a different directory using absolute path", "[posix]") {
+    const auto path_fs =
+        std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
+    const char *PATHNAME = path_fs.c_str();
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = openat(0, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    REQUIRE(close(fd) != -1);
+    struct stat statbuf {};
+    REQUIRE(fstatat(0, PATHNAME, &statbuf, 0) == 0);
+    check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(unlinkat(0, PATHNAME, 0) != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test fstatat syscall on folder in a different directory using absolute path",
+          "[posix]") {
+    const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
+    const char *PATHNAME = path_fs.c_str();
+    REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    struct stat statbuf {};
+    REQUIRE(fstatat(0, PATHNAME, &statbuf, 0) == 0);
+    check_statbuf(statbuf, 4096);
+    REQUIRE(unlinkat(0, PATHNAME, AT_REMOVEDIR) != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test fstatat syscall on file in a different directory using dirfd", "[posix]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    const char *DIRPATH            = std::getenv("PWD");
+    int dirfd                      = open(DIRPATH, O_RDONLY | O_DIRECTORY);
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = openat(dirfd, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    REQUIRE(close(fd) != -1);
+    struct stat statbuf {};
+    REQUIRE(fstatat(dirfd, PATHNAME, &statbuf, 0) == 0);
+    check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(unlinkat(dirfd, PATHNAME, 0) != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test fstatat syscall on folder in a different directory using dirfd", "[posix]") {
+    constexpr const char *PATHNAME = "test";
+    const char *DIRPATH            = std::getenv("PWD");
+    int flags                      = O_RDONLY | O_DIRECTORY;
+    int dirfd                      = open(DIRPATH, flags);
+    REQUIRE(dirfd != -1);
+    REQUIRE(mkdirat(dirfd, PATHNAME, S_IRWXU) != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    struct stat statbuf {};
+    REQUIRE(fstatat(dirfd, PATHNAME, &statbuf, 0) == 0);
+    check_statbuf(statbuf, 4096);
+    REQUIRE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR) != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
+    REQUIRE(close(dirfd) != -1);
+}
+
+TEST_CASE("Test file creation, write and close using stat", "[posix]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr int ARRAY_SIZE       = 100;
     int array[ARRAY_SIZE];
     for (int i = 0; i < ARRAY_SIZE; i++) {
         array[i] = i;
     }
-    REQUIRE(fwrite(array, sizeof(int), ARRAY_SIZE, fp) == ARRAY_SIZE);
-    REQUIRE(sem_post(sem1) == 0);
-    return 0;
-}
-
-TEST_CASE("Test stat", "[posix]") {
-    constexpr const char *PATHNAME = "test_file.txt";
-    sem1                           = static_cast<sem_t *>(malloc(sizeof(sem_t)));
-    REQUIRE(sem_init(sem1, 0, 0) == 0);
     FILE *fp = fopen(PATHNAME, "w+");
     REQUIRE(fp != nullptr);
-    write_file_stat(fp);
-    REQUIRE(sem_wait(sem1) == 0);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(fwrite(array, sizeof(int), ARRAY_SIZE, fp) == ARRAY_SIZE);
     REQUIRE(fseek(fp, 0, SEEK_SET) != -1);
     int num;
-    while (fread(&num, sizeof(int), 1, fp) != 0)
-        ;
+    for (int i = 0; i < ARRAY_SIZE; i++) {
+        REQUIRE(fread(&num, sizeof(int), 1, fp) == 1);
+        REQUIRE(num == i);
+    }
+    REQUIRE(fread(&num, sizeof(int), 1, fp) == 0);
     REQUIRE(feof(fp) != 0);
-    REQUIRE(fclose(fp) != EOF);
+    REQUIRE(fclose(fp) != -1);
     REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test directory creation, reopening and close with stat", "[posix]") {
+    constexpr const char *PATHNAME = "test";
+    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
+    FILE *fp = fopen(PATHNAME, "r");
+    REQUIRE(fp != nullptr);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(fclose(fp) != -1);
+    fp = fopen(PATHNAME, "r");
+    REQUIRE(fp != nullptr);
+    REQUIRE(fclose(fp) != -1);
+    REQUIRE(rmdir(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
 }

--- a/tests/posix/statx.cpp
+++ b/tests/posix/statx.cpp
@@ -1,0 +1,105 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+void check_statxbuf(struct statx &buf, unsigned long st_size) {
+    REQUIRE(buf.stx_blocks == 8);
+    REQUIRE(buf.stx_gid == getgid());
+    REQUIRE(buf.stx_size == st_size);
+    REQUIRE(buf.stx_uid == getuid());
+}
+
+TEST_CASE("Test statx syscall on file with AT_FDCWD", "[posix]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = openat(AT_FDCWD, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    REQUIRE(close(fd) != -1);
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test statx syscall on folder with AT_FDCWD", "[posix]") {
+    constexpr const char *PATHNAME = "test";
+    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, 4096);
+    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test statx syscall on file in a different directory using absolute path", "[posix]") {
+    const auto path_fs =
+        std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
+    const char *PATHNAME = path_fs.c_str();
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = openat(0, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    REQUIRE(close(fd) != -1);
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(unlinkat(0, PATHNAME, 0) != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test statx syscall on folder in a different directory using absolute path", "[posix]") {
+    const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
+    const char *PATHNAME = path_fs.c_str();
+    REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, 4096);
+    REQUIRE(unlinkat(0, PATHNAME, AT_REMOVEDIR) != -1);
+    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test statx syscall on file in a different directory using dirfd", "[posix]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    const char *DIRPATH            = std::getenv("PWD");
+    int dirfd                      = open(DIRPATH, O_RDONLY | O_DIRECTORY);
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int fd = openat(dirfd, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(fd != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    REQUIRE(close(fd) != -1);
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(unlinkat(dirfd, PATHNAME, 0) != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test statx syscall on folder in a different directory using dirfd", "[posix]") {
+    constexpr const char *PATHNAME = "test";
+    const char *DIRPATH            = std::getenv("PWD");
+    int flags                      = O_RDONLY | O_DIRECTORY;
+    int dirfd                      = open(DIRPATH, flags);
+    REQUIRE(dirfd != -1);
+    REQUIRE(mkdirat(dirfd, PATHNAME, S_IRWXU) != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, 4096);
+    REQUIRE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR) != -1);
+    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
+    REQUIRE(close(dirfd) != -1);
+}


### PR DESCRIPTION
This commit adds a `capio_statx` function that captures the `statx` system call. In addition, this commit introduces new unit tests for the `stat` family of syscalls and for the new `statx`.