### PR TITLE
Improve test suite

### DIFF
--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -4,6 +4,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
+#include <fstream>
 #include <string>
 #include <utility>
 

--- a/src/common/capio/syscall.hpp
+++ b/src/common/capio/syscall.hpp
@@ -4,7 +4,9 @@
 #include <syscall.h>
 
 #ifdef __CAPIO_POSIX
+
 #include <libsyscall_intercept_hook_point.h>
+
 #define capio_syscall syscall_no_intercept
 
 /* Allows CAPIO to deactivate syscalls hooking. */

--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -6,7 +6,7 @@
 inline off64_t capio_access(const std::string *pathname, mode_t mode, long tid) {
     START_LOG(tid, "call(pathname=%s, mode=%o)", pathname->c_str(), mode);
 
-    const std::string *abs_pathname = capio_posix_realpath(tid, pathname);
+    const std::string *abs_pathname = capio_posix_realpath(pathname);
     if (abs_pathname->length() == 0) {
         errno = ENONET;
         return -1;

--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -14,7 +14,7 @@ inline int capio_chdir(const std::string *path, long tid) {
     START_LOG(tid, "call(path=%s)", path);
 
     if (!is_absolute(path)) {
-        path_to_check = capio_posix_realpath(tid, path);
+        path_to_check = capio_posix_realpath(path);
     }
 
     if (is_capio_path(*path_to_check)) {

--- a/src/posix/handlers/mkdir.hpp
+++ b/src/posix/handlers/mkdir.hpp
@@ -9,7 +9,7 @@ inline off64_t capio_mkdirat(int dirfd, std::string *pathname, mode_t mode, long
     std::string path_to_check(*pathname);
     if (!is_absolute(pathname)) {
         if (dirfd == AT_FDCWD) {
-            path_to_check = *capio_posix_realpath(tid, pathname);
+            path_to_check = *capio_posix_realpath(pathname);
             if (path_to_check.length() == 0) {
                 return -2;
             }
@@ -48,7 +48,7 @@ inline off64_t capio_rmdir(std::string *pathname, long tid) {
 
     std::string path_to_check(*pathname);
     if (!is_absolute(pathname)) {
-        path_to_check = *capio_posix_realpath(tid, pathname);
+        path_to_check = *capio_posix_realpath(pathname);
         if (path_to_check.length() == 0) {
             LOG("path_to_check.len = 0!");
             return -2;

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -17,7 +17,7 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
 
     if (!is_absolute(pathname)) {
         if (dirfd == AT_FDCWD) {
-            path_to_check = *capio_posix_realpath(tid, pathname);
+            path_to_check = *capio_posix_realpath(pathname);
             if (path_to_check.length() == 0) {
                 return -2;
             }

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -4,7 +4,7 @@
 #include "utils/filesystem.hpp"
 
 inline std::string absolute(long tid, const std::string &path) {
-    return is_absolute(&path) ? path : *capio_posix_realpath(tid, &path);
+    return is_absolute(&path) ? path : *capio_posix_realpath(&path);
 }
 
 inline off64_t capio_rename(const std::string &oldpath, const std::string &newpath, long tid) {

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -67,7 +67,7 @@ inline int capio_lstat_wrapper(const std::string *path, struct stat *statbuf, lo
         return -2;
     }
 
-    const std::string *absolute_path = capio_posix_realpath(tid, path);
+    const std::string *absolute_path = capio_posix_realpath(path);
     if (absolute_path->length() == 0) {
         return -2;
     }

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -51,7 +51,7 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
     } else {
         if (!is_absolute(pathname)) {
             if (dirfd == AT_FDCWD) {
-                absolute_path = *capio_posix_realpath(tid, pathname);
+                absolute_path = *capio_posix_realpath(pathname);
             } else {
                 if (!is_directory(dirfd)) {
                     return -2;

--- a/src/posix/handlers/unlink.hpp
+++ b/src/posix/handlers/unlink.hpp
@@ -25,7 +25,7 @@ inline off64_t capio_unlinkat(int dirfd, const std::string &pathname, int flags,
     bool is_dir = flags & AT_REMOVEDIR;
     if (!is_absolute(&pathname)) {
         if (dirfd == AT_FDCWD) {
-            const std::string *abs_path = capio_posix_realpath(tid, &pathname);
+            const std::string *abs_path = capio_posix_realpath(&pathname);
             if (abs_path->length() == 0) {
                 return -2;
             }

--- a/src/posix/utils/filesystem.hpp
+++ b/src/posix/utils/filesystem.hpp
@@ -14,7 +14,6 @@
 #include "capio/logger.hpp"
 #include "capio/syscall.hpp"
 
-#include "requests.hpp"
 #include "types.hpp"
 
 CPFileDescriptors_t *capio_files_descriptors;
@@ -60,12 +59,11 @@ inline void add_capio_fd(long tid, const std::string &path, int fd, off64_t offs
 
 /**
  * Compute the absolute path for @pathname
- * @param tid
  * @param pathname
  * @return
  */
-const std::string *capio_posix_realpath(long tid, const std::string *pathname) {
-    START_LOG(tid, "call(path=%s)", pathname->c_str());
+const std::string *capio_posix_realpath(const std::string *pathname) {
+    START_LOG(syscall_no_intercept(SYS_gettid), "call(path=%s)", pathname->c_str());
     char *posix_real_path = capio_realpath((char *) pathname->c_str(), nullptr);
 
     // if capio_realpath fails, then it should be a capio_file
@@ -75,27 +73,24 @@ const std::string *capio_posix_realpath(long tid, const std::string *pathname) {
         const std::string *capio_dir = get_capio_dir();
         if (current_dir->find(*capio_dir) != std::string::npos) {
             if (pathname[0] != "/") {
-                auto newPath = new std::string(*capio_dir + "/" + *pathname);
+                auto new_path = new std::string(*capio_dir + "/" + *pathname);
 
                 // remove /./ from path
                 std::size_t pos = 0;
-                while ((pos = newPath->find("/./", pos)) != std::string::npos) {
-                    newPath->replace(newPath->find("/./"), 3, "/");
+                while ((pos = new_path->find("/./", pos)) != std::string::npos) {
+                    new_path->replace(new_path->find("/./"), 3, "/");
                     pos += 1;
                 }
 
-                LOG("Computed absolute path = %s", newPath->c_str());
-                return newPath;
+                LOG("Computed absolute path = %s", new_path->c_str());
+                return new_path;
             } else {
                 LOG("Path=%s is already absolute", pathname->c_str());
             }
             return pathname;
         } else {
             // if file not found, then error is returned
-            LOG("Fatal: file %s is not a posix file, nor a capio "
-                "file!",
-                pathname->c_str());
-            exit(EXIT_FAILURE);
+            ERR_EXIT("Fatal: file %s is not a posix file, nor a capio file!", pathname->c_str());
         }
     }
 
@@ -126,6 +121,17 @@ inline void delete_capio_path(const std::string &path) {
         delete_capio_fd(fd);
     }
     capio_files_paths->erase(path);
+}
+
+/**
+ * Destroy metadata structures
+ * @return
+ */
+inline void destroy_filesystem() {
+    delete current_dir;
+    delete capio_files_descriptors;
+    delete capio_files_paths;
+    delete files;
 }
 
 /**

--- a/src/posix/utils/types.hpp
+++ b/src/posix/utils/types.hpp
@@ -15,6 +15,7 @@ typedef std::unordered_map<int, std::string> CPFileDescriptors_t;
 typedef std::unordered_map<std::string, std::unordered_set<int>> CPFilesPaths_t;
 typedef std::unordered_map<int, std::pair<SPSC_queue<char> *, SPSC_queue<char> *>>
     CPThreadDataBufs_t;
+
 typedef int (*CPHandler_t)(long, long, long, long, long, long, long *);
 
 #endif // CAPIO_POSIX_UTILS_TYPES_HPP

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -31,7 +31,16 @@ add_executable(${TARGET_NAME} ${TARGET_SOURCES} ${simdjson_SOURCE_DIR}/singlehea
 # Include files and directories
 #####################################
 file(GLOB_RECURSE CAPIO_SERVER_HEADERS "*.hpp")
-target_include_directories(${TARGET_NAME} PRIVATE . ${MPI_INCLUDE_PATH} ${args_SOURCE_DIR} ${simdjson_SOURCE_DIR})
+target_sources(${TARGET_NAME} PRIVATE
+        "${CAPIO_COMMON_HEADERS}"
+        "${CAPIO_SERVER_HEADERS}"
+)
+target_include_directories(${TARGET_NAME} PRIVATE
+        ${TARGET_INCLUDE_FOLDER}
+        ${MPI_INCLUDE_PATH}
+        ${args_SOURCE_DIR}
+        ${simdjson_SOURCE_DIR}
+)
 
 #####################################
 # Target properties

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -28,7 +28,7 @@
 #include "utils/env.hpp"
 #include "utils/json.hpp"
 #include "utils/metadata.hpp"
-#include "utils/requests.hpp" //TODO: check whether to include requests here or in capio posix
+#include "utils/requests.hpp"
 
 using namespace simdjson;
 

--- a/src/server/handlers.hpp
+++ b/src/server/handlers.hpp
@@ -22,6 +22,5 @@
 #include "handlers/utils/util_filesys.hpp"
 #include "handlers/utils/util_producer.hpp"
 #include "handlers/write.hpp"
-#include "utils/requests.hpp" //TODO: check whether to include requests here or in capio posix
 
 #endif // CAPIO_SERVER_HANDLERS_HPP

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -1,9 +1,16 @@
 #ifndef CAPIO_SERVER_UTILS_CAPIO_FILE_HPP
 #define CAPIO_SERVER_UTILS_CAPIO_FILE_HPP
 
+#include <algorithm>
 #include <set>
 #include <string_view>
 #include <utility>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "capio/logger.hpp"
 
 /*
  * Only the server have all the information

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,23 +1,4 @@
 #####################################
-# Target information
-#####################################
-set(TARGET_NAME capio_tests)
-set(TARGET_SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/clone.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/directory.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/file.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/rename.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/stat.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/statx.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/posix/write.cpp
-)
-
-#####################################
-# Target definition
-#####################################
-add_executable(${TARGET_NAME} ${TARGET_SOURCES})
-
-#####################################
 # External projects
 #####################################
 FetchContent_Declare(
@@ -28,20 +9,14 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 
 #####################################
-# Link libraries
-#####################################
-target_link_libraries(${TARGET_NAME} PRIVATE Catch2::Catch2WithMain)
-
-#####################################
 # CMake module imports
 #####################################
 include(CTest)
 include(Catch)
 
 #####################################
-# Configure tests
+# Targets
 #####################################
-catch_discover_tests(${TARGET_NAME}
-        PROPERTIES
-        ENVIRONMENT LD_PRELOAD=${CMAKE_BINARY_DIR}/src/posix/libcapio_posix.so
-)
+add_subdirectory(posix)
+add_subdirectory(server)
+add_subdirectory(syscall)

--- a/tests/old_unit_tests/capio_file_tests.cpp
+++ b/tests/old_unit_tests/capio_file_tests.cpp
@@ -205,6 +205,7 @@ void test_seek_hole() {
     res = c_file.seek_hole(9);
     std::cout << "res " << res << std::endl;
 }
+
 int main(int argc, char **argv) {
     std::cout << "test 1" << std::endl;
     test1();

--- a/tests/old_unit_tests/simple_read.cpp
+++ b/tests/old_unit_tests/simple_read.cpp
@@ -52,6 +52,7 @@ void read_from_file(int *data, long int num_elements, long int num_reads, int ra
         std::cerr << "process " << rank << ", error closing the file\n";
     }
 }
+
 void read_from_files(int *data, long int num_elements, long int num_reads, long int num_files,
                      int rank, std::string time_file) {
     std::ofstream file;

--- a/tests/old_unit_tests/simple_read_fopen.cpp
+++ b/tests/old_unit_tests/simple_read_fopen.cpp
@@ -54,6 +54,7 @@ void read_from_file(int *data, long int num_elements, long int num_reads, int ra
         std::cerr << "process " << rank << ", error closing the file\n";
     }
 }
+
 void read_from_files(int *data, long int num_elements, long int num_reads, long int num_files,
                      int rank, std::string time_file) {
     std::ofstream file;

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -1,36 +1,25 @@
 #####################################
 # Target information
 #####################################
-set(TARGET_NAME capio_posix)
-set(TARGET_INCLUDE_FOLDER ${CMAKE_CURRENT_SOURCE_DIR})
-set(TARGET_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/libcapio_posix.cpp)
+set(TARGET_NAME capio_posix_tests)
+set(TARGET_INCLUDE_FOLDER "${PROJECT_SOURCE_DIR}/src/posix")
+set(TARGET_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/realpath.cpp
+)
 
 #####################################
 # Target definition
 #####################################
-add_library(${TARGET_NAME} SHARED ${TARGET_SOURCES})
+add_executable(${TARGET_NAME} ${TARGET_SOURCES})
 
 #####################################
 # External projects
 #####################################
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept)
-execute_process(
-        COMMAND ${CMAKE_COMMAND}
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-        "${CMAKE_CURRENT_SOURCE_DIR}/syscall_intercept"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept"
-)
-IF (UNIX)
-    execute_process(
-            COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept"
-    )
-ELSE (UNIX)
-    message(WARNING, "The syscall_intercept library only supports Unix OS.")
-ENDIF (UNIX)
-set(SYSCALL_INTERCEPT_INCLUDE_FOLDER "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/include")
+set(SYSCALL_BINARY_DIR "${CMAKE_BINARY_DIR}/src/posix/syscall_intercept")
+set(SYSCALL_INTERCEPT_INCLUDE_FOLDER "${SYSCALL_BINARY_DIR}/include")
 set(SYSCALL_INTERCEPT_LIB_FOLDERS
-        "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/lib"
-        "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/lib64"
+        "${SYSCALL_BINARY_DIR}/lib"
+        "${SYSCALL_BINARY_DIR}/lib64"
 )
 
 #####################################
@@ -41,7 +30,7 @@ target_compile_definitions(${TARGET_NAME} PRIVATE __CAPIO_POSIX)
 #####################################
 # Include files and directories
 #####################################
-file(GLOB_RECURSE CAPIO_POSIX_HEADERS "*.hpp")
+file(GLOB_RECURSE CAPIO_POSIX_HEADERS "${TARGET_INCLUDE_FOLDER}/*.hpp")
 file(GLOB_RECURSE SYSCALL_INTERCEPT_HEADERS "${SYSCALL_INTERCEPT_INCLUDE_FOLDER}/*.h")
 target_sources(${TARGET_NAME} PRIVATE
         "${CAPIO_COMMON_HEADERS}"
@@ -57,4 +46,9 @@ target_include_directories(${TARGET_NAME} PRIVATE
 # Link libraries
 #####################################
 target_link_directories(${TARGET_NAME} PRIVATE ${SYSCALL_INTERCEPT_LIB_FOLDERS})
-target_link_libraries(${TARGET_NAME} PRIVATE rt syscall_intercept)
+target_link_libraries(${TARGET_NAME} PRIVATE rt syscall_intercept Catch2::Catch2WithMain)
+
+#####################################
+# Configure tests
+#####################################
+catch_discover_tests(${TARGET_NAME})

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -1,0 +1,33 @@
+#####################################
+# Target information
+#####################################
+set(TARGET_NAME capio_server_tests)
+set(TARGET_INCLUDE_FOLDER "${PROJECT_SOURCE_DIR}/src/server")
+set(TARGET_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/capio_file.cpp
+)
+
+#####################################
+# Target definition
+#####################################
+add_executable(${TARGET_NAME} ${TARGET_SOURCES})
+
+#####################################
+# Include files and directories
+#####################################
+file(GLOB_RECURSE CAPIO_SERVER_HEADERS "${TARGET_INCLUDE_FOLDER}/*.hpp")
+target_sources(${TARGET_NAME} PRIVATE
+        "${CAPIO_COMMON_HEADERS}"
+        "${CAPIO_SERVER_HEADERS}"
+)
+target_include_directories(${TARGET_NAME} PRIVATE ${TARGET_INCLUDE_FOLDER})
+
+#####################################
+# Link libraries
+#####################################
+target_link_libraries(${TARGET_NAME} PRIVATE Catch2::Catch2WithMain)
+
+#####################################
+# Configure tests
+#####################################
+catch_discover_tests(${TARGET_NAME})

--- a/tests/server/src/capio_file.cpp
+++ b/tests/server/src/capio_file.cpp
@@ -1,0 +1,39 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+#include "utils/capio_file.hpp"
+
+TEST_CASE("Test inserting a single sector", "[server]") {
+    Capio_file c_file;
+    c_file.insert_sector(1, 3);
+    c_file.print(std::cout);
+}
+
+TEST_CASE("Test inserting two non-overlapping sectors", "[server]") {
+    Capio_file c_file;
+    c_file.insert_sector(5, 7);
+    c_file.insert_sector(1, 3);
+    c_file.print(std::cout);
+}
+
+TEST_CASE("Test inserting two overlapping sectors starting at the same offset", "[server]") {
+    Capio_file c_file;
+    c_file.insert_sector(1, 4);
+    c_file.insert_sector(1, 3);
+    c_file.print(std::cout);
+}
+
+TEST_CASE("Test inserting two overlapping sectors ending at the same offset", "[server]") {
+    Capio_file c_file;
+    c_file.insert_sector(1, 4);
+    c_file.insert_sector(2, 4);
+    c_file.print(std::cout);
+}
+
+TEST_CASE("Test inserting two overlapping sectors with one nested in the other", "[server]") {
+    Capio_file c_file;
+    c_file.insert_sector(1, 4);
+    c_file.insert_sector(2, 3);
+    c_file.print(std::cout);
+}

--- a/tests/syscall/CMakeLists.txt
+++ b/tests/syscall/CMakeLists.txt
@@ -1,0 +1,31 @@
+#####################################
+# Target information
+#####################################
+set(TARGET_NAME capio_syscall_tests)
+set(TARGET_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/clone.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/directory.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/file.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/rename.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/stat.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/statx.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/write.cpp
+)
+
+#####################################
+# Target definition
+#####################################
+add_executable(${TARGET_NAME} ${TARGET_SOURCES})
+
+#####################################
+# Link libraries
+#####################################
+target_link_libraries(${TARGET_NAME} PRIVATE Catch2::Catch2WithMain)
+
+#####################################
+# Configure tests
+#####################################
+catch_discover_tests(${TARGET_NAME}
+        PROPERTIES
+        ENVIRONMENT LD_PRELOAD=${CMAKE_BINARY_DIR}/src/posix/libcapio_posix.so
+)

--- a/tests/syscall/src/clone.cpp
+++ b/tests/syscall/src/clone.cpp
@@ -1,9 +1,10 @@
-#include <fcntl.h>
-#include <unistd.h>
-
 #include <catch2/catch_test_macros.hpp>
-#include <semaphore.h>
+
 #include <thread>
+
+#include <fcntl.h>
+#include <semaphore.h>
+#include <unistd.h>
 
 constexpr int ARRAY_SIZE = 100;
 
@@ -33,7 +34,7 @@ int write_file_stat_clone(FILE *fp) {
     return 0;
 }
 
-TEST_CASE("Test thread clone", "[posix]") {
+TEST_CASE("Test thread clone", "[syscall]") {
     int *num = static_cast<int *>(malloc(sizeof(int)));
     *num     = 12345;
     std::thread t(func, num);
@@ -41,7 +42,7 @@ TEST_CASE("Test thread clone", "[posix]") {
     free(num);
 }
 
-TEST_CASE("Test thread clone producer/consumer", "[posix]") {
+TEST_CASE("Test thread clone producer/consumer", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_RDWR | O_TRUNC;
     int fd                         = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
@@ -59,7 +60,7 @@ TEST_CASE("Test thread clone producer/consumer", "[posix]") {
     REQUIRE(unlink(PATHNAME) != -1);
 }
 
-TEST_CASE("Test thread clone producer/consumer with stat", "[posix]") {
+TEST_CASE("Test thread clone producer/consumer with stat", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     sem                            = static_cast<sem_t *>(malloc(sizeof(sem_t)));
     REQUIRE(sem_init(sem, 0, 0) == 0);

--- a/tests/syscall/src/directory.cpp
+++ b/tests/syscall/src/directory.cpp
@@ -1,3 +1,5 @@
+#include <catch2/catch_test_macros.hpp>
+
 #include <cerrno>
 #include <filesystem>
 
@@ -5,11 +7,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <catch2/catch_test_macros.hpp>
-
-TEST_CASE("Test directory creation, reopening and close", "[posix]") {
+TEST_CASE("Test directory creation, reopening and close", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
     int flags = O_RDONLY | O_DIRECTORY;
     int fd    = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
     REQUIRE(fd != -1);
@@ -18,9 +19,11 @@ TEST_CASE("Test directory creation, reopening and close", "[posix]") {
     REQUIRE(fd != -1);
     REQUIRE(close(fd) != -1);
     REQUIRE(rmdir(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test directory creation, reopening, and close using mkdirat with AT_FDCWD", "[posix]") {
+TEST_CASE("Test directory creation, reopening, and close using mkdirat with AT_FDCWD",
+          "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
@@ -35,7 +38,7 @@ TEST_CASE("Test directory creation, reopening, and close using mkdirat with AT_F
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test that mkdir fails if directory already exists", "[posix]") {
+TEST_CASE("Test that mkdir fails if directory already exists", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
@@ -47,7 +50,7 @@ TEST_CASE("Test that mkdir fails if directory already exists", "[posix]") {
 
 TEST_CASE("Test directory creation, reopening, and close in a different directory using openat "
           "with absolute path",
-          "[posix]") {
+          "[syscall]") {
     const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
     const char *PATHNAME = path_fs.c_str();
     REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
@@ -65,7 +68,7 @@ TEST_CASE("Test directory creation, reopening, and close in a different director
 
 TEST_CASE("Test directory creation, reopening, and close in a different directory using mkdirat "
           "with dirfd",
-          "[posix]") {
+          "[syscall]") {
     constexpr const char *PATHNAME = "test";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;
@@ -85,7 +88,7 @@ TEST_CASE("Test directory creation, reopening, and close in a different director
 }
 
 /*
-TEST_CASE("Test obtaining the current directory with getcwd system call", "[posix]") {
+TEST_CASE("Test obtaining the current directory with getcwd system call", "[syscall]") {
     auto expected_path = std::string(std::getenv("PWD"));
     char obtained_path[PATH_MAX];
     getcwd(obtained_path, PATH_MAX);

--- a/tests/syscall/src/file.cpp
+++ b/tests/syscall/src/file.cpp
@@ -1,3 +1,5 @@
+#include <catch2/catch_test_macros.hpp>
+
 #include <cerrno>
 #include <filesystem>
 #include <memory>
@@ -5,9 +7,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <catch2/catch_test_macros.hpp>
-
-TEST_CASE("Test file creation, reopening, and close", "[posix]") {
+TEST_CASE("Test file creation, reopening, and close", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
     int fd                         = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
@@ -21,7 +21,7 @@ TEST_CASE("Test file creation, reopening, and close", "[posix]") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test file creation using creat system call", "[posix]") {
+TEST_CASE("Test file creation using creat system call", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     int fd                         = creat(PATHNAME, S_IRUSR | S_IWUSR);
     REQUIRE(fd != -1);
@@ -31,7 +31,7 @@ TEST_CASE("Test file creation using creat system call", "[posix]") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test file creation, reopening, and close using openat with AT_FDCWD", "[posix]") {
+TEST_CASE("Test file creation, reopening, and close using openat with AT_FDCWD", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
     int fd                         = openat(AT_FDCWD, PATHNAME, flags, S_IRUSR | S_IWUSR);
@@ -45,7 +45,7 @@ TEST_CASE("Test file creation, reopening, and close using openat with AT_FDCWD",
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test that open O_EXCL fails if file already exists", "[posix]") {
+TEST_CASE("Test that open O_EXCL fails if file already exists", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC | O_EXCL;
     int fd                         = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
@@ -61,7 +61,7 @@ TEST_CASE("Test that open O_EXCL fails if file already exists", "[posix]") {
 
 TEST_CASE(
     "Test file creation, reopen and close in a different directory using openat with absolute path",
-    "[posix]") {
+    "[syscall]") {
     const auto path_fs =
         std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
     const char *PATHNAME = path_fs.c_str();
@@ -78,7 +78,7 @@ TEST_CASE(
 }
 
 TEST_CASE("Test file creation, reopen and close in a different directory using openat with dirfd",
-          "[posix]") {
+          "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;

--- a/tests/syscall/src/rename.cpp
+++ b/tests/syscall/src/rename.cpp
@@ -4,7 +4,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-TEST_CASE("Test file rename when the new path does not exist", "[posix]") {
+TEST_CASE("Test file rename when the new path does not exist", "[syscall]") {
     constexpr const char *OLDNAME = "test_file.txt";
     constexpr const char *NEWNAME = "test_file2.txt";
     int flags                     = O_CREAT | O_WRONLY | O_TRUNC;
@@ -19,7 +19,7 @@ TEST_CASE("Test file rename when the new path does not exist", "[posix]") {
     REQUIRE(access(NEWNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test file rename when the new path already exists", "[posix]") {
+TEST_CASE("Test file rename when the new path already exists", "[syscall]") {
     constexpr const char *OLDNAME = "test_file.txt";
     constexpr const char *NEWNAME = "test_file2.txt";
     int flags                     = O_CREAT | O_WRONLY | O_TRUNC;
@@ -36,7 +36,7 @@ TEST_CASE("Test file rename when the new path already exists", "[posix]") {
     REQUIRE(access(NEWNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test directory rename when the new path does not exist", "[posix]") {
+TEST_CASE("Test directory rename when the new path does not exist", "[syscall]") {
     constexpr const char *OLDNAME = "test";
     constexpr const char *NEWNAME = "test2";
     REQUIRE(mkdir(OLDNAME, S_IRWXU) != -1);
@@ -49,7 +49,7 @@ TEST_CASE("Test directory rename when the new path does not exist", "[posix]") {
     REQUIRE(access(NEWNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test directory rename when the new path already exists", "[posix]") {
+TEST_CASE("Test directory rename when the new path already exists", "[syscall]") {
     constexpr const char *OLDNAME = "test";
     constexpr const char *NEWNAME = "test2";
     REQUIRE(mkdir(OLDNAME, S_IRWXU) != -1);

--- a/tests/syscall/src/stat.cpp
+++ b/tests/syscall/src/stat.cpp
@@ -1,10 +1,11 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <thread>
+
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#include <catch2/catch_test_macros.hpp>
-#include <filesystem>
-#include <thread>
 
 void check_statbuf(struct stat &buf, unsigned long st_size) {
     REQUIRE(buf.st_blocks == 8);
@@ -13,7 +14,7 @@ void check_statbuf(struct stat &buf, unsigned long st_size) {
     REQUIRE(buf.st_uid == getuid());
 }
 
-TEST_CASE("Test stat syscall on file", "[posix]") {
+TEST_CASE("Test stat syscall on file", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
@@ -29,7 +30,7 @@ TEST_CASE("Test stat syscall on file", "[posix]") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test stat syscall on folder", "[posix]") {
+TEST_CASE("Test stat syscall on folder", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
     REQUIRE(access(PATHNAME, F_OK) == 0);
@@ -40,7 +41,7 @@ TEST_CASE("Test stat syscall on folder", "[posix]") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test fstat syscall on file", "[posix]") {
+TEST_CASE("Test fstat syscall on file", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
@@ -56,7 +57,7 @@ TEST_CASE("Test fstat syscall on file", "[posix]") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test fstat syscall on folder", "[posix]") {
+TEST_CASE("Test fstat syscall on folder", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
     REQUIRE(access(PATHNAME, F_OK) == 0);
@@ -71,7 +72,7 @@ TEST_CASE("Test fstat syscall on folder", "[posix]") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test fstatat syscall on file with AT_FDCWD", "[posix]") {
+TEST_CASE("Test fstatat syscall on file with AT_FDCWD", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
@@ -87,7 +88,7 @@ TEST_CASE("Test fstatat syscall on file with AT_FDCWD", "[posix]") {
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test fstatat syscall on folder with AT_FDCWD", "[posix]") {
+TEST_CASE("Test fstatat syscall on folder with AT_FDCWD", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
@@ -98,7 +99,8 @@ TEST_CASE("Test fstatat syscall on folder with AT_FDCWD", "[posix]") {
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test fstatat syscall on file in a different directory using absolute path", "[posix]") {
+TEST_CASE("Test fstatat syscall on file in a different directory using absolute path",
+          "[syscall]") {
     const auto path_fs =
         std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
     const char *PATHNAME = path_fs.c_str();
@@ -117,7 +119,7 @@ TEST_CASE("Test fstatat syscall on file in a different directory using absolute 
 }
 
 TEST_CASE("Test fstatat syscall on folder in a different directory using absolute path",
-          "[posix]") {
+          "[syscall]") {
     const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
     const char *PATHNAME = path_fs.c_str();
     REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
@@ -129,7 +131,7 @@ TEST_CASE("Test fstatat syscall on folder in a different directory using absolut
     REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test fstatat syscall on file in a different directory using dirfd", "[posix]") {
+TEST_CASE("Test fstatat syscall on file in a different directory using dirfd", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     const char *DIRPATH            = std::getenv("PWD");
     int dirfd                      = open(DIRPATH, O_RDONLY | O_DIRECTORY);
@@ -147,7 +149,7 @@ TEST_CASE("Test fstatat syscall on file in a different directory using dirfd", "
     REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test fstatat syscall on folder in a different directory using dirfd", "[posix]") {
+TEST_CASE("Test fstatat syscall on folder in a different directory using dirfd", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;
@@ -163,7 +165,7 @@ TEST_CASE("Test fstatat syscall on folder in a different directory using dirfd",
     REQUIRE(close(dirfd) != -1);
 }
 
-TEST_CASE("Test file creation, write and close using stat", "[posix]") {
+TEST_CASE("Test file creation, write and close using stat", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr int ARRAY_SIZE       = 100;
     int array[ARRAY_SIZE];
@@ -187,7 +189,7 @@ TEST_CASE("Test file creation, write and close using stat", "[posix]") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test directory creation, reopening and close with stat", "[posix]") {
+TEST_CASE("Test directory creation, reopening and close with stat", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
     FILE *fp = fopen(PATHNAME, "r");

--- a/tests/syscall/src/statx.cpp
+++ b/tests/syscall/src/statx.cpp
@@ -13,7 +13,7 @@ void check_statxbuf(struct statx &buf, unsigned long st_size) {
     REQUIRE(buf.stx_uid == getuid());
 }
 
-TEST_CASE("Test statx syscall on file with AT_FDCWD", "[posix]") {
+TEST_CASE("Test statx syscall on file with AT_FDCWD", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
@@ -29,7 +29,7 @@ TEST_CASE("Test statx syscall on file with AT_FDCWD", "[posix]") {
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test statx syscall on folder with AT_FDCWD", "[posix]") {
+TEST_CASE("Test statx syscall on folder with AT_FDCWD", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
@@ -40,7 +40,7 @@ TEST_CASE("Test statx syscall on folder with AT_FDCWD", "[posix]") {
     REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test statx syscall on file in a different directory using absolute path", "[posix]") {
+TEST_CASE("Test statx syscall on file in a different directory using absolute path", "[syscall]") {
     const auto path_fs =
         std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
     const char *PATHNAME = path_fs.c_str();
@@ -58,7 +58,8 @@ TEST_CASE("Test statx syscall on file in a different directory using absolute pa
     REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test statx syscall on folder in a different directory using absolute path", "[posix]") {
+TEST_CASE("Test statx syscall on folder in a different directory using absolute path",
+          "[syscall]") {
     const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
     const char *PATHNAME = path_fs.c_str();
     REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
@@ -70,7 +71,7 @@ TEST_CASE("Test statx syscall on folder in a different directory using absolute 
     REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test statx syscall on file in a different directory using dirfd", "[posix]") {
+TEST_CASE("Test statx syscall on file in a different directory using dirfd", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     const char *DIRPATH            = std::getenv("PWD");
     int dirfd                      = open(DIRPATH, O_RDONLY | O_DIRECTORY);
@@ -88,7 +89,7 @@ TEST_CASE("Test statx syscall on file in a different directory using dirfd", "[p
     REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
 }
 
-TEST_CASE("Test statx syscall on folder in a different directory using dirfd", "[posix]") {
+TEST_CASE("Test statx syscall on folder in a different directory using dirfd", "[syscall]") {
     constexpr const char *PATHNAME = "test";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;

--- a/tests/syscall/src/write.cpp
+++ b/tests/syscall/src/write.cpp
@@ -8,7 +8,7 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
-TEST_CASE("Test file creation, write and close", "[posix]") {
+TEST_CASE("Test file creation, write and close", "[syscall]") {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
@@ -52,7 +52,7 @@ TEST_CASE("Test file creation, write with lseek and close") {
     REQUIRE(access(PATHNAME, F_OK) != 0);
 }
 
-TEST_CASE("Test file creation, buffered write and close", "[posix]") {
+TEST_CASE("Test file creation, buffered write and close", "[syscall]") {
     constexpr const char *PATHNAME              = "test_file.txt";
     constexpr const std::array<int, 10> BUFFER1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     constexpr const std::array<int, 8> BUFFER2  = {10, 11, 12, 13, 14, 15, 16, 17};


### PR DESCRIPTION
This commit adds three different test executables to test server, posix, and syscalls CAPIO features. Each executable is compiled independently. The `capio_posix_tests` executable includes the `syscall_intercept`and should be used to test features in the `posix` CAPIO package. Similarly, the `server` package should test features in the `server` CAPIO package. Finally, the `syscall` package should test the CAPIO behaviour when calling system calls in the business code, and should not explicitly include any of the CAPIO packages.