### PR TITLE
Add Dockerfile to build Docker images

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -17,6 +17,40 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Run codespell"
         uses: codespell-project/actions-codespell@v2
+  docker-check:
+    name: "Check Docker image"
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        cmake-build-type:
+          - "Debug"
+          - "Release"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: "Build Docker image"
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            CAPIO_BUILD_TESTS=${{ matrix.cmake-build-type == 'Debug' && 'ON' || 'OFF' }}
+            CAPIO_LOG=${{ matrix.cmake-build-type == 'Debug' && 'ON' || 'OFF' }}
+            CMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }}
+          load: true
+          tags: hpio/capio:latest
+      - name: "Run test with Docker"
+        run: |
+          docker run --detach --rm              \
+            --env CAPIO_DIR=/tmp                \
+            --env CAPIO_LOG_LEVEL=-1            \
+            --name capio-docker                 \
+            hpio/capio:latest                   \
+            capio_server --no-config
+          docker exec                           \
+            --env LD_PRELOAD=libcapio_posix.so  \
+            capio-docker                        \
+            sh -c "mkdir /tmp/test && touch /tmp/test/file1 && ls /tmp/test && rm -rf /tmp/test"
+          docker stop capio-docker
   format-check:
     name: "Check ${{ matrix.path }} clang-format conformance"
     runs-on: ubuntu-22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+FROM debian:bookworm AS builder
+
+ARG CAPIO_BUILD_TESTS=OFF
+ARG CAPIO_LOG=OFF
+ARG CMAKE_BUILD_TYPE=Release
+
+RUN apt update                              \
+ && apt install -y --no-install-recommends  \
+        build-essential                     \
+        ca-certificates                     \
+        cmake                               \
+        git                                 \
+        libcapstone-dev                     \
+        libopenmpi-dev                      \
+        ninja-build                         \
+        openmpi-bin                         \
+        pkg-config
+
+COPY CMakeLists.txt /opt/capio/
+COPY scripts /opt/capio/scripts
+COPY src /opt/capio/src
+COPY tests /opt/capio/tests
+
+RUN mkdir -p /opt/capio/build                     \
+ && cmake                                         \
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}    \
+        -DCAPIO_BUILD_TESTS=${CAPIO_BUILD_TESTS}  \
+        -DCAPIO_LOG=${CAPIO_LOG}                  \
+        -G Ninja                                  \
+        -B /opt/capio/build                       \
+        -S /opt/capio                             \
+ && cmake --build /opt/capio/build -j$(nproc)     \
+ && cmake --install /opt/capio/build --prefix /usr/local
+
+
+FROM debian:bookworm
+
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+
+RUN apt update                              \
+ && apt install -y --no-install-recommends  \
+        libcapstone4                        \
+        openmpi-bin                         \
+ && rm -rf /var/lib/apt/lists/*
+
+# Include files
+COPY --from=builder                                         \
+    /usr/local/include/libsyscall_intercept_hook_point.h    \
+    /usr/local/include/simdjson.h                           \
+    /usr/local/include/
+
+# Libraries
+COPY --from=builder                                         \
+    /usr/local/lib/libcapio_posix.so                        \
+    /usr/local/lib/libcapio_posix.so.0                      \
+    /usr/local/lib/libcapio_posix.so.0.0.1                  \
+    /usr/local/lib/libsimdjson.a                            \
+    /usr/local/lib/libsyscall_intercept.a                   \
+    /usr/local/lib/libsyscall_intercept.so                  \
+    /usr/local/lib/libsyscall_intercept.so.0                \
+    /usr/local/lib/libsyscall_intercept.so.0.1.0            \
+    /usr/local/lib/
+
+# Binaries
+COPY --from=builder                                         \
+    /usr/local/bin/capio_server                             \
+    /usr/local/bin/
+
+# Pkgconfig
+COPY --from=builder                                         \
+    /usr/local/lib/pkgconfig/args.pc                        \
+    /usr/local/lib/pkgconfig/libsyscall_intercept.pc        \
+    /usr/local/lib/pkgconfig/simdjson.pc                    \
+    /usr/local/lib/pkgconfig/
+
+# CMake files
+COPY --from=builder                                         \
+    /usr/local/lib/cmake/simdjson/                          \
+    /usr/local/lib/cmake/


### PR DESCRIPTION
This commit adds support for Docker by introducing a Dockerfile in the repository.

This commit also adds a no regression test that ensures the Docker image builds correctly with both `Debug` and `Release` CMake build types.