### PR TITLE
Improve support for C++ compilers

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -45,11 +45,12 @@ jobs:
           - g++-10
           - g++-11
           - g++-12
-          - clang-11
-          - clang-12
+          - g++-13
           - clang-13
           - clang-14
           - clang-15
+          - clang-16
+          - clang-17
     steps:
       - uses: actions/checkout@v4
       - name: "Install packages"
@@ -59,12 +60,24 @@ jobs:
             libopenmpi-dev \
             ninja-build \
             openmpi-bin \
-            pkg-config \
-            ${{ matrix.cxx }}
+            pkg-config
       - name: "Get compiler version"
         run: |
           IFS='-' read -r -a COMPILER <<< "${{ matrix.cxx }}"
           echo "CXX_VERSION=${COMPILER[1]}" >> $GITHUB_ENV
+      - name: "Install Clang"
+        if: ${{ startsWith(matrix.cxx, 'clang-') }}
+        run: |
+          wget -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod u+x /tmp/llvm.sh
+          sudo /tmp/llvm.sh ${{ env.CXX_VERSION }}
+          rm -f /tmp/llvm.sh
+      - name: "Install GCC"
+        if: ${{ startsWith(matrix.cxx, 'g++-') }}
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
+          sudo apt update
+          sudo apt install -y ${{ matrix.cxx }}
       - name: "Run CMake"
         env:
           CXX: ${{ startsWith(matrix.cxx, 'clang-') && 'clang++' || 'g++' }}-${{ env.CXX_VERSION }}

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -8,19 +8,13 @@
 #include <string>
 #include <utility>
 
-#include "constants.hpp"
-#include "syscall.hpp"
 #include <sys/mman.h>
 
-#ifndef __CAPIO_POSIX // fix for older version of gcc found on galileo100 and
-// leonardo
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
+#include "constants.hpp"
+#include "syscall.hpp"
 
+#ifndef __CAPIO_POSIX
 std::ofstream logfile; // if building for server, self contained logfile
-
 #else
 FILE *logfileFP;
 bool logfileOpen = false;

--- a/src/common/capio/syscall.hpp
+++ b/src/common/capio/syscall.hpp
@@ -25,4 +25,9 @@ inline char *syscall_no_intercept_realpath(const char *path, char *resolved) {
 #define capio_realpath realpath
 #endif
 
+// The gettid function has been introduced in glibc v2.30
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#define gettid() capio_syscall(SYS_gettid)
+#endif
+
 #endif // CAPIO_COMMON_SYSCALL_HPP


### PR DESCRIPTION
This commit adds older and newer versions of Clang and g++ compilers to the CI pipeline. Plus, this commit solves an issue which prevented capio to compile with glibc versions older than `v2.30`.