### PR TITLE
Configure install logic in CMake

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -75,13 +75,13 @@ jobs:
                 -G Ninja \
                 -B build \
                 -S ${GITHUB_WORKSPACE}
-      - name: "Build with Ninja"
-        run: cmake --build build --target all -j $(nproc)
+          cmake --build build -j $(nproc)
+          sudo cmake --install build --prefix /usr/local
       - name: "Run CAPIO server"
         env:
           CAPIO_DIR: ${{ github.workspace }}
           CAPIO_LOG_LEVEL: -1
-        run: mpirun -n 1 build/src/server/capio_server --no-config &
+        run: mpirun -n 1 capio_server --no-config &
       - name: "Run tests"
         id: run-tests
         timeout-minutes: 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(CAPIO_SYNC "Use sync MPI primitives" FALSE)
 # CMake module imports
 #####################################
 include(FetchContent)
+include(GNUInstallDirs)
 
 #####################################
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The following dependencies are automatically fetched during cmake configuration 
 git clone https://github.com/High-Performance-IO/capio.git capio && cd capio
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . -j$(nproc)
+sudo cmake --install .
 ```
 
 It is also possible to enable log in CAPIO, by defining `-DCAPIO_LOG=TRUE`.
@@ -47,16 +49,16 @@ the first is optional).
    want to execute your program (one daemon for each node). If you desire to specify a custom folder
    for capio, set `CAPIO_DIR` as a environment variable.
    ```bash
-   [CAPIO_DIR=your_capiodir] mpiexec -N 1 --hostfile your_hostfile src/capio_server -c conf.json 
+   [CAPIO_DIR=your_capiodir] mpiexec -N 1 --hostfile your_hostfile capio_server -c conf.json 
    ```
 
 > [!NOTE]
-> if `CAPIO_DIR` is not specified when launching caio_Server, it will default to the current working directory of
+> if `CAPIO_DIR` is not specified when launching capio_server, it will default to the current working directory of
 > capio_server.
 
 3) Launch your programs preloading the CAPIO shared library like this:
    ```bash
-   CAPIO_DIR=your_capiodir LD_PRELOAD=<build_folder_path>/src/posix/libcapio_posix.so ./your_app args
+   CAPIO_DIR=your_capiodir LD_PRELOAD=libcapio_posix.so ./your_app args
     ```
 
 > [!WARNING]  

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -14,24 +14,33 @@ add_library(${TARGET_NAME} SHARED ${TARGET_SOURCES})
 # External projects
 #####################################
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept)
+
+set(SYSCALL_INTERCEPT_INCLUDE_FOLDER "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/${CMAKE_INSTALL_INCLUDEDIR}")
+set(SYSCALL_INTERCEPT_LIB_FOLDER "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/${CMAKE_INSTALL_LIBDIR}")
+
 execute_process(
         COMMAND ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         "${CMAKE_CURRENT_SOURCE_DIR}/syscall_intercept"
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept"
 )
+
 IF (UNIX)
     execute_process(
-            COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept"
+            COMMAND ${CMAKE_COMMAND} --build
+            "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept"
     )
+
+    file(GLOB SYSCALL_INTERCEPT_HEADERS "${SYSCALL_INTERCEPT_INCLUDE_FOLDER}/*.h")
+    file(GLOB SYSCALL_INTERCEPT_LIBS "${SYSCALL_INTERCEPT_LIB_FOLDER}/*.a" "${SYSCALL_INTERCEPT_LIB_FOLDER}/*.so*")
+    file(GLOB SYSCALL_INTERCEPT_PKGCONFIGS "${SYSCALL_INTERCEPT_LIB_FOLDER}/pkgconfig/*.pc")
+
+    install(FILES ${SYSCALL_INTERCEPT_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    install(FILES ${SYSCALL_INTERCEPT_LIBS} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    install(FILES ${SYSCALL_INTERCEPT_PKGCONFIGS} DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 ELSE (UNIX)
     message(WARNING, "The syscall_intercept library only supports Unix OS.")
 ENDIF (UNIX)
-set(SYSCALL_INTERCEPT_INCLUDE_FOLDER "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/include")
-set(SYSCALL_INTERCEPT_LIB_FOLDERS
-        "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/lib"
-        "${CMAKE_CURRENT_BINARY_DIR}/syscall_intercept/lib64"
-)
 
 #####################################
 # Definitions
@@ -54,7 +63,22 @@ target_include_directories(${TARGET_NAME} PRIVATE
 )
 
 #####################################
+# Target properties
+#####################################
+set_target_properties(${TARGET_NAME} PROPERTIES
+        VERSION "${CMAKE_PROJECT_VERSION}"
+        SOVERSION "${CMAKE_PROJECT_VERSION_MAJOR}"
+)
+
+#####################################
 # Link libraries
 #####################################
-target_link_directories(${TARGET_NAME} PRIVATE ${SYSCALL_INTERCEPT_LIB_FOLDERS})
+target_link_directories(${TARGET_NAME} PRIVATE ${SYSCALL_INTERCEPT_LIB_FOLDER})
 target_link_libraries(${TARGET_NAME} PRIVATE rt syscall_intercept)
+
+#####################################
+# Install rules
+#####################################
+install(TARGETS ${TARGET_NAME}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -57,3 +57,10 @@ ENDIF (MPI_LINK_FLAGS)
 # Link libraries
 #####################################
 target_link_libraries(${TARGET_NAME} PRIVATE ${MPI_LIBRARIES} rt stdc++fs)
+
+#####################################
+# Install rules
+#####################################
+install(TARGETS ${TARGET_NAME}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -15,12 +15,11 @@ add_executable(${TARGET_NAME} ${TARGET_SOURCES})
 #####################################
 # External projects
 #####################################
-set(SYSCALL_BINARY_DIR "${PROJECT_BINARY_DIR}/src/posix/syscall_intercept")
-set(SYSCALL_INTERCEPT_INCLUDE_FOLDER "${SYSCALL_BINARY_DIR}/include")
-set(SYSCALL_INTERCEPT_LIB_FOLDERS
-        "${SYSCALL_BINARY_DIR}/lib"
-        "${SYSCALL_BINARY_DIR}/lib64"
-)
+set(SYSCALL_INTERCEPT_BINARY_DIR "${PROJECT_BINARY_DIR}/src/posix/syscall_intercept")
+set(SYSCALL_INTERCEPT_INCLUDE_FOLDER
+        "${SYSCALL_INTERCEPT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(SYSCALL_INTERCEPT_LIB_FOLDER
+        "${SYSCALL_INTERCEPT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 
 #####################################
 # Definitions
@@ -45,7 +44,7 @@ target_include_directories(${TARGET_NAME} PRIVATE
 #####################################
 # Link libraries
 #####################################
-target_link_directories(${TARGET_NAME} PRIVATE ${SYSCALL_INTERCEPT_LIB_FOLDERS})
+target_link_directories(${TARGET_NAME} PRIVATE ${SYSCALL_INTERCEPT_LIB_FOLDER})
 target_link_libraries(${TARGET_NAME} PRIVATE rt syscall_intercept Catch2::Catch2WithMain)
 
 #####################################


### PR DESCRIPTION
This commit introduces the possibility to install CAPIO in a system using the `cmake --install` command. It also slightly modifies the CI test to verify that CAPIO is installed correctly.