### PR TITLE
Removed magic numbers in capio posix handlers

### DIFF
--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -41,10 +41,10 @@ constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(
                                           sizeof(unsigned short) + sizeof(unsigned char) +
                                           sizeof(char) * NAME_MAX;
 
-constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO            = 0;
-constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO  = -1;
-constexpr int POSIX_SYSCALL_TO_HANDLE_BY_KERNEL         = 1;
-constexpr int POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL = -2;
+constexpr int POSIX_SYSCALL_SUCCESS      = 0;
+constexpr int POSIX_SYSCALL_SKIP         = 1;
+constexpr int POSIX_SYSCALL_ERRNO        = -1;
+constexpr int POSIX_SYSCALL_REQUEST_SKIP = -2;
 
 constexpr char CAPIO_BANNER[] =
     "\n\n "

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -42,9 +42,9 @@ constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(
                                           sizeof(char) * NAME_MAX;
 
 constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO            = 0;
+constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO  = -1;
 constexpr int POSIX_SYSCALL_TO_HANDLE_BY_KERNEL         = 1;
 constexpr int POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL = -2;
-constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO  = -1;
 
 constexpr char CAPIO_BANNER[] =
     "\n\n "
@@ -81,11 +81,8 @@ constexpr char CAPIO_LOG_CLI_WARNING_LOG_SET_NOT_COMPILED[] =
 // constant strings for argument parser and capio server help
 constexpr char CAPIO_SERVER_ARG_PARSER_PRE[] =
     "Cross Application Programmable IO application. developed by Alberto "
-    "Riccardo Martinelli (UniTO), "
-    "Massimo Torquati(UniPI), Marco Aldinucci (UniTO), Iacopo "
-    "Colonneli(UniTO) "
-    "and"
-    " Marco Edoardo Santimaria (UniTO).";
+    "Riccardo Martinelli (UniTO), Massimo Torquati(UniPI), Marco Aldinucci (UniTO), Iacopo "
+    "Colonneli(UniTO)  and Marco Edoardo Santimaria (UniTO).";
 constexpr char CAPIO_SERVER_ARG_PARSER_EPILOGUE[] =
     "For further help, a full list of the available ENVIRONMENT VARIABLES,"
     " and a guide on config JSON file structure, please visit "

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -41,6 +41,9 @@ constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(
                                           sizeof(unsigned short) + sizeof(unsigned char) +
                                           sizeof(char) * NAME_MAX;
 
+constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO    = 0;
+constexpr int POSIX_SYSCALL_TO_HANDLE_BY_KERNEL = 1;
+
 constexpr char CAPIO_BANNER[] =
     "\n\n "
     "\033[1;34m /$$$$$$   /$$$$$$  /$$$$$$$\033[0;96m  /$$$$$$  /$$$$$$ \n"

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -44,6 +44,7 @@ constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(
 constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO            = 0;
 constexpr int POSIX_SYSCALL_TO_HANDLE_BY_KERNEL         = 1;
 constexpr int POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL = -2;
+constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO  = -1;
 
 constexpr char CAPIO_BANNER[] =
     "\n\n "

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -82,7 +82,7 @@ constexpr char CAPIO_LOG_CLI_WARNING_LOG_SET_NOT_COMPILED[] =
 constexpr char CAPIO_SERVER_ARG_PARSER_PRE[] =
     "Cross Application Programmable IO application. developed by Alberto "
     "Riccardo Martinelli (UniTO), Massimo Torquati(UniPI), Marco Aldinucci (UniTO), Iacopo "
-    "Colonneli(UniTO)  and Marco Edoardo Santimaria (UniTO).";
+    "Colonnelli(UniTO)  and Marco Edoardo Santimaria (UniTO).";
 constexpr char CAPIO_SERVER_ARG_PARSER_EPILOGUE[] =
     "For further help, a full list of the available ENVIRONMENT VARIABLES,"
     " and a guide on config JSON file structure, please visit "

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -41,8 +41,9 @@ constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(
                                           sizeof(unsigned short) + sizeof(unsigned char) +
                                           sizeof(char) * NAME_MAX;
 
-constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO    = 0;
-constexpr int POSIX_SYSCALL_TO_HANDLE_BY_KERNEL = 1;
+constexpr int POSIX_SYSCALL_HANDLED_BY_CAPIO            = 0;
+constexpr int POSIX_SYSCALL_TO_HANDLE_BY_KERNEL         = 1;
+constexpr int POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL = -2;
 
 constexpr char CAPIO_BANNER[] =
     "\n\n "

--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -15,7 +15,7 @@ inline off64_t capio_access(const std::string *pathname, mode_t mode, long tid) 
     if (is_capio_path(*abs_pathname)) {
         return access_request(*abs_pathname, tid);
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 
@@ -31,11 +31,11 @@ inline off64_t capio_faccessat(int dirfd, const std::string *pathname, mode_t mo
         } else {
             if (!is_directory(dirfd)) {
                 LOG("dirfd does not point to a directory");
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             std::string path = dir_path + "/" + *pathname;
             return is_capio_path(path) ? access_request(path, tid) : -2;

--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -10,12 +10,12 @@ inline off64_t capio_access(const std::string *pathname, mode_t mode, long tid) 
     const std::string *abs_pathname = capio_posix_realpath(pathname);
     if (abs_pathname->empty()) {
         errno = ENONET;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+        return POSIX_SYSCALL_ERRNO;
     }
     if (is_capio_path(*abs_pathname)) {
         return access_request(*abs_pathname, tid);
     } else {
-        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
@@ -31,11 +31,11 @@ inline off64_t capio_faccessat(int dirfd, const std::string *pathname, mode_t mo
         } else {
             if (!is_directory(dirfd)) {
                 LOG("dirfd does not point to a directory");
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             std::string path = dir_path + "/" + *pathname;
             return is_capio_path(path) ? access_request(path, tid) : -2;

--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -10,7 +10,7 @@ inline off64_t capio_access(const std::string *pathname, mode_t mode, long tid) 
     const std::string *abs_pathname = capio_posix_realpath(pathname);
     if (abs_pathname->empty()) {
         errno = ENONET;
-        return -1;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
     }
     if (is_capio_path(*abs_pathname)) {
         return access_request(*abs_pathname, tid);

--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -2,6 +2,7 @@
 #define CAPIO_POSIX_HANDLERS_ACCESS_HPP
 
 #include "utils/filesystem.hpp"
+#include "utils/functions.hpp"
 
 inline off64_t capio_access(const std::string *pathname, mode_t mode, long tid) {
     START_LOG(tid, "call(pathname=%s, mode=%o)", pathname->c_str(), mode);
@@ -49,12 +50,7 @@ int access_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     auto mode = static_cast<mode_t>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_access(&pathname, mode, tid);
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_access(&pathname, mode, tid), result);
 }
 
 int faccessat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
@@ -65,12 +61,7 @@ int faccessat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
     auto flags = static_cast<int>(arg3);
     long tid   = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_faccessat(dirfd, &pathname, mode, flags, tid);
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_faccessat(dirfd, &pathname, mode, flags, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_ACCESS_HPP

--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -21,18 +21,18 @@ int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         path_to_check = capio_posix_realpath(&path);
         if (path_to_check->empty()) {
             *result = -errno;
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
     }
 
     if (is_capio_path(*path_to_check)) {
         set_current_dir(path_to_check);
         errno = 0;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
 
     // if not a capio path, then control is given to kernel
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_CHDIR_HPP

--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -21,18 +21,18 @@ int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         path_to_check = capio_posix_realpath(&path);
         if (path_to_check->empty()) {
             *result = -errno;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
     }
 
     if (is_capio_path(*path_to_check)) {
         set_current_dir(path_to_check);
         errno = 0;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
 
     // if not a capio path, then control is given to kernel
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_CHDIR_HPP

--- a/src/posix/handlers/close.hpp
+++ b/src/posix/handlers/close.hpp
@@ -13,7 +13,7 @@ int close_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         delete_capio_fd(fd);
         *result = 0;
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_CLOSE_HPP

--- a/src/posix/handlers/close.hpp
+++ b/src/posix/handlers/close.hpp
@@ -13,7 +13,7 @@ int close_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         delete_capio_fd(fd);
         *result = 0;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_CLOSE_HPP

--- a/src/posix/handlers/dup.hpp
+++ b/src/posix/handlers/dup.hpp
@@ -14,15 +14,15 @@ int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5
         int res = open("/dev/null", O_WRONLY);
         if (res == -1) {
             *result = -errno;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
         dup_request(fd, res, tid);
         dup_capio_fd(tid, fd, res, false);
 
         *result = res;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -38,16 +38,16 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         int res = static_cast<int>(syscall_no_intercept(SYS_dup2, fd, fd2));
         if (res == -1) {
             *result = -errno;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
         if (fd != res) {
             dup_request(fd, res, tid);
             dup_capio_fd(tid, fd, res, false);
         }
         *result = res;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -69,16 +69,16 @@ int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         int res = static_cast<int>(syscall_no_intercept(SYS_dup3, fd, fd2, flags));
         if (res == -1) {
             *result = -errno;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
         bool is_cloexec = (flags & O_CLOEXEC) == O_CLOEXEC;
         dup_request(fd, res, tid);
         dup_capio_fd(tid, fd, res, is_cloexec);
 
         *result = res;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_DUP_HPP

--- a/src/posix/handlers/dup.hpp
+++ b/src/posix/handlers/dup.hpp
@@ -14,15 +14,15 @@ int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5
         int res = open("/dev/null", O_WRONLY);
         if (res == -1) {
             *result = -errno;
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
         dup_request(fd, res, tid);
         dup_capio_fd(tid, fd, res, false);
 
         *result = res;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -38,16 +38,16 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         int res = static_cast<int>(syscall_no_intercept(SYS_dup2, fd, fd2));
         if (res == -1) {
             *result = -errno;
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
         if (fd != res) {
             dup_request(fd, res, tid);
             dup_capio_fd(tid, fd, res, false);
         }
         *result = res;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -69,16 +69,16 @@ int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         int res = static_cast<int>(syscall_no_intercept(SYS_dup3, fd, fd2, flags));
         if (res == -1) {
             *result = -errno;
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
         bool is_cloexec = (flags & O_CLOEXEC) == O_CLOEXEC;
         dup_request(fd, res, tid);
         dup_capio_fd(tid, fd, res, is_cloexec);
 
         *result = res;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_DUP_HPP

--- a/src/posix/handlers/dup.hpp
+++ b/src/posix/handlers/dup.hpp
@@ -2,7 +2,6 @@
 #define CAPIO_POSIX_HANDLERS_DUP_HPP
 
 #include "capio/syscall.hpp"
-
 #include "utils/requests.hpp"
 
 int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {

--- a/src/posix/handlers/execve.hpp
+++ b/src/posix/handlers/execve.hpp
@@ -9,7 +9,7 @@ int execve_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
 
     create_snapshot(tid);
 
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_EXECVE_HPP

--- a/src/posix/handlers/execve.hpp
+++ b/src/posix/handlers/execve.hpp
@@ -9,7 +9,7 @@ int execve_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
 
     create_snapshot(tid);
 
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_EXECVE_HPP

--- a/src/posix/handlers/exit_group.hpp
+++ b/src/posix/handlers/exit_group.hpp
@@ -18,7 +18,7 @@ int exit_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
 
     exit_group_request(tid);
 
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_EXIT_GROUP_HPP

--- a/src/posix/handlers/exit_group.hpp
+++ b/src/posix/handlers/exit_group.hpp
@@ -18,7 +18,7 @@ int exit_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
 
     exit_group_request(tid);
 
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_EXIT_GROUP_HPP

--- a/src/posix/handlers/fchmod.hpp
+++ b/src/posix/handlers/fchmod.hpp
@@ -6,11 +6,11 @@ int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
 
     if (!exists_capio_fd(fd)) {
-        return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_SUCCESS;
     }
     *result = -errno;
 
-    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+    return POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCHMOD_HPP

--- a/src/posix/handlers/fchmod.hpp
+++ b/src/posix/handlers/fchmod.hpp
@@ -6,11 +6,11 @@ int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
 
     if (!exists_capio_fd(fd)) {
-        return 1;
+        return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
     *result = -errno;
 
-    return 0;
+    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCHMOD_HPP

--- a/src/posix/handlers/fchown.hpp
+++ b/src/posix/handlers/fchown.hpp
@@ -6,11 +6,11 @@ int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
 
     if (!exists_capio_fd(fd)) {
-        return 1;
+        return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
     *result = -errno;
 
-    return 0;
+    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCHOWN_HPP

--- a/src/posix/handlers/fchown.hpp
+++ b/src/posix/handlers/fchown.hpp
@@ -6,11 +6,11 @@ int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
 
     if (!exists_capio_fd(fd)) {
-        return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_SKIP;
     }
     *result = -errno;
 
-    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+    return POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCHOWN_HPP

--- a/src/posix/handlers/fcntl.hpp
+++ b/src/posix/handlers/fcntl.hpp
@@ -17,22 +17,22 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         switch (cmd) {
         case F_GETFD: {
             *result = get_capio_fd_cloexec(fd);
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
 
         case F_SETFD: {
             set_capio_fd_cloexec(fd, arg);
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
 
         case F_GETFL: {
             *result = get_capio_fd_flags(fd);
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
 
         case F_SETFL: {
             set_capio_fd_flags(fd, arg);
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
 
         case F_DUPFD_CLOEXEC: {
@@ -50,14 +50,14 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
             dup_capio_fd(tid, fd, res, true);
             dup_request(fd, res, tid);
 
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         }
 
         default:
             ERR_EXIT("fcntl with cmd %d is not yet supported", cmd);
         }
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCNTL_HPP

--- a/src/posix/handlers/fcntl.hpp
+++ b/src/posix/handlers/fcntl.hpp
@@ -17,22 +17,22 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         switch (cmd) {
         case F_GETFD: {
             *result = get_capio_fd_cloexec(fd);
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
 
         case F_SETFD: {
             set_capio_fd_cloexec(fd, arg);
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
 
         case F_GETFL: {
             *result = get_capio_fd_flags(fd);
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
 
         case F_SETFL: {
             set_capio_fd_flags(fd, arg);
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
 
         case F_DUPFD_CLOEXEC: {
@@ -50,14 +50,14 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
             dup_capio_fd(tid, fd, res, true);
             dup_request(fd, res, tid);
 
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         }
 
         default:
             ERR_EXIT("fcntl with cmd %d is not yet supported", cmd);
         }
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCNTL_HPP

--- a/src/posix/handlers/fgetxattr.hpp
+++ b/src/posix/handlers/fgetxattr.hpp
@@ -1,5 +1,6 @@
 #ifndef CAPIO_POSIX_HANDLERS_FGETXATTR_HPP
 #define CAPIO_POSIX_HANDLERS_FGETXATTR_HPP
+
 int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                       long *result) {
     std::string name(reinterpret_cast<const char *>(arg1));

--- a/src/posix/handlers/fgetxattr.hpp
+++ b/src/posix/handlers/fgetxattr.hpp
@@ -13,12 +13,12 @@ int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
         if (std::equal(name.begin(), name.end(), "system.posix_acl_access")) {
             errno   = ENODATA;
             *result = -errno;
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         } else {
             ERR_EXIT("fgetxattr with name %s is not yet supported in CAPIO", name.c_str());
         }
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FGETXATTR_HPP

--- a/src/posix/handlers/fgetxattr.hpp
+++ b/src/posix/handlers/fgetxattr.hpp
@@ -14,12 +14,12 @@ int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
         if (std::equal(name.begin(), name.end(), "system.posix_acl_access")) {
             errno   = ENODATA;
             *result = -errno;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         } else {
             ERR_EXIT("fgetxattr with name %s is not yet supported in CAPIO", name.c_str());
         }
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FGETXATTR_HPP

--- a/src/posix/handlers/fork.hpp
+++ b/src/posix/handlers/fork.hpp
@@ -19,7 +19,7 @@ int fork_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         *result = pid;
     }
 
-    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+    return POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FORK_HPP

--- a/src/posix/handlers/fork.hpp
+++ b/src/posix/handlers/fork.hpp
@@ -19,7 +19,7 @@ int fork_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         *result = pid;
     }
 
-    return 0;
+    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FORK_HPP

--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -16,7 +16,7 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
         cwd.copy(buf, size);
         buf[cwd.length()] = '\0';
     }
-    return 0;
+    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_GETCWD_HPP

--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -16,7 +16,7 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
         cwd.copy(buf, size);
         buf[cwd.length()] = '\0';
     }
-    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+    return POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_GETCWD_HPP

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -34,11 +34,11 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
         set_capio_fd_offset(fd, offset + bytes_read);
 
         *result = bytes_read;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     } else {
         LOG("fd=%d, is not a capio file descriptor", fd);
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 inline int getdents_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -34,11 +34,11 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
         set_capio_fd_offset(fd, offset + bytes_read);
 
         *result = bytes_read;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     } else {
         LOG("fd=%d, is not a capio file descriptor", fd);
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 inline int getdents_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -2,17 +2,7 @@
 #define CAPIO_POSIX_HANDLERS_GETDENTS_HPP
 
 #include "utils/data.hpp"
-
-inline off64_t round(off64_t bytes, bool is_getdents64) {
-    off64_t res = 0;
-    off64_t ld_size;
-    ld_size = THEORETICAL_SIZE_DIRENT64;
-
-    while (res + ld_size <= bytes) {
-        res += ld_size;
-    }
-    return res;
-}
+#include "utils/functions.hpp"
 
 // TODO: too similar to capio_read, refactoring needed
 inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, bool is64bit) {

--- a/src/posix/handlers/ioctl.hpp
+++ b/src/posix/handlers/ioctl.hpp
@@ -10,9 +10,9 @@ int ioctl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     if (exists_capio_fd(fd)) {
         errno   = ENOTTY;
         *result = -errno;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_REQUEST_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_IOCTL_HPP

--- a/src/posix/handlers/ioctl.hpp
+++ b/src/posix/handlers/ioctl.hpp
@@ -10,9 +10,9 @@ int ioctl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     if (exists_capio_fd(fd)) {
         errno   = ENOTTY;
         *result = -errno;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_IOCTL_HPP

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -16,7 +16,7 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
                 return offset;
             } else {
                 errno = EINVAL;
-                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+                return POSIX_SYSCALL_ERRNO;
             }
         } else if (whence == SEEK_CUR) {
             off64_t new_offset = file_offset + offset;
@@ -26,7 +26,7 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
                 return new_offset;
             } else {
                 errno = EINVAL;
-                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+                return POSIX_SYSCALL_ERRNO;
             }
         } else if (whence == SEEK_END) {
             off64_t file_size  = seek_end_request(fd, tid);
@@ -43,10 +43,10 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
             return new_offset;
         } else {
             errno = EINVAL;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+            return POSIX_SYSCALL_ERRNO;
         }
     } else {
-        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -16,7 +16,7 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
                 return offset;
             } else {
                 errno = EINVAL;
-                return -1;
+                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
             }
         } else if (whence == SEEK_CUR) {
             off64_t new_offset = file_offset + offset;
@@ -26,7 +26,7 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
                 return new_offset;
             } else {
                 errno = EINVAL;
-                return -1;
+                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
             }
         } else if (whence == SEEK_END) {
             off64_t file_size  = seek_end_request(fd, tid);
@@ -43,7 +43,7 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
             return new_offset;
         } else {
             errno = EINVAL;
-            return -1;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
         }
     } else {
         return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_LSEEK_HPP
 #define CAPIO_POSIX_HANDLERS_LSEEK_HPP
 
+#include "utils/functions.hpp"
+
 // TODO: EOVERFLOW is not addressed
 inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
     START_LOG(tid, "call(fd=%d, offset=%ld, whence=%d)", fd, offset, whence);
@@ -54,13 +56,7 @@ int lseek_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     int whence  = static_cast<int>(arg2);
     long tid    = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_lseek(fd, offset, whence, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_lseek(fd, offset, whence, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_LSEEK_HPP

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -46,7 +46,7 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
             return -1;
         }
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 

--- a/src/posix/handlers/mkdir.hpp
+++ b/src/posix/handlers/mkdir.hpp
@@ -12,15 +12,15 @@ inline off64_t capio_mkdirat(int dirfd, std::string *pathname, mode_t mode, long
         if (dirfd == AT_FDCWD) {
             path_to_check = *capio_posix_realpath(pathname);
             if (path_to_check.empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
         } else {
             if (!is_directory(dirfd)) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             path_to_check = dir_path + "/" + *pathname;
         }
@@ -40,7 +40,7 @@ inline off64_t capio_mkdirat(int dirfd, std::string *pathname, mode_t mode, long
             return res;
         }
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 
@@ -52,7 +52,7 @@ inline off64_t capio_rmdir(std::string *pathname, long tid) {
         path_to_check = *capio_posix_realpath(pathname);
         if (path_to_check.empty()) {
             LOG("path_to_check.len = 0!");
-            return -2;
+            return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
         }
     }
 
@@ -73,7 +73,7 @@ inline off64_t capio_rmdir(std::string *pathname, long tid) {
             return res;
         }
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 

--- a/src/posix/handlers/mkdir.hpp
+++ b/src/posix/handlers/mkdir.hpp
@@ -12,15 +12,15 @@ inline off64_t capio_mkdirat(int dirfd, std::string *pathname, mode_t mode, long
         if (dirfd == AT_FDCWD) {
             path_to_check = *capio_posix_realpath(pathname);
             if (path_to_check.empty()) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
         } else {
             if (!is_directory(dirfd)) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             path_to_check = dir_path + "/" + *pathname;
         }
@@ -29,18 +29,18 @@ inline off64_t capio_mkdirat(int dirfd, std::string *pathname, mode_t mode, long
     if (is_capio_path(path_to_check)) {
         if (exists_capio_path(path_to_check)) {
             errno = EEXIST;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+            return POSIX_SYSCALL_ERRNO;
         }
         off64_t res = mkdir_request(path_to_check, tid);
         if (res == 1) {
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+            return POSIX_SYSCALL_ERRNO;
         } else {
             LOG("Adding %s to capio_files_path", path_to_check.c_str());
             add_capio_path(path_to_check);
             return res;
         }
     } else {
-        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
@@ -52,7 +52,7 @@ inline off64_t capio_rmdir(std::string *pathname, long tid) {
         path_to_check = *capio_posix_realpath(pathname);
         if (path_to_check.empty()) {
             LOG("path_to_check.len = 0!");
-            return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+            return POSIX_SYSCALL_REQUEST_SKIP;
         }
     }
 
@@ -61,19 +61,19 @@ inline off64_t capio_rmdir(std::string *pathname, long tid) {
             LOG("capio_files_path.find == end. errno = "
                 "ENOENT");
             errno = ENOENT;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+            return POSIX_SYSCALL_ERRNO;
         }
         off64_t res = rmdir_request(path_to_check, tid);
         if (res == 2) {
             LOG("res == 2. errno = ENOENT");
             errno = ENOENT;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+            return POSIX_SYSCALL_ERRNO;
         } else {
             delete_capio_path(path_to_check);
             return res;
         }
     } else {
-        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 

--- a/src/posix/handlers/mkdir.hpp
+++ b/src/posix/handlers/mkdir.hpp
@@ -2,6 +2,7 @@
 #define CAPIO_POSIX_HANDLERS_MKDIR_HPP
 
 #include "utils/filesystem.hpp"
+#include "utils/functions.hpp"
 
 inline off64_t capio_mkdirat(int dirfd, std::string *pathname, mode_t mode, long tid) {
     START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o)", dirfd, pathname->c_str(), mode);
@@ -81,13 +82,7 @@ int mkdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto mode = static_cast<mode_t>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_mkdirat(AT_FDCWD, &pathname, mode, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_mkdirat(AT_FDCWD, &pathname, mode, tid), result);
 }
 
 int mkdirat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
@@ -97,25 +92,14 @@ int mkdirat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
     auto mode = static_cast<mode_t>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_mkdirat(dirfd, &pathname, mode, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_mkdirat(dirfd, &pathname, mode, tid), result);
 }
 
 int rmdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     std::string pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_rmdir(&pathname, tid);
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_rmdir(&pathname, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_MKDIR_HPP

--- a/src/posix/handlers/mkdir.hpp
+++ b/src/posix/handlers/mkdir.hpp
@@ -29,11 +29,11 @@ inline off64_t capio_mkdirat(int dirfd, std::string *pathname, mode_t mode, long
     if (is_capio_path(path_to_check)) {
         if (exists_capio_path(path_to_check)) {
             errno = EEXIST;
-            return -1;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
         }
         off64_t res = mkdir_request(path_to_check, tid);
         if (res == 1) {
-            return -1;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
         } else {
             LOG("Adding %s to capio_files_path", path_to_check.c_str());
             add_capio_path(path_to_check);
@@ -61,13 +61,13 @@ inline off64_t capio_rmdir(std::string *pathname, long tid) {
             LOG("capio_files_path.find == end. errno = "
                 "ENOENT");
             errno = ENOENT;
-            return -1;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
         }
         off64_t res = rmdir_request(path_to_check, tid);
         if (res == 2) {
             LOG("res == 2. errno = ENOENT");
             errno = ENOENT;
-            return -1;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
         } else {
             delete_capio_path(path_to_check);
             return res;

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -5,11 +5,6 @@
 #include "utils/filesystem.hpp"
 #include "utils/functions.hpp"
 
-std::string get_capio_parent_dir(const std::string &path) {
-    auto pos = path.rfind('/');
-    return path.substr(0, pos);
-}
-
 inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
     START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%X)", dirfd, pathname->c_str(), flags);
 

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -54,19 +54,19 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
             off64_t return_code = create_exclusive_request(fd, path_to_check, tid);
             if (return_code == 1) {
                 errno = EEXIST;
-                return -1;
+                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
             }
         } else if (create) {
             off64_t return_code = create_request(fd, path_to_check, tid);
             if (return_code == 1) {
                 errno = ENOENT;
-                return -1;
+                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
             }
         } else {
             off64_t return_code = open_request(fd, path_to_check, tid);
             if (return_code == 1) {
                 errno = ENOENT;
-                return -1;
+                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
             }
         }
         int actual_flags = flags & ~O_CLOEXEC;

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -2,8 +2,8 @@
 #define CAPIO_POSIX_HANDLERS_OPENAT_HPP
 
 #include "lseek.hpp"
-
 #include "utils/filesystem.hpp"
+#include "utils/functions.hpp"
 
 std::string get_capio_parent_dir(const std::string &path) {
     auto pos = path.rfind('/');
@@ -88,13 +88,8 @@ int creat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     std::string pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
-    int res = capio_openat(AT_FDCWD, &pathname, O_CREAT | O_WRONLY | O_TRUNC, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_openat(AT_FDCWD, &pathname, O_CREAT | O_WRONLY | O_TRUNC, tid),
+                              result);
 }
 
 int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -103,13 +98,7 @@ int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     int flags = static_cast<int>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    int res = capio_openat(dirfd, &pathname, flags, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_openat(dirfd, &pathname, flags, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_OPENAT_HPP

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -19,16 +19,16 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
         if (dirfd == AT_FDCWD) {
             path_to_check = *capio_posix_realpath(pathname);
             if (path_to_check.empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
         } else {
             if (!is_directory(dirfd)) {
                 LOG("dirfd does not point to a directory");
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
 
             if (pathname->substr(0, 2) == "./") {
@@ -80,7 +80,7 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
         }
         return fd;
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -14,16 +14,16 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
         if (dirfd == AT_FDCWD) {
             path_to_check = *capio_posix_realpath(pathname);
             if (path_to_check.empty()) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
         } else {
             if (!is_directory(dirfd)) {
                 LOG("dirfd does not point to a directory");
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
 
             if (pathname->substr(0, 2) == "./") {
@@ -49,19 +49,19 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
             off64_t return_code = create_exclusive_request(fd, path_to_check, tid);
             if (return_code == 1) {
                 errno = EEXIST;
-                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+                return POSIX_SYSCALL_ERRNO;
             }
         } else if (create) {
             off64_t return_code = create_request(fd, path_to_check, tid);
             if (return_code == 1) {
                 errno = ENOENT;
-                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+                return POSIX_SYSCALL_ERRNO;
             }
         } else {
             off64_t return_code = open_request(fd, path_to_check, tid);
             if (return_code == 1) {
                 errno = ENOENT;
-                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+                return POSIX_SYSCALL_ERRNO;
             }
         }
         int actual_flags = flags & ~O_CLOEXEC;
@@ -75,7 +75,7 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
         }
         return fd;
     } else {
-        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 

--- a/src/posix/handlers/read.hpp
+++ b/src/posix/handlers/read.hpp
@@ -21,9 +21,9 @@ int read_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         read_data(tid, buffer, bytes_read);
         set_capio_fd_offset(fd, offset + bytes_read);
         *result = bytes_read;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_READ_HPP

--- a/src/posix/handlers/read.hpp
+++ b/src/posix/handlers/read.hpp
@@ -21,9 +21,9 @@ int read_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         read_data(tid, buffer, bytes_read);
         set_capio_fd_offset(fd, offset + bytes_read);
         *result = bytes_read;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_READ_HPP

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -3,10 +3,6 @@
 
 #include "utils/filesystem.hpp"
 
-inline std::string absolute(const std::string &path) {
-    return is_absolute(&path) ? path : *capio_posix_realpath(&path);
-}
-
 int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     const std::string oldpath(reinterpret_cast<const char *>(arg0));
     const std::string newpath(reinterpret_cast<const char *>(arg1));

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -15,21 +15,21 @@ int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     if (is_prefix(oldpath_abs, newpath_abs)) { // TODO: The check is more complex
         errno   = EINVAL;
         *result = -errno;
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
 
     if (is_capio_path(oldpath_abs)) {
         rename_capio_path(oldpath_abs, newpath_abs);
         auto res = rename_request(tid, oldpath_abs, newpath_abs);
         *result  = (res < 0 ? -errno : res);
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     } else {
         if (is_capio_path(newpath_abs)) {
             std::filesystem::copy(oldpath_abs, newpath_abs);
             *result = -errno;
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+            return POSIX_SYSCALL_SUCCESS;
         } else {
-            return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+            return POSIX_SYSCALL_SKIP;
         }
     }
 }

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -19,21 +19,21 @@ int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     if (is_prefix(oldpath_abs, newpath_abs)) { // TODO: The check is more complex
         errno   = EINVAL;
         *result = -errno;
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
 
     if (is_capio_path(oldpath_abs)) {
         rename_capio_path(oldpath_abs, newpath_abs);
         auto res = rename_request(tid, oldpath_abs, newpath_abs);
         *result  = (res < 0 ? -errno : res);
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     } else {
         if (is_capio_path(newpath_abs)) {
             std::filesystem::copy(oldpath_abs, newpath_abs);
             *result = -errno;
-            return 0;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO;
         } else {
-            return 1;
+            return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
         }
     }
 }

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -42,7 +42,7 @@ inline int capio_fstat(int fd, struct stat *statbuf, long tid) {
     if (exists_capio_fd(fd)) {
         auto [file_size, is_dir] = fstat_request(fd, tid);
         fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(get_capio_fd_path(fd)));
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     } else {
         return -2;
     }
@@ -54,7 +54,7 @@ inline int capio_lstat(const std::string &absolute_path, struct stat *statbuf, l
     if (is_capio_path(absolute_path)) {
         auto [file_size, is_dir] = stat_request(absolute_path, tid);
         fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path));
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     } else {
         return -2;
     }

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -4,8 +4,8 @@
 #include <sys/vfs.h>
 
 #include "capio/env.hpp"
-
 #include "utils/filesystem.hpp"
+#include "utils/functions.hpp"
 #include "utils/requests.hpp"
 
 inline blkcnt_t get_nblocks(off64_t file_size) {
@@ -127,13 +127,7 @@ int fstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto *buf = reinterpret_cast<struct stat *>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    int res = capio_fstat(fd, buf, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_fstat(fd, buf, tid), result);
 }
 
 int fstatat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
@@ -144,13 +138,7 @@ int fstatat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
     auto flags    = static_cast<int>(arg3);
     long tid      = syscall_no_intercept(SYS_gettid);
 
-    int res = capio_fstatat(dirfd, &pathname, statbuf, flags, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_fstatat(dirfd, &pathname, statbuf, flags, tid), result);
 }
 
 int lstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -158,13 +146,7 @@ int lstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto *buf = reinterpret_cast<struct stat *>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    int res = capio_lstat_wrapper(&path, buf, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_lstat_wrapper(&path, buf, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_STAT_HPP

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -88,7 +88,7 @@ inline int capio_fstatat(int dirfd, std::string *pathname, struct stat *statbuf,
                 return capio_fstat(dirfd, statbuf, tid);
             } else {
                 // TODO: set errno
-                return -1;
+                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
             }
         }
     }

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -44,7 +44,7 @@ inline int capio_fstat(int fd, struct stat *statbuf, long tid) {
         fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(get_capio_fd_path(fd)));
         return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 
@@ -56,7 +56,7 @@ inline int capio_lstat(const std::string &absolute_path, struct stat *statbuf, l
         fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path));
         return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 
@@ -64,12 +64,12 @@ inline int capio_lstat_wrapper(const std::string *path, struct stat *statbuf, lo
     START_LOG(tid, "call(path=%s, buf=0x%08x)", path, statbuf);
 
     if (path == nullptr) {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 
     const std::string *absolute_path = capio_posix_realpath(path);
     if (absolute_path->empty()) {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
     return capio_lstat(*absolute_path, statbuf, tid);
 }
@@ -99,11 +99,11 @@ inline int capio_fstatat(int dirfd, std::string *pathname, struct stat *statbuf,
             return capio_lstat_wrapper(pathname, statbuf, tid);
         } else {
             if (!is_directory(dirfd)) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
 
             if (pathname->substr(0, 2) == "./") {

--- a/src/posix/handlers/statfs.hpp
+++ b/src/posix/handlers/statfs.hpp
@@ -14,9 +14,9 @@ int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
         const std::string *capio_dir = get_capio_dir();
 
         *result = static_cast<int>(syscall_no_intercept(SYS_statfs, capio_dir->c_str(), buf));
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_STATFS_HPP

--- a/src/posix/handlers/statfs.hpp
+++ b/src/posix/handlers/statfs.hpp
@@ -14,9 +14,9 @@ int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
         const std::string *capio_dir = get_capio_dir();
 
         *result = static_cast<int>(syscall_no_intercept(SYS_statfs, capio_dir->c_str(), buf));
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_STATFS_HPP

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -47,7 +47,7 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
                     absolute_path = get_capio_fd_path(dirfd);
                 } else {
                     LOG("returning -2 due to !exists_capio_fd");
-                    return -2;
+                    return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
                 }
             } else {
                 LOG("returning -1 due to pathname empty");
@@ -67,12 +67,12 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
             } else {
                 if (!is_directory(dirfd)) {
                     LOG("returning -2 due to !is_directory");
-                    return -2;
+                    return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
                 }
                 std::string dir_path = get_dir_path(dirfd);
                 if (dir_path.empty()) {
                     LOG("returning -2 due to dir path empty");
-                    return -2;
+                    return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
                 }
                 if (pathname->substr(0, 2) == "./") {
                     absolute_path = pathname->substr(2, pathname->length() - 1);
@@ -86,7 +86,7 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
         }
         if (!is_capio_path(absolute_path)) {
             LOG("returning -2 due to not being a capio path");
-            return -2;
+            return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
         }
     }
 

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -52,7 +52,7 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
             } else {
                 LOG("returning -1 due to pathname empty");
                 // TODO: set errno
-                return -1;
+                return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
             }
         }
     } else {
@@ -62,7 +62,7 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
                 absolute_path = *capio_posix_realpath(pathname);
                 if (absolute_path.empty()) {
                     LOG("returning -1 due to pathname empty");
-                    return -1;
+                    return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
                 }
             } else {
                 if (!is_directory(dirfd)) {

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -93,7 +93,7 @@ inline int capio_statx(int dirfd, const std::string *pathname, int flags, int ma
     auto [file_size, is_dir] = stat_request(absolute_path, tid);
     LOG("Filling statx buffer");
     fill_statxbuf(statxbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path), mask);
-    return 0;
+    return POSIX_SYSCALL_HANDLED_BY_CAPIO;
 }
 
 int statx_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_STATX_HPP
 #define CAPIO_POSIX_HANDLERS_STATX_HPP
 
+#include "utils/functions.hpp"
+
 inline void fill_statxbuf(struct statx *statxbuf, off_t file_size, bool is_dir, ino_t inode,
                           int mask) {
     START_LOG(syscall_no_intercept(SYS_gettid), "call(filesize=%ld, is_dir=%d, inode=%d, mask=%d)",
@@ -105,17 +107,7 @@ int statx_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     START_LOG(tid, "call(dirfd=%ld, pathname=%s, flags=%d, mask=%d)", dirfd, pathname.c_str(),
               flags, mask);
 
-    int res = capio_statx(dirfd, &pathname, flags, mask, buf, tid);
-
-    LOG("result of capio_statx is %d", res);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        LOG("statx completed. returning 0");
-        return 0;
-    }
-    LOG("statx completed with error. returning 1");
-    return 1;
+    return posix_return_value(capio_statx(dirfd, &pathname, flags, mask, buf, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_STATX_HPP

--- a/src/posix/handlers/unlink.hpp
+++ b/src/posix/handlers/unlink.hpp
@@ -9,7 +9,7 @@ off64_t capio_unlink_abs(const std::string &abs_path, long tid, bool is_dir) {
         if (is_capio_dir(abs_path)) {
             ERR_EXIT("ERROR: unlink to the capio_dir %s", abs_path.c_str());
         } else {
-            return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+            return POSIX_SYSCALL_REQUEST_SKIP;
         }
     } else {
         off64_t res = is_dir ? rmdir_request(abs_path, tid) : unlink_request(abs_path, tid);
@@ -29,16 +29,16 @@ inline off64_t capio_unlinkat(int dirfd, const std::string &pathname, int flags,
         if (dirfd == AT_FDCWD) {
             const std::string *abs_path = capio_posix_realpath(&pathname);
             if (abs_path->empty()) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             res = capio_unlink_abs(*abs_path, tid, is_dir);
         } else {
             if (!is_directory(dirfd)) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+                return POSIX_SYSCALL_REQUEST_SKIP;
             }
             std::string path = dir_path + "/" + pathname;
 

--- a/src/posix/handlers/unlink.hpp
+++ b/src/posix/handlers/unlink.hpp
@@ -9,7 +9,7 @@ off64_t capio_unlink_abs(const std::string &abs_path, long tid, bool is_dir) {
         if (is_capio_dir(abs_path)) {
             ERR_EXIT("ERROR: unlink to the capio_dir %s", abs_path.c_str());
         } else {
-            return -2;
+            return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
         }
     } else {
         off64_t res = is_dir ? rmdir_request(abs_path, tid) : unlink_request(abs_path, tid);
@@ -29,16 +29,16 @@ inline off64_t capio_unlinkat(int dirfd, const std::string &pathname, int flags,
         if (dirfd == AT_FDCWD) {
             const std::string *abs_path = capio_posix_realpath(&pathname);
             if (abs_path->empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             res = capio_unlink_abs(*abs_path, tid, is_dir);
         } else {
             if (!is_directory(dirfd)) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             std::string dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return -2;
+                return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
             }
             std::string path = dir_path + "/" + pathname;
 

--- a/src/posix/handlers/unlink.hpp
+++ b/src/posix/handlers/unlink.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_UNLINK_HPP
 #define CAPIO_POSIX_HANDLERS_UNLINK_HPP
 
+#include "utils/functions.hpp"
+
 off64_t capio_unlink_abs(const std::string &abs_path, long tid, bool is_dir) {
     START_LOG(tid, "call(abs_path=%s, is_dir=%s)", abs_path.c_str(), is_dir ? "true" : "false");
     if (!is_capio_path(abs_path)) {
@@ -53,13 +55,7 @@ int unlink_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     std::string pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_unlinkat(AT_FDCWD, pathname, 0, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_unlinkat(AT_FDCWD, pathname, 0, tid), result);
 }
 
 int unlinkat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
@@ -69,14 +65,7 @@ int unlinkat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long
     int flags = static_cast<int>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    off64_t res = capio_unlinkat(dirfd, pathname, flags, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-
-    return 1;
+    return posix_return_value(capio_unlinkat(dirfd, pathname, flags, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_UNLINK_HPP

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -2,6 +2,7 @@
 #define CAPIO_POSIX_HANDLERS_WRITE_HPP
 
 #include "utils/requests.hpp"
+#include "utils/functions.hpp"
 
 inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) {
     START_LOG(tid, "call(fd=%d, buf=0x%08x, count=%ld)", fd, buffer, count);
@@ -56,14 +57,7 @@ int write_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto count      = static_cast<off64_t>(arg2);
     long tid        = syscall_no_intercept(SYS_gettid);
 
-    ssize_t res = capio_write(fd, buf, count, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-
-    return 1;
+    return posix_return_value(capio_write(fd, buf, count, tid), result);
 }
 
 int writev_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -72,13 +66,7 @@ int writev_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     auto iovcnt     = static_cast<int>(arg2);
     long tid        = syscall_no_intercept(SYS_gettid);
 
-    ssize_t res = capio_writev(fd, iov, iovcnt, tid);
-
-    if (res != -2) {
-        *result = (res < 0 ? -errno : res);
-        return 0;
-    }
-    return 1;
+    return posix_return_value(capio_writev(fd, iov, iovcnt, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_WRITE_HPP

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -1,8 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_WRITE_HPP
 #define CAPIO_POSIX_HANDLERS_WRITE_HPP
 
-#include "utils/requests.hpp"
 #include "utils/functions.hpp"
+#include "utils/requests.hpp"
 
 inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) {
     START_LOG(tid, "call(fd=%d, buf=0x%08x, count=%ld)", fd, buffer, count);

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -18,7 +18,7 @@ inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) 
 
         return count;
     } else {
-        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
@@ -41,13 +41,13 @@ inline ssize_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long ti
             ++i;
         }
         if (res == -1) {
-            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
+            return POSIX_SYSCALL_ERRNO;
         } else {
             return tot_bytes;
         }
     } else {
         LOG("fd %d is not a capio fd. returning -2", fd);
-        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
+        return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -41,7 +41,7 @@ inline ssize_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long ti
             ++i;
         }
         if (res == -1) {
-            return -1;
+            return POSIX_SYSCALL_HANDLED_BY_CAPIO_SET_ERRNO;
         } else {
             return tot_bytes;
         }

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -18,7 +18,7 @@ inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) 
 
         return count;
     } else {
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 
@@ -47,7 +47,7 @@ inline ssize_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long ti
         }
     } else {
         LOG("fd %d is not a capio fd. returning -2", fd);
-        return -2;
+        return POSIX_REQUEST_SYSCALL_TO_HANDLE_BY_KERNEL;
     }
 }
 

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -44,47 +44,129 @@ static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
         _syscallTable[i] = not_handled_handler;
     }
 
-    _syscallTable[SYS_access]     = access_handler;
-    _syscallTable[SYS_chdir]      = chdir_handler;
-    _syscallTable[SYS_chmod]      = fchmod_handler;
-    _syscallTable[SYS_chown]      = fchown_handler;
-    _syscallTable[SYS_close]      = close_handler;
-    _syscallTable[SYS_creat]      = creat_handler;
-    _syscallTable[SYS_dup]        = dup_handler;
-    _syscallTable[SYS_dup2]       = dup2_handler;
-    _syscallTable[SYS_dup3]       = dup3_handler;
-    _syscallTable[SYS_execve]     = execve_handler;
-    _syscallTable[SYS_exit]       = exit_handler;
+#ifdef SYS_access
+    _syscallTable[SYS_access] = access_handler;
+#endif
+#ifdef SYS_chdir
+    _syscallTable[SYS_chdir] = chdir_handler;
+#endif
+#ifdef SYS_chmod
+    _syscallTable[SYS_chmod] = fchmod_handler;
+#endif
+#ifdef SYS_chown
+    _syscallTable[SYS_chown] = fchown_handler;
+#endif
+#ifdef SYS_close
+    _syscallTable[SYS_close] = close_handler;
+#endif
+#ifdef SYS_creat
+    _syscallTable[SYS_creat] = creat_handler;
+#endif
+#ifdef SYS_dup
+    _syscallTable[SYS_dup] = dup_handler;
+#endif
+#ifdef SYS_dup2
+    _syscallTable[SYS_dup2] = dup2_handler;
+#endif
+#ifdef SYS_dup3
+    _syscallTable[SYS_dup3] = dup3_handler;
+#endif
+#ifdef SYS_execve
+    _syscallTable[SYS_execve] = execve_handler;
+#endif
+#ifdef SYS_exit
+    _syscallTable[SYS_exit] = exit_handler;
+#endif
+#ifdef SYS_exit_group
     _syscallTable[SYS_exit_group] = exit_handler;
-    _syscallTable[SYS_faccessat]  = faccessat_handler;
+#endif
+#ifdef SYS_faccessat
+    _syscallTable[SYS_faccessat] = faccessat_handler;
+#endif
+#ifdef SYS_faccessat2
     _syscallTable[SYS_faccessat2] = faccessat_handler;
-    _syscallTable[SYS_fcntl]      = fcntl_handler;
-    _syscallTable[SYS_fgetxattr]  = fgetxattr_handler;
+#endif
+#ifdef SYS_fcntl
+    _syscallTable[SYS_fcntl] = fcntl_handler;
+#endif
+#ifdef SYS_fgetxattr
+    _syscallTable[SYS_fgetxattr] = fgetxattr_handler;
+#endif
+#ifdef SYS_flistxattr
     _syscallTable[SYS_flistxattr] = not_implemented_handler;
-    _syscallTable[SYS_fork]       = fork_handler;
-    _syscallTable[SYS_fstat]      = fstat_handler;
-    _syscallTable[SYS_fstatfs]    = fstatfs_handler;
-    _syscallTable[SYS_getcwd]     = getcwd_handler;
-    _syscallTable[SYS_getdents]   = getdents_handler;
+#endif
+#ifdef SYS_fork
+    _syscallTable[SYS_fork] = fork_handler;
+#endif
+#ifdef SYS_fstat
+    _syscallTable[SYS_fstat] = fstat_handler;
+#endif
+#ifdef SYS_fstatfs
+    _syscallTable[SYS_fstatfs] = fstatfs_handler;
+#endif
+#ifdef SYS_getcwd
+    _syscallTable[SYS_getcwd] = getcwd_handler;
+#endif
+#ifdef SYS_getdents
+    _syscallTable[SYS_getdents] = getdents_handler;
+#endif
+#ifdef SYS_getdents64
     _syscallTable[SYS_getdents64] = getdents64_handler;
-    _syscallTable[SYS_getxattr]   = not_implemented_handler;
-    _syscallTable[SYS_ioctl]      = ioctl_handler;
-    _syscallTable[SYS_lgetxattr]  = not_implemented_handler;
-    _syscallTable[SYS_lseek]      = lseek_handler;
-    _syscallTable[SYS_lstat]      = lstat_handler;
-    _syscallTable[SYS_mkdir]      = mkdir_handler;
-    _syscallTable[SYS_mkdirat]    = mkdirat_handler;
+#endif
+#ifdef SYS_getxattr
+    _syscallTable[SYS_getxattr] = not_implemented_handler;
+#endif
+#ifdef SYS_ioctl
+    _syscallTable[SYS_ioctl] = ioctl_handler;
+#endif
+#ifdef SYS_lgetxattr
+    _syscallTable[SYS_lgetxattr] = not_implemented_handler;
+#endif
+#ifdef SYS_lseek
+    _syscallTable[SYS_lseek] = lseek_handler;
+#endif
+#ifdef SYS_lstat
+    _syscallTable[SYS_lstat] = lstat_handler;
+#endif
+#ifdef SYS_mkdir
+    _syscallTable[SYS_mkdir] = mkdir_handler;
+#endif
+#ifdef SYS_mkdirat
+    _syscallTable[SYS_mkdirat] = mkdirat_handler;
+#endif
+#ifdef SYS_newfstatat
     _syscallTable[SYS_newfstatat] = fstatat_handler;
-    _syscallTable[SYS_openat]     = openat_handler;
-    _syscallTable[SYS_read]       = read_handler;
-    _syscallTable[SYS_rename]     = rename_handler;
-    _syscallTable[SYS_stat]       = lstat_handler;
-    _syscallTable[SYS_statx]      = statx_handler;
-    _syscallTable[SYS_unlink]     = unlink_handler;
-    _syscallTable[SYS_unlinkat]   = unlinkat_handler;
-    _syscallTable[SYS_write]      = write_handler;
-    _syscallTable[SYS_writev]     = writev_handler;
-    _syscallTable[SYS_rmdir]      = rmdir_handler;
+#endif
+#ifdef SYS_openat
+    _syscallTable[SYS_openat] = openat_handler;
+#endif
+#ifdef SYS_read
+    _syscallTable[SYS_read] = read_handler;
+#endif
+#ifdef SYS_rename
+    _syscallTable[SYS_rename] = rename_handler;
+#endif
+#ifdef SYS_stat
+    _syscallTable[SYS_stat] = lstat_handler;
+#endif
+#ifdef SYS_statx
+    _syscallTable[SYS_statx] = statx_handler;
+#endif
+#ifdef SYS_unlink
+    _syscallTable[SYS_unlink] = unlink_handler;
+#endif
+#ifdef SYS_unlinkat
+    _syscallTable[SYS_unlinkat] = unlinkat_handler;
+#endif
+#ifdef SYS_write
+    _syscallTable[SYS_write] = write_handler;
+#endif
+#ifdef SYS_writev
+    _syscallTable[SYS_writev] = writev_handler;
+#endif
+#ifdef SYS_rmdir
+    _syscallTable[SYS_rmdir] = rmdir_handler;
+#endif
 
     return _syscallTable;
 }

--- a/src/posix/utils/functions.hpp
+++ b/src/posix/utils/functions.hpp
@@ -3,14 +3,13 @@
 #ifndef CAPIO_FUNCTIONS_H
 #define CAPIO_FUNCTIONS_H
 
-int posix_return_value(long res, long* result){
+int posix_return_value(long res, long *result) {
     if (res != -2) {
         *result = (res < 0 ? -errno : res);
-        return 0;
+        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
-    return 1;
+    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
 }
-
 
 inline off64_t round(off64_t bytes, bool is_getdents64) {
     off64_t res = 0;

--- a/src/posix/utils/functions.hpp
+++ b/src/posix/utils/functions.hpp
@@ -4,11 +4,23 @@
 #define CAPIO_FUNCTIONS_H
 
 int posix_return_value(long res, long *result) {
+    START_LOG(capio_syscall(SYS_gettid), "cal(res=%ld)", res);
     if (res != -2) {
         *result = (res < 0 ? -errno : res);
+        LOG("SYSCALL handled by capio. errno is: %s", res < 0 ? strerror(-errno) : "none");
         return POSIX_SYSCALL_HANDLED_BY_CAPIO;
     }
+    LOG("SYSCALL delegated to the kernel");
     return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+}
+
+inline std::string absolute(const std::string &path) {
+    return is_absolute(&path) ? path : *capio_posix_realpath(&path);
+}
+
+std::string get_capio_parent_dir(const std::string &path) {
+    auto pos = path.rfind('/');
+    return path.substr(0, pos);
 }
 
 inline off64_t round(off64_t bytes, bool is_getdents64) {

--- a/src/posix/utils/functions.hpp
+++ b/src/posix/utils/functions.hpp
@@ -1,0 +1,26 @@
+#include <cerrno>
+
+#ifndef CAPIO_FUNCTIONS_H
+#define CAPIO_FUNCTIONS_H
+
+int posix_return_value(long res, long* result){
+    if (res != -2) {
+        *result = (res < 0 ? -errno : res);
+        return 0;
+    }
+    return 1;
+}
+
+
+inline off64_t round(off64_t bytes, bool is_getdents64) {
+    off64_t res = 0;
+    off64_t ld_size;
+    ld_size = THEORETICAL_SIZE_DIRENT64;
+
+    while (res + ld_size <= bytes) {
+        res += ld_size;
+    }
+    return res;
+}
+
+#endif // CAPIO_FUNCTIONS_H

--- a/src/posix/utils/functions.hpp
+++ b/src/posix/utils/functions.hpp
@@ -5,13 +5,13 @@
 
 int posix_return_value(long res, long *result) {
     START_LOG(capio_syscall(SYS_gettid), "cal(res=%ld)", res);
-    if (res != -2) {
+    if (res != POSIX_SYSCALL_REQUEST_SKIP) {
         *result = (res < 0 ? -errno : res);
         LOG("SYSCALL handled by capio. errno is: %s", res < 0 ? strerror(-errno) : "none");
-        return POSIX_SYSCALL_HANDLED_BY_CAPIO;
+        return POSIX_SYSCALL_SUCCESS;
     }
     LOG("SYSCALL delegated to the kernel");
-    return POSIX_SYSCALL_TO_HANDLE_BY_KERNEL;
+    return POSIX_SYSCALL_SKIP;
 }
 
 inline std::string absolute(const std::string &path) {


### PR DESCRIPTION
This pr address the following issued:
- Only handlers for available syscall in target kernel shall be added to syscall table
- Removed replicated code in capio syscall handler for setting errors codes and return values
- Removed magic numbers around capio posix handlers, by replacing them with some hopefully clear constants values
- Posix handlers now contains only handlers. accessories functions have been moved in dedicated file