### PR TITLE
Fix `capio_posix_path` and `getcwd` behaviour

### DIFF
--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -15,6 +15,9 @@ inline int capio_chdir(const std::string *path, long tid) {
 
     if (!is_absolute(path)) {
         path_to_check = capio_posix_realpath(path);
+        if (path_to_check->length() == 0) {
+            return -1;
+        }
     }
 
     if (is_capio_path(*path_to_check)) {

--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -1,27 +1,17 @@
 #ifndef CAPIO_POSIX_HANDLERS_GETCWD_HPP
 #define CAPIO_POSIX_HANDLERS_GETCWD_HPP
+int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+    auto buf  = reinterpret_cast<char *>(arg0);
+    auto size = static_cast<size_t>(arg1);
+    long tid  = syscall_no_intercept(SYS_gettid);
 
-inline std::string *capio_getcwd(std::string *buf, size_t size, long tid) {
     START_LOG(tid, "call(buf=0x%08x, size=%ld)", buf, size);
 
     const std::string *cwd = get_current_dir();
     if ((cwd->length() + 1) * sizeof(char) > size) {
-        errno = ERANGE;
-        return nullptr;
+        *result = -ERANGE;
     } else {
-        std::strcpy(buf->data(), cwd->c_str());
-        return buf;
-    }
-}
-
-int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::string buf(reinterpret_cast<char *>(arg0));
-    auto size = static_cast<size_t>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
-
-    auto rescw = capio_getcwd(&buf, size, tid);
-    if (rescw == nullptr) {
-        *result = -errno;
+        cwd->copy(buf, size);
     }
     return 0;
 }

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -52,6 +52,9 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
         if (!is_absolute(pathname)) {
             if (dirfd == AT_FDCWD) {
                 absolute_path = *capio_posix_realpath(pathname);
+                if (absolute_path.length() == 0) {
+                    return -1;
+                }
             } else {
                 if (!is_directory(dirfd)) {
                     return -2;

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -26,9 +26,11 @@ inline ssize_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long ti
               iov->iov_base, iov->iov_len, iovcnt);
 
     if (exists_capio_fd(fd)) {
+        LOG("fd %d exists and is a capio fd", fd);
         ssize_t tot_bytes = 0;
         ssize_t res       = 0;
         int i             = 0;
+        LOG("iov setup completed. starting write request loop");
         while (i < iovcnt && res >= 0) {
             size_t iov_len = iov[i].iov_len;
             if (iov_len != 0) {
@@ -43,6 +45,7 @@ inline ssize_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long ti
             return tot_bytes;
         }
     } else {
+        LOG("fd %d is not a capio fd. returning -2", fd);
         return -2;
     }
 }

--- a/src/posix/utils/filesystem.hpp
+++ b/src/posix/utils/filesystem.hpp
@@ -104,8 +104,9 @@ const std::string *capio_posix_realpath(const std::string *pathname) {
             }
             return pathname;
         } else {
-            // if file not found, then error is returned
-            ERR_EXIT("Fatal: file %s is not a posix file, nor a capio file!", pathname->c_str());
+            // if file not found, then nullptr is returned and errno can be read
+            LOG("file %s is not a posix file, nor a capio file!", pathname->c_str());
+            return new std::string("");
         }
     }
 
@@ -170,7 +171,10 @@ inline void dup_capio_fd(long tid, int oldfd, int newfd, bool is_cloexec) {
  * @param fd
  * @return if the file descriptor exists
  */
-inline bool exists_capio_fd(int fd) { return files->find(fd) != files->end(); }
+inline bool exists_capio_fd(int fd) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%d)", fd);
+    return files->find(fd) != files->end();
+}
 
 /**
  * Check if a path exists in metadata structures

--- a/tests/syscall/src/directory.cpp
+++ b/tests/syscall/src/directory.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cerrno>
+#include <climits>
 #include <filesystem>
 
 #include <fcntl.h>
@@ -87,11 +88,9 @@ TEST_CASE("Test directory creation, reopening, and close in a different director
     REQUIRE(close(dirfd) != -1);
 }
 
-/*
 TEST_CASE("Test obtaining the current directory with getcwd system call", "[syscall]") {
     auto expected_path = std::string(std::getenv("PWD"));
     char obtained_path[PATH_MAX];
     getcwd(obtained_path, PATH_MAX);
     REQUIRE(expected_path == std::string(obtained_path));
 }
-*/


### PR DESCRIPTION
This commits fix a wrong behavior for `capio_posix_realpath`, in which instead of returning an empty string if a file does not exist, the client app would crash. This is a wrong behaviour: one might want to try to open a file just to see if it actually exists. With this commit, an empty `std::string` object is returned instead of calling `ERR_EXIT`. It is now up to the caller of `capio_posix_realpath` to check whether the string has length > 0.

This commit also fixes th behaviour of the `getcwd` syscall, which incorrectly converted a `char *` pointer into a `std::string` type. The `getcwd` unit test has also been restored.