### PR TITLE
This  PR fixes a bug in the ls command 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ cmake-build-*
 .vscode
 .ccls
 
+#logfies and capio files
+*.log
+files_location_*.txt
+
 # Other
 debug
 build

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -16,7 +16,7 @@ inline void fill_statbuf(struct stat *statbuf, off_t file_size, bool is_dir, ino
     struct timespec time {
         1, 1
     };
-    if (is_dir == 0) {
+    if (is_dir == 1) {
         statbuf->st_mode = S_IFDIR | S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
         file_size        = 4096;
     } else {

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -7,7 +7,7 @@ inline void fill_statxbuf(struct statx *statxbuf, off_t file_size, bool is_dir, 
               file_size, static_cast<int>(is_dir), mask);
 
     statx_timestamp time{1, 1};
-    if (is_dir == 0) {
+    if (is_dir == 1) {
         LOG("Filling statx struct for file entry");
         statxbuf->stx_mode = S_IFDIR | S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
         file_size          = 4096;
@@ -56,6 +56,7 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
     } else {
         if (!is_absolute(pathname)) {
             if (dirfd == AT_FDCWD) {
+                LOG("dirfd is AT_FDCWD");
                 absolute_path = *capio_posix_realpath(pathname);
                 if (absolute_path.empty()) {
                     LOG("returning -1 due to pathname empty");
@@ -101,7 +102,8 @@ int statx_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto *buf  = reinterpret_cast<struct statx *>(arg4);
     long tid   = syscall_no_intercept(SYS_gettid);
 
-    START_LOG(tid, "call(dirfd=%ld, pathname=%s, flags=%d, mask=%d)", dirfd, pathname.c_str(), flags, mask);
+    START_LOG(tid, "call(dirfd=%ld, pathname=%s, flags=%d, mask=%d)", dirfd, pathname.c_str(),
+              flags, mask);
 
     int res = capio_statx(dirfd, &pathname, flags, mask, buf, tid);
 

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -3,14 +3,17 @@
 
 inline void fill_statxbuf(struct statx *statxbuf, off_t file_size, bool is_dir, ino_t inode,
                           int mask) {
+    START_LOG(syscall_no_intercept(SYS_gettid), "call(filesize=%ld, is_dir=%d, inode=%d, mask=%d)",
+              file_size, static_cast<int>(is_dir), mask);
+
     statx_timestamp time{1, 1};
     if (is_dir == 0) {
-        statxbuf->stx_mode |= S_IFDIR;
-        statxbuf->stx_mode |= S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
-        file_size = 4096;
+        LOG("Filling statx struct for file entry");
+        statxbuf->stx_mode = S_IFDIR | S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+        file_size          = 4096;
     } else {
-        statxbuf->stx_mode |= S_IFREG;
-        statxbuf->stx_mode |= S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+        LOG("Filling statx struct for directory entry");
+        statxbuf->stx_mode = S_IFREG | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
     }
     statxbuf->stx_mask            = STATX_BASIC_STATS | STATX_BTIME;
     statxbuf->stx_attributes_mask = 0;
@@ -41,9 +44,11 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
                 if (exists_capio_fd(dirfd)) {
                     absolute_path = get_capio_fd_path(dirfd);
                 } else {
+                    LOG("returning -2 due to !exists_capio_fd");
                     return -2;
                 }
             } else {
+                LOG("returning -1 due to pathname empty");
                 // TODO: set errno
                 return -1;
             }
@@ -53,14 +58,17 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
             if (dirfd == AT_FDCWD) {
                 absolute_path = *capio_posix_realpath(pathname);
                 if (absolute_path.empty()) {
+                    LOG("returning -1 due to pathname empty");
                     return -1;
                 }
             } else {
                 if (!is_directory(dirfd)) {
+                    LOG("returning -2 due to !is_directory");
                     return -2;
                 }
                 std::string dir_path = get_dir_path(dirfd);
                 if (dir_path.empty()) {
+                    LOG("returning -2 due to dir path empty");
                     return -2;
                 }
                 if (pathname->substr(0, 2) == "./") {
@@ -74,11 +82,13 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
             }
         }
         if (!is_capio_path(absolute_path)) {
+            LOG("returning -2 due to not being a capio path");
             return -2;
         }
     }
 
     auto [file_size, is_dir] = stat_request(absolute_path, tid);
+    LOG("Filling statx buffer");
     fill_statxbuf(statxbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path), mask);
     return 0;
 }
@@ -91,12 +101,18 @@ int statx_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto *buf  = reinterpret_cast<struct statx *>(arg4);
     long tid   = syscall_no_intercept(SYS_gettid);
 
+    START_LOG(tid, "call(dirfd=%ld, pathname=%s, flags=%d, mask=%d)", dirfd, pathname.c_str(), flags, mask);
+
     int res = capio_statx(dirfd, &pathname, flags, mask, buf, tid);
+
+    LOG("result of capio_statx is %d", res);
 
     if (res != -2) {
         *result = (res < 0 ? -errno : res);
+        LOG("statx completed. returning 0");
         return 0;
     }
+    LOG("statx completed with error. returning 1");
     return 1;
 }
 

--- a/src/server/utils/metadata.hpp
+++ b/src/server/utils/metadata.hpp
@@ -65,8 +65,10 @@ get_capio_file_opt(const char *const path) {
     const std::lock_guard<std::mutex> lg(files_metadata_mutex);
     auto it = files_metadata.find(path);
     if (it == files_metadata.end()) {
+        LOG("File %s was not found in files_metadata. returning empty object", path);
         return {};
     } else {
+        LOG("File found. returning contained item");
         return {*it->second};
     }
 }


### PR DESCRIPTION
This  PR fixes a bug in the ls command, that was located in the stat and statx code. 
Warning: from this commit, the changes to syscallnames.h are ignored. this is done trough
```git update-index --skip-worktree src/common/capio/syscallnames.h```
To re enable tracking changes, run
```git update-index --no-skip-worktree src/common/capio/syscallnames.h```