### PR TITLE
Added option for logger to have a different logfile for each different thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ cmake-build-*
 #logfies and capio files
 *.log
 files_location*.txt
+capio_logs
 
 # Other
 debug

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -83,6 +83,7 @@ docker compose -p example exec        \
   --index 1                           \
   --env CAPIO_DIR=/tmp/capio          \
   --env LD_PRELOAD=libcapio_posix.so  \
+  --workdir /home/capio/server        \
   --user capio                        \
   capio                               \
   touch /tmp/capio/test_file.txt
@@ -95,6 +96,7 @@ docker compose -p example exec        \
   --index 2                           \
   --env CAPIO_DIR=/tmp/capio          \
   --env LD_PRELOAD=libcapio_posix.so  \
+  --workdir /home/capio/server        \
   --user capio                        \
   capio                               \
   ls -la /tmp/capio/test_file.txt

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -95,8 +95,8 @@ constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING[] =
     "|==================================================================|\n";
 constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE[] =
     "CAPIO_LOG set but log support was not compiled into CAPIO!";
-constexpr char CAPIO_LOG_SERVER_REQUEST_START[] = "\n+++++++++++ [%ld] REQUEST +++++++++++";
-constexpr char CAPIO_LOG_SERVER_REQUEST_END[]   = "~~~~~~~~~ [%ld] END REQUEST ~~~~~~~~~\n";
+constexpr char CAPIO_LOG_SERVER_REQUEST_START[] = "\n+++++++++++ REQUEST +++++++++++";
+constexpr char CAPIO_LOG_SERVER_REQUEST_END[]   = "~~~~~~~~~ END REQUEST ~~~~~~~~~\n";
 
 // CAPIO server argument parser
 constexpr char CAPIO_SERVER_ARG_PARSER_PRE[] =

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -21,26 +21,24 @@ constexpr int CAPIO_SEM_MAX_RETRIES          = 100;
 constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC = 10e5;
 
 // CAPIO communication constants
-constexpr int CAPIO_DATA_BUFFER_LENGTH                = 10;
-constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE          = 256 * 1024;
-constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE        = sizeof(char) * (PATH_MAX + 81920);
-constexpr size_t CAPIO_REQUEST_MAX_SIZE               = 256 * sizeof(char);
-constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_PREFIX[] = "server_thread_\0";
-constexpr char CAPIO_SERVER_DEFAULT_LOG_FOLDER[]      = "capio_logs\0";
-constexpr char CAPIO_APP_LOG_FILE_NAME[]              = "/dev/stderr\0";
-constexpr char LOG_PRE_MSG[]                          = "tid[%ld]-at[%s]: ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]          = "[ \033[1;32m SERVER \033[0m ] ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[]  = "[ \033[1;33m SERVER \033[0m ] ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]    = "[ \033[1;31m SERVER \033[0m ] ";
-constexpr char LOG_CAPIO_START_REQUEST[]              = "\n+++++++++++ SYSCALL %s (%d) +++++++++++";
-constexpr char LOG_CAPIO_END_REQUEST[]                = "----------- END SYSCALL ----------\n";
-constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[]   = "+++++++++++++++++REQUEST+++++++++++++++++";
-constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]     = "~~~~~~~~~~~~~~~END REQUEST~~~~~~~~~~~~~~~";
-constexpr int N_ELEMS_DATA_BUFS                       = 10;
-constexpr int WINDOW_DATA_BUFS                        = 256 * 1024;
-constexpr int CAPIO_LOG_MAX_MSG_LEN                   = 2048;
-constexpr int CAPIO_SEM_RETRIES                       = 100;
-constexpr int THEORETICAL_SIZE_DIRENT64               = sizeof(ino64_t) + sizeof(off64_t) +
+constexpr int CAPIO_DATA_BUFFER_LENGTH               = 10;
+constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE         = 256 * 1024;
+constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE       = sizeof(char) * (PATH_MAX + 81920);
+constexpr size_t CAPIO_REQUEST_MAX_SIZE              = 256 * sizeof(char);
+constexpr char CAPIO_APP_LOG_FILE_NAME[]             = "/dev/stderr\0";
+constexpr char LOG_PRE_MSG[]                         = "tid[%ld]-at[%s]: ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]         = "[ \033[1;32m SERVER \033[0m ] ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
+constexpr char LOG_CAPIO_START_REQUEST[]             = "\n+++++++++++ SYSCALL %s (%d) +++++++++++";
+constexpr char LOG_CAPIO_END_REQUEST[]               = "----------- END SYSCALL ----------\n";
+constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[]  = "+++++++++++++++++REQUEST+++++++++++++++++";
+constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]    = "~~~~~~~~~~~~~~~END REQUEST~~~~~~~~~~~~~~~";
+constexpr int N_ELEMS_DATA_BUFS                      = 10;
+constexpr int WINDOW_DATA_BUFS                       = 256 * 1024;
+constexpr int CAPIO_LOG_MAX_MSG_LEN                  = 2048;
+constexpr int CAPIO_SEM_RETRIES                      = 100;
+constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(off64_t) +
                                           sizeof(unsigned short) + sizeof(unsigned char) +
                                           sizeof(char) * NAME_MAX;
 
@@ -57,14 +55,16 @@ constexpr int CAPIO_POSIX_SYSCALL_SKIP         = 1;
 constexpr int CAPIO_POSIX_SYSCALL_SUCCESS      = 0;
 
 // CAPIO logger - common
-constexpr char CAPIO_LOG_PRE_MSG[] = "at[%s]: ";
+constexpr char CAPIO_LOG_PRE_MSG[]        = "at[%s]: ";
+constexpr char CAPIO_DEFAULT_LOG_FOLDER[] = "capio_logs\0";
 
 // CAPIO logger - POSIX
-constexpr char CAPIO_LOG_POSIX_DEFAULT_FILE_NAME[] = "/dev/stderr\0";
-constexpr char CAPIO_LOG_POSIX_SYSCALL_START[]     = "\n+++++++++ [%ld] SYSCALL %s (%d) +++++++++";
-constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]       = "--------- [%ld] END SYSCALL --------\n";
+constexpr char CAPIO_LOG_POSIX_DEFAULT_LOG_FILE_PREFIX[] = "posix_threas_\0";
+constexpr char CAPIO_LOG_POSIX_SYSCALL_START[]       = "\n+++++++++ SYSCALL %s (%d) +++++++++";
+constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]         = "---------  END SYSCALL --------\n";
 
 // CAPIO logger - server
+constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_PREFIX[] = "server_thread_\0";
 constexpr char CAPIO_LOG_SERVER_BANNER[] =
     "\n\n "
     "\033[1;34m /$$$$$$   /$$$$$$  /$$$$$$$\033[0;96m  /$$$$$$  /$$$$$$ \n"

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -57,7 +57,7 @@ constexpr int CAPIO_POSIX_SYSCALL_SKIP         = 1;
 constexpr int CAPIO_POSIX_SYSCALL_SUCCESS      = 0;
 
 // CAPIO logger - common
-constexpr char CAPIO_LOG_PRE_MSG[] = "tid[%ld]-at[%s]: ";
+constexpr char CAPIO_LOG_PRE_MSG[] = "at[%s]: ";
 
 // CAPIO logger - POSIX
 constexpr char CAPIO_LOG_POSIX_DEFAULT_FILE_NAME[] = "/dev/stderr\0";

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -58,8 +58,8 @@ constexpr char CAPIO_DEFAULT_LOG_FOLDER[] = "capio_logs\0";
 
 // CAPIO logger - POSIX
 constexpr char CAPIO_LOG_POSIX_DEFAULT_LOG_FILE_PREFIX[] = "posix_thread_\0";
-constexpr char CAPIO_LOG_POSIX_SYSCALL_START[]       = "\n+++++++++ SYSCALL %s (%d) +++++++++";
-constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]         = "---------  END SYSCALL --------\n";
+constexpr char CAPIO_LOG_POSIX_SYSCALL_START[]           = "\n+++++++++ SYSCALL %s (%d) +++++++++";
+constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]             = "---------  END SYSCALL --------\n";
 
 // CAPIO logger - server
 constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_PREFIX[] = "server_thread_\0";

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -21,10 +21,28 @@ constexpr int CAPIO_SEM_MAX_RETRIES          = 100;
 constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC = 10e5;
 
 // CAPIO communication constants
-constexpr int CAPIO_DATA_BUFFER_LENGTH         = 10;
-constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE   = 256 * 1024;
-constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE = sizeof(char) * (PATH_MAX + 81920);
-constexpr size_t CAPIO_REQUEST_MAX_SIZE        = 256 * sizeof(char);
+constexpr int CAPIO_DATA_BUFFER_LENGTH               = 10;
+constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE         = 256 * 1024;
+constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE       = sizeof(char) * (PATH_MAX + 81920);
+constexpr size_t CAPIO_REQUEST_MAX_SIZE              = 256 * sizeof(char);
+constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_NAME[]  = "server_thread_\0";
+constexpr char CAPIO_SERVER_DEFAULT_LOG_FOLDER[]     = "capio_logs\0";
+constexpr char CAPIO_APP_LOG_FILE_NAME[]             = "/dev/stderr\0";
+constexpr char LOG_PRE_MSG[]                         = "tid[%ld]-at[%s]: ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]         = "[ \033[1;32m SERVER \033[0m ] ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
+constexpr char LOG_CAPIO_START_REQUEST[]             = "\n+++++++++++ SYSCALL %s (%d) +++++++++++";
+constexpr char LOG_CAPIO_END_REQUEST[]               = "----------- END SYSCALL ----------\n";
+constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[]  = "+++++++++++++++++REQUEST+++++++++++++++++";
+constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]    = "~~~~~~~~~~~~~~~END REQUEST~~~~~~~~~~~~~~~";
+constexpr int N_ELEMS_DATA_BUFS                      = 10;
+constexpr int WINDOW_DATA_BUFS                       = 256 * 1024;
+constexpr int CAPIO_LOG_MAX_MSG_LEN                  = 2048;
+constexpr int CAPIO_SEM_RETRIES                      = 100;
+constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(off64_t) +
+                                          sizeof(unsigned short) + sizeof(unsigned char) +
+                                          sizeof(char) * NAME_MAX;
 
 // CAPIO streaming semantics
 constexpr char CAPIO_FILE_MODE_NO_UPDATE[]      = "no_update";
@@ -39,8 +57,7 @@ constexpr int CAPIO_POSIX_SYSCALL_SKIP         = 1;
 constexpr int CAPIO_POSIX_SYSCALL_SUCCESS      = 0;
 
 // CAPIO logger - common
-constexpr int CAPIO_LOG_MAX_MSG_LEN = 2048;
-constexpr char CAPIO_LOG_PRE_MSG[]  = "tid[%ld]-at[%s]: ";
+constexpr char CAPIO_LOG_PRE_MSG[] = "tid[%ld]-at[%s]: ";
 
 // CAPIO logger - POSIX
 constexpr char CAPIO_LOG_POSIX_DEFAULT_FILE_NAME[] = "/dev/stderr\0";

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -21,26 +21,26 @@ constexpr int CAPIO_SEM_MAX_RETRIES          = 100;
 constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC = 10e5;
 
 // CAPIO communication constants
-constexpr int CAPIO_DATA_BUFFER_LENGTH               = 10;
-constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE         = 256 * 1024;
-constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE       = sizeof(char) * (PATH_MAX + 81920);
-constexpr size_t CAPIO_REQUEST_MAX_SIZE              = 256 * sizeof(char);
-constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_NAME[]  = "server_thread_\0";
-constexpr char CAPIO_SERVER_DEFAULT_LOG_FOLDER[]     = "capio_logs\0";
-constexpr char CAPIO_APP_LOG_FILE_NAME[]             = "/dev/stderr\0";
-constexpr char LOG_PRE_MSG[]                         = "tid[%ld]-at[%s]: ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]         = "[ \033[1;32m SERVER \033[0m ] ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
-constexpr char LOG_CAPIO_START_REQUEST[]             = "\n+++++++++++ SYSCALL %s (%d) +++++++++++";
-constexpr char LOG_CAPIO_END_REQUEST[]               = "----------- END SYSCALL ----------\n";
-constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[]  = "+++++++++++++++++REQUEST+++++++++++++++++";
-constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]    = "~~~~~~~~~~~~~~~END REQUEST~~~~~~~~~~~~~~~";
-constexpr int N_ELEMS_DATA_BUFS                      = 10;
-constexpr int WINDOW_DATA_BUFS                       = 256 * 1024;
-constexpr int CAPIO_LOG_MAX_MSG_LEN                  = 2048;
-constexpr int CAPIO_SEM_RETRIES                      = 100;
-constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(off64_t) +
+constexpr int CAPIO_DATA_BUFFER_LENGTH                = 10;
+constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE          = 256 * 1024;
+constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE        = sizeof(char) * (PATH_MAX + 81920);
+constexpr size_t CAPIO_REQUEST_MAX_SIZE               = 256 * sizeof(char);
+constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_PREFIX[] = "server_thread_\0";
+constexpr char CAPIO_SERVER_DEFAULT_LOG_FOLDER[]      = "capio_logs\0";
+constexpr char CAPIO_APP_LOG_FILE_NAME[]              = "/dev/stderr\0";
+constexpr char LOG_PRE_MSG[]                          = "tid[%ld]-at[%s]: ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]          = "[ \033[1;32m SERVER \033[0m ] ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[]  = "[ \033[1;33m SERVER \033[0m ] ";
+constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]    = "[ \033[1;31m SERVER \033[0m ] ";
+constexpr char LOG_CAPIO_START_REQUEST[]              = "\n+++++++++++ SYSCALL %s (%d) +++++++++++";
+constexpr char LOG_CAPIO_END_REQUEST[]                = "----------- END SYSCALL ----------\n";
+constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[]   = "+++++++++++++++++REQUEST+++++++++++++++++";
+constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]     = "~~~~~~~~~~~~~~~END REQUEST~~~~~~~~~~~~~~~";
+constexpr int N_ELEMS_DATA_BUFS                       = 10;
+constexpr int WINDOW_DATA_BUFS                        = 256 * 1024;
+constexpr int CAPIO_LOG_MAX_MSG_LEN                   = 2048;
+constexpr int CAPIO_SEM_RETRIES                       = 100;
+constexpr int THEORETICAL_SIZE_DIRENT64               = sizeof(ino64_t) + sizeof(off64_t) +
                                           sizeof(unsigned short) + sizeof(unsigned char) +
                                           sizeof(char) * NAME_MAX;
 
@@ -97,9 +97,8 @@ constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING[] =
     "|==================================================================|\n";
 constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE[] =
     "CAPIO_LOG set but log support was not compiled into CAPIO!";
-constexpr char CAPIO_LOG_SERVER_DEFAULT_FILE_NAME[] = "server_rank_\0";
-constexpr char CAPIO_LOG_SERVER_REQUEST_START[]     = "\n+++++++++++ [%ld] REQUEST +++++++++++";
-constexpr char CAPIO_LOG_SERVER_REQUEST_END[]       = "~~~~~~~~~ [%ld] END REQUEST ~~~~~~~~~\n";
+constexpr char CAPIO_LOG_SERVER_REQUEST_START[] = "\n+++++++++++ [%ld] REQUEST +++++++++++";
+constexpr char CAPIO_LOG_SERVER_REQUEST_END[]   = "~~~~~~~~~ [%ld] END REQUEST ~~~~~~~~~\n";
 
 // CAPIO server argument parser
 constexpr char CAPIO_SERVER_ARG_PARSER_PRE[] =
@@ -111,6 +110,8 @@ constexpr char CAPIO_SERVER_ARG_PARSER_EPILOGUE[] =
     " and a guide on config JSON file structure, please visit "
     "https://github.com/High-Performance-IO/capio";
 constexpr char CAPIO_SERVER_ARG_PARSER_PRE_COMMAND[] = "{ENVIRONMENT_VARS}  mpirun -n 1";
+constexpr char CAPIO_SERVER_ARG_PARSER_LOGILE_DIR_OPT_HELP[] =
+    "Name of the folder to which capio server will put log files into";
 constexpr char CAPIO_SERVER_ARG_PARSER_LOGILE_OPT_HELP[] =
     "Filename to which capio_server will log to, without extension";
 constexpr char CAPIO_SERVER_ARG_PARSER_CONFIG_OPT_HELP[] =

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -25,8 +25,6 @@ constexpr int CAPIO_DATA_BUFFER_LENGTH               = 10;
 constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE         = 256 * 1024;
 constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE       = sizeof(char) * (PATH_MAX + 81920);
 constexpr size_t CAPIO_REQUEST_MAX_SIZE              = 256 * sizeof(char);
-constexpr char CAPIO_APP_LOG_FILE_NAME[]             = "/dev/stderr\0";
-constexpr char LOG_PRE_MSG[]                         = "tid[%ld]-at[%s]: ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]         = "[ \033[1;32m SERVER \033[0m ] ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
@@ -59,7 +57,7 @@ constexpr char CAPIO_LOG_PRE_MSG[]        = "at[%s]: ";
 constexpr char CAPIO_DEFAULT_LOG_FOLDER[] = "capio_logs\0";
 
 // CAPIO logger - POSIX
-constexpr char CAPIO_LOG_POSIX_DEFAULT_LOG_FILE_PREFIX[] = "posix_threas_\0";
+constexpr char CAPIO_LOG_POSIX_DEFAULT_LOG_FILE_PREFIX[] = "posix_thread_\0";
 constexpr char CAPIO_LOG_POSIX_SYSCALL_START[]       = "\n+++++++++ SYSCALL %s (%d) +++++++++";
 constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]         = "---------  END SYSCALL --------\n";
 

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -124,7 +124,7 @@ class Logger {
 
         va_list argp, argpc;
 
-        sprintf(format, CAPIO_LOG_PRE_MSG, capio_syscall(SYS_gettid), this->invoker);
+        sprintf(format, CAPIO_LOG_PRE_MSG, this->invoker);
         size_t pre_msg_len = strlen(format);
 
         strcpy(format + pre_msg_len, message);
@@ -160,7 +160,7 @@ class Logger {
     inline void log(const char *message, ...) {
         va_list argp, argpc;
 
-        sprintf(format, CAPIO_LOG_PRE_MSG, capio_syscall(SYS_gettid), this->invoker);
+        sprintf(format, CAPIO_LOG_PRE_MSG, this->invoker);
         size_t pre_msg_len = strlen(format);
 
         strcpy(format + pre_msg_len, message);
@@ -196,7 +196,7 @@ class Logger {
 
     inline ~Logger() {
         current_log_level--;
-        sprintf(format, CAPIO_LOG_PRE_MSG, capio_syscall(SYS_gettid), this->invoker);
+        sprintf(format, CAPIO_LOG_PRE_MSG, this->invoker);
         size_t pre_msg_len = strlen(format);
         strcpy(format + pre_msg_len, "returned");
 

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -17,7 +17,7 @@
 #endif
 
 #ifndef __CAPIO_POSIX
-std::ofstream logfile; // if building for server, self contained logfile
+thread_local std::ofstream logfile; // if building for server, self contained logfile
 #else
 FILE *logfileFP;
 bool logfileOpen = false;

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -280,11 +280,7 @@ class Logger {
         if (strcmp(invoker, "capio_server") == 0 &&
             (strcmp(CAPIO_LOG_SERVER_REQUEST_START, message) == 0 ||
              strcmp(CAPIO_LOG_SERVER_REQUEST_END, message) == 0)) {
-            auto buf1 = reinterpret_cast<char *>(capio_syscall(
-                SYS_mmap, nullptr, 50, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-            sprintf(buf1, message, capio_syscall(SYS_gettid));
-            logfile << buf1 << std::endl;
-            capio_syscall(SYS_munmap, buf1, 50);
+            logfile << message << std::endl;
             return;
         }
 #endif

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -13,6 +13,69 @@
 #include "constants.hpp"
 #include "syscall.hpp"
 
+#ifdef __CAPIO_POSIX
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* recursive mkdir from https://gist.github.com/ChisholmKyle/0cbedcd3e64132243a39 */
+int mkdir_p(const char *dir, const mode_t mode) {
+    char tmp[PATH_MAX];
+    char *p = nullptr;
+    struct stat sb;
+    size_t len;
+
+    /* copy path */
+    len = strnlen(dir, PATH_MAX);
+    if (len == 0 || len == PATH_MAX) {
+        return -1;
+    }
+    memcpy(tmp, dir, len);
+    tmp[len] = '\0';
+
+    /* remove trailing slash */
+    if (tmp[len - 1] == '/') {
+        tmp[len - 1] = '\0';
+    }
+
+    /* check if path exists and is a directory */
+    if (capio_syscall(SYS_stat, tmp, &sb) == 0) {
+        if (S_ISDIR(sb.st_mode)) {
+            return 0;
+        }
+    }
+
+    /* recursive mkdir */
+    for (p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = 0;
+            /* test path */
+            if (capio_syscall(SYS_stat, tmp, &sb) != 0) {
+                /* path does not exist - create directory */
+                if (capio_syscall(SYS_mkdir, tmp, mode) < 0) {
+                    return -1;
+                }
+            } else if (!S_ISDIR(sb.st_mode)) {
+                /* not a directory */
+                return -1;
+            }
+            *p = '/';
+        }
+    }
+    /* test path */
+    if (capio_syscall(SYS_stat, tmp, &sb) != 0) {
+        /* path does not exist - create directory */
+        if (capio_syscall(SYS_mkdir, tmp, mode) < 0) {
+            return -1;
+        }
+    } else if (!S_ISDIR(sb.st_mode)) {
+        /* not a directory */
+        return -1;
+    }
+    return 0;
+}
+#endif
+
 #if defined(CAPIOLOG) && defined(__CAPIO_POSIX)
 #include "syscallnames.h"
 #endif
@@ -142,28 +205,25 @@ class Logger {
 #else
         if (!logfileOpen) {
             setup_posix_log_filenames();
-            //create recursively all capio directory structure
-            char tmp[256];
-            char *p = nullptr;
-            size_t len;
-            snprintf(tmp, sizeof(tmp), "%s", posix_log_dir_path);
-            len = strlen(tmp);
-            if (tmp[len - 1] == '/') {
-                tmp[len - 1] = 0;
+            if (mkdir_p(posix_log_dir_path, 0777) == -1) {
+                capio_syscall(SYS_write, fileno(stdout),
+                              "Err mkdir file: ", strlen("Err mkdir file: "));
+                capio_syscall(SYS_write, fileno(stdout), posix_log_dir_path,
+                              strlen(posix_log_dir_path));
+                capio_syscall(SYS_write, fileno(stdout), "\n", 1);
+                exit(EXIT_FAILURE);
             }
-            for (p = tmp + 1; *p; p++) {
-                if (*p == '/') {
-                    *p = 0;
-                    capio_syscall(SYS_mkdir, tmp, 0777);
-                    *p = '/';
-                }
-            }
-            capio_syscall(SYS_mkdir, tmp, 0777);
 
             logfileFP = fopen(logfile_path, "w");
 
             if (logfileFP == nullptr) {
-                capio_syscall(SYS_write, fileno(stdout), "Err fopen\0", strlen("Err fopen\0"));
+                capio_syscall(SYS_write, fileno(stdout),
+                              "Err fopen file: ", strlen("Err fopen file: "));
+                capio_syscall(SYS_write, fileno(stdout), logfile_path, strlen(logfile_path));
+                capio_syscall(SYS_write, fileno(stdout), " ", 1);
+                capio_syscall(SYS_write, fileno(stdout), strerror(errno), strlen(strerror(errno)));
+                capio_syscall(SYS_write, fileno(stdout), "\n", 1);
+                exit(EXIT_FAILURE);
             } else {
                 logfileOpen = true;
             }

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -204,12 +204,10 @@ int parseCLI(int argc, char **argv, int rank) {
     } else {
 #ifdef CAPIOLOG
         // log file not given. starting with default name
-        const std::string logname =
-            CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::to_string(rank) + ".log";
-        logfile.open(logname, std::ofstream::out);
-        log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to default logfile "
-                  << logname << std::endl;
+        auto logname = open_server_logfile();
+        log          = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
+        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "started logging to default logfile " << logname
+                  << std::endl;
 #endif
     }
 


### PR DESCRIPTION
Logs are now controlled by the following environment variables:
- `CAPIO_LOGDIR` which tells the name of the msater directory cotaining all log files (defaults to capio_log)
- `CAPIO_LOGFILE` which tells the prefix name of log files (defaults to server_thread_%d for server and posix_thread_%d for capio applications). 
Logs are also separated in two directories: `server` and `posix`, and inside them logfiles are grouped into directories called like the hostname of the machine on which they have been generated

Example for docker was also fixed to include correct workdir to ensure capio logs can be created correctly 