### PR TITLE
Added tests on realpath and dup

### DIFF
--- a/src/posix/handlers/dup.hpp
+++ b/src/posix/handlers/dup.hpp
@@ -14,7 +14,7 @@ inline int capio_dup(int fd, long tid) {
             ERR_EXIT("open in capio_dup");
         }
         dup_request(fd, res, tid);
-        dup_capio_fd(tid, fd, res);
+        dup_capio_fd(tid, fd, res, false);
 
         return res;
     } else {
@@ -30,8 +30,31 @@ inline int capio_dup2(int fd, int fd2, long tid) {
         if (res == -1) {
             return -1;
         }
+        if (fd != res) {
+            dup_request(fd, res, tid);
+            dup_capio_fd(tid, fd, res, false);
+        }
+        return res;
+    } else {
+        return -2;
+    }
+}
+
+inline int capio_dup3(int fd, int fd2, int flags, long tid) {
+    START_LOG(tid, "call(fd=%d, fd2=%d)", fd, fd2);
+
+    if (exists_capio_fd(fd)) {
+        if (fd == fd2) {
+            errno = EINVAL;
+            return -1;
+        }
+        int res = static_cast<int>(syscall_no_intercept(SYS_dup3, fd, fd2, flags));
+        if (res == -1) {
+            return -1;
+        }
+        bool is_cloexec = (flags & O_CLOEXEC) == O_CLOEXEC;
         dup_request(fd, res, tid);
-        dup_capio_fd(tid, fd, res);
+        dup_capio_fd(tid, fd, res, is_cloexec);
         return res;
     } else {
         return -2;
@@ -56,6 +79,20 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     int fd2  = static_cast<int>(arg1);
 
     int res = capio_dup2(fd, fd2, tid);
+    if (res != -2) {
+        *result = (res < 0 ? -errno : res);
+        return 0;
+    }
+    return 1;
+}
+
+int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+    long tid  = syscall_no_intercept(SYS_gettid);
+    int fd    = static_cast<int>(arg0);
+    int fd2   = static_cast<int>(arg1);
+    int flags = static_cast<int>(arg2);
+
+    int res = capio_dup3(fd, fd2, flags, tid);
     if (res != -2) {
         *result = (res < 0 ? -errno : res);
         return 0;

--- a/src/posix/handlers/fcntl.hpp
+++ b/src/posix/handlers/fcntl.hpp
@@ -35,8 +35,7 @@ inline int capio_fcntl(int fd, int cmd, int arg, long tid) {
 
             int res = fcntl(dev_fd, F_DUPFD_CLOEXEC, arg);
             close(dev_fd);
-            dup_capio_fd(tid, fd, res);
-            set_capio_fd_cloexec(res, true);
+            dup_capio_fd(tid, fd, res, true);
             dup_request(fd, res, tid);
 
             return res;

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -52,6 +52,7 @@ static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
     _syscallTable[SYS_creat]      = creat_handler;
     _syscallTable[SYS_dup]        = dup_handler;
     _syscallTable[SYS_dup2]       = dup2_handler;
+    _syscallTable[SYS_dup3]       = dup3_handler;
     _syscallTable[SYS_execve]     = execve_handler;
     _syscallTable[SYS_exit]       = exit_handler;
     _syscallTable[SYS_exit_group] = exit_handler;

--- a/src/server/handlers/dup.hpp
+++ b/src/server/handlers/dup.hpp
@@ -4,12 +4,12 @@
 #include "utils/metadata.hpp"
 
 void dup_handler(const char *const str, int rank) {
-    int tid;
-    int old_fd, new_fd;
+    int tid, old_fd, new_fd;
     sscanf(str, "%d %d %d", &tid, &old_fd, &new_fd);
     START_LOG(gettid(), "call(tid=%d, old_fd=%d, new_fd=%d)", tid, old_fd, new_fd);
-
-    dup_capio_file(tid, old_fd, new_fd);
+    if (old_fd != new_fd) {
+        dup_capio_file(tid, old_fd, new_fd);
+    }
 }
 
 #endif // CAPIO_SERVER_HANDLERS_DUP_HPP

--- a/tests/posix/src/realpath.cpp
+++ b/tests/posix/src/realpath.cpp
@@ -1,0 +1,50 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+
+#include <filesystem>
+
+#include <fcntl.h>
+
+#include "utils/filesystem.hpp"
+
+class FileSystemRegistrar : public Catch::EventListenerBase {
+  public:
+    using Catch::EventListenerBase::EventListenerBase;
+
+    void testCaseStarting(Catch::TestCaseInfo const &testCaseInfo) override { init_filesystem(); }
+
+    void testCaseEnded(Catch::TestCaseStats const &testCaseStats) override { destroy_filesystem(); }
+};
+
+CATCH_REGISTER_LISTENER(FileSystemRegistrar);
+
+TEST_CASE("Test absolute paths inside the CAPIO_DIR when path exists", "[posix]") {
+    const std::string PATHNAME =
+        std::filesystem::path(*get_capio_dir()) / std::filesystem::path("test");
+    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
+    REQUIRE(*capio_posix_realpath(&PATHNAME) == PATHNAME);
+    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+}
+
+TEST_CASE("Test absolute paths inside the CAPIO_DIR when path does not exist", "[posix]") {
+    const std::string PATHNAME =
+        std::filesystem::path(*get_capio_dir()) / std::filesystem::path("test");
+    REQUIRE(*capio_posix_realpath(&PATHNAME) == PATHNAME);
+}
+
+TEST_CASE("Test absolute paths outside the CAPIO_DIR when path exists", "[posix]") {
+    const std::string PATHNAME = "/tmp/test";
+    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
+    REQUIRE(*capio_posix_realpath(&PATHNAME) == PATHNAME);
+    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+}
+
+TEST_CASE("Test absolute paths outside the CAPIO_DIR when path does not exist", "[posix]") {
+    const std::string PATHNAME = "/tmp/test";
+    REQUIRE(*capio_posix_realpath(&PATHNAME) == PATHNAME);
+}

--- a/tests/syscall/CMakeLists.txt
+++ b/tests/syscall/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TARGET_NAME capio_syscall_tests)
 set(TARGET_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/clone.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/directory.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/dup.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/file.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/rename.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/stat.cpp

--- a/tests/syscall/src/dup.cpp
+++ b/tests/syscall/src/dup.cpp
@@ -1,0 +1,145 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+TEST_CASE("Test dup system call", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int flags = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    int newfd = dup(oldfd);
+    REQUIRE(newfd > oldfd);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(lseek(oldfd, 0, SEEK_SET) == 0);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(close(newfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test dup2 system call", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int flags = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    int newfd = oldfd + 10;
+    REQUIRE(dup2(oldfd, newfd) == newfd);
+    REQUIRE(newfd > oldfd);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(lseek(oldfd, 0, SEEK_SET) == 0);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(close(newfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test dup2 system call when newfd points to an open file", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int flags = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    int newfd = open("/dev/null", O_WRONLY);
+    REQUIRE(dup2(oldfd, newfd) == newfd);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(close(newfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test dup2 system call when the two arguments are equal", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd                      = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    int newfd = oldfd;
+    REQUIRE(dup2(oldfd, newfd) == newfd);
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test dup3 system call", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int flags = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    int newfd = oldfd + 10;
+    REQUIRE(dup3(oldfd, newfd, 0) == newfd);
+    REQUIRE(newfd > oldfd);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(lseek(oldfd, 0, SEEK_SET) == 0);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(close(newfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test dup3 system call when newfd points to an open file", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int flags = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    int newfd = open("/dev/null", O_WRONLY);
+    REQUIRE(dup3(oldfd, newfd, 0) == newfd);
+    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(close(newfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test dup3 system call when the two arguments are equal", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd                      = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    int newfd = oldfd;
+    REQUIRE(dup3(oldfd, newfd, 0) == -1);
+    REQUIRE(errno == EINVAL);
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}
+
+TEST_CASE("Test dup3 system call with the O_CLOEXEC flag", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
+    int oldfd                      = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
+    REQUIRE(oldfd != -1);
+    REQUIRE(access(PATHNAME, F_OK) == 0);
+    int newfd = oldfd + 10;
+    REQUIRE(dup3(oldfd, newfd, O_CLOEXEC) == newfd);
+    REQUIRE((fcntl(oldfd, F_GETFD) & FD_CLOEXEC) != FD_CLOEXEC);
+    REQUIRE((fcntl(newfd, F_GETFD) & FD_CLOEXEC) == FD_CLOEXEC);
+    REQUIRE(close(oldfd) != -1);
+    REQUIRE(close(newfd) != -1);
+    REQUIRE(unlink(PATHNAME) != -1);
+    REQUIRE(access(PATHNAME, F_OK) != 0);
+}


### PR DESCRIPTION
This commit adds new CI tests on the `dup` family of system calls and on the `capio_posix_realpath` function.