### PR TITLE
Fix the `getcwd` system call in CAPIO

### DIFF
--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -12,7 +12,7 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
         *result = -ERANGE;
     } else {
         cwd->copy(buf, size);
-        buf[size] = '\0';
+        buf[cwd->length()] = '\0';
     }
     return 0;
 }

--- a/tests/syscall/src/directory.cpp
+++ b/tests/syscall/src/directory.cpp
@@ -94,3 +94,11 @@ TEST_CASE("Test obtaining the current directory with getcwd system call", "[sysc
     getcwd(obtained_path, PATH_MAX);
     REQUIRE(expected_path == std::string(obtained_path));
 }
+
+TEST_CASE("Test getcwd system call when path is longer than size", "[syscall]") {
+    auto expected_path = std::string(std::getenv("PWD"));
+    REQUIRE(expected_path.size() > 1);
+    char obtained_path[1];
+    REQUIRE(getcwd(obtained_path, 1) == nullptr);
+    REQUIRE(errno == ERANGE);
+}


### PR DESCRIPTION
This commit fixes the `getcwd` handler function, which did not correctly handle the last null character when workdir path was shorter than the buffer size.

This commit also adds an additional test to check that the correct `errno` is returned when the buffer argument is too small.