### PR TITLE
Skip clone when `child_tid` is negative

### DIFF
--- a/src/posix/utils/clone.hpp
+++ b/src/posix/utils/clone.hpp
@@ -48,6 +48,11 @@ void hook_clone_parent(long child_tid) {
     long parent_tid = syscall_no_intercept(SYS_gettid);
     START_LOG(parent_tid, "call(parent_tid=%d, child_tid=%ld)", parent_tid, child_tid);
 
+    if (child_tid < 0) {
+        LOG("Skipping clone as child tid is set to %d: %s", child_tid, std::strerror(child_tid));
+        return;
+    }
+
     LOG("Initializing child thread %d", child_tid);
     init_process(child_tid);
     clone_request(parent_tid, child_tid);


### PR DESCRIPTION
In some cases the `clone` and `clone3` system calls can return an error code such as `ENOSYS` or `EPERM`. The `syscall_intercept` library is not smart enough to figure out these cases alone, and still runs the clone intercept hooks. Now the `hook_clone_parent` explicitly checks for negative `child_tid` values and just logs the reported error, without processing the clone any further.