### PR TITLE
Use `<filesystem>` standard library where possible

### DIFF
--- a/src/common/capio/circular_buffer.hpp
+++ b/src/common/capio/circular_buffer.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_COMMON_CIRCULAR_BUFFER_HPP
 #define CAPIO_COMMON_CIRCULAR_BUFFER_HPP
 
+#include <iostream>
+
 #include <semaphore.h>
 
 #include "capio/logger.hpp"

--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -12,12 +12,12 @@
 #include "logger.hpp"
 #include "syscall.hpp"
 
-const std::string *get_capio_dir() {
-    static std::string *capio_dir = nullptr;
+const std::filesystem::path &get_capio_dir() {
+    static std::filesystem::path capio_dir{};
     START_LOG(capio_syscall(SYS_gettid), "call()");
     // TODO: if CAPIO_DIR is not set, it should be left as null
 
-    if (capio_dir == nullptr) {
+    if (capio_dir.empty()) {
         const char *val = std::getenv("CAPIO_DIR");
         auto buf        = std::unique_ptr<char[]>(new char[PATH_MAX]);
 
@@ -41,9 +41,9 @@ const std::string *get_capio_dir() {
                          val, buf.get());
             }
         }
-        capio_dir = new std::string(buf.get());
+        capio_dir = std::filesystem::path(buf.get());
     }
-    LOG("CAPIO=DIR=%s", capio_dir->c_str());
+    LOG("CAPIO=DIR=%s", capio_dir.c_str());
 
     return capio_dir;
 }

--- a/src/common/capio/filesystem.hpp
+++ b/src/common/capio/filesystem.hpp
@@ -13,34 +13,21 @@
 #include "logger.hpp"
 #include "syscall.hpp"
 
-std::string get_parent_dir_path(const std::string &file_path) {
-    START_LOG(capio_syscall(SYS_gettid), "call(file-Path=%s)", file_path.c_str());
-    std::size_t i = file_path.rfind('/');
-    if (i == std::string::npos) {
+std::filesystem::path get_parent_dir_path(const std::filesystem::path &file_path) {
+    START_LOG(capio_syscall(SYS_gettid), "call(file_path=%s)", file_path.c_str());
+    if (file_path == file_path.root_path()) {
+        return file_path;
+    }
+    const size_t pos = file_path.native().rfind('/');
+    if (pos == std::string::npos) {
         LOG("invalid file_path in get_parent_dir_path");
     }
-    return file_path.substr(0, i);
+    return {file_path.native().substr(0, pos)};
 }
 
 inline bool in_dir(const std::string &path, const std::string &glob) {
-    size_t res = path.find('/', glob.length() - 1);
+    const size_t res = path.find('/', glob.length() - 1);
     return res != std::string::npos;
-}
-
-inline bool is_absolute(const std::string *pathname) {
-    return pathname != nullptr && (pathname->rfind("/", 0) == 0);
-}
-
-inline bool is_directory(const std::string &path) {
-    START_LOG(capio_syscall(SYS_gettid), "call(path=%s)", path.c_str());
-
-    struct stat statbuf {};
-    if (stat(path.c_str(), &statbuf) != 0) {
-        LOG("Error at is_directory(path=%d) -> %d: %d (%s)", path.c_str(), errno,
-            std::strerror(errno));
-        return -1;
-    }
-    return S_ISDIR(statbuf.st_mode) == 1;
 }
 
 inline bool is_directory(int dirfd) {
@@ -56,25 +43,24 @@ inline bool is_directory(int dirfd) {
     return S_ISDIR(path_stat.st_mode) == 1;
 }
 
-inline bool is_prefix(const std::string &path_1, const std::string &path_2) {
-    auto res = std::mismatch(path_1.begin(), path_1.end(), path_2.begin());
-    return res.first == path_2.end();
+inline bool is_prefix(const std::filesystem::path &path_1, const std::filesystem::path &path_2) {
+    const auto relpath = path_2.lexically_relative(path_1);
+    return !relpath.empty() && relpath.native().rfind("..", 0) != 0;
 }
 
-static inline bool is_capio_dir(const std::string &path_to_check) {
+static inline bool is_capio_dir(const std::filesystem::path &path_to_check) {
     START_LOG(capio_syscall(SYS_gettid), "call(path_to_check=%s)", path_to_check.c_str());
 
-    const std::filesystem::path capio_dir(*get_capio_dir());
-    auto res = capio_dir.compare(path_to_check) == 0;
+    const auto res = get_capio_dir().compare(path_to_check) == 0;
     LOG("is_capio_dir:%s", res ? "yes" : "no");
     return res;
 }
 
-static inline bool is_capio_path(const std::string &path_to_check) {
+static inline bool is_capio_path(const std::filesystem::path &path_to_check) {
     START_LOG(capio_syscall(SYS_gettid), "call(path_to_check=%s)", path_to_check.c_str());
 
     // check if path_to_check begins with CAPIO_DIR
-    auto res = path_to_check.find(*get_capio_dir()) == 0;
+    const auto res = is_prefix(get_capio_dir(), path_to_check);
     LOG("is_capio_path:%s", res ? "yes" : "no");
     return res;
 }

--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -1,13 +1,13 @@
 #ifndef CAPIO_POSIX_HANDLERS_ACCESS_HPP
 #define CAPIO_POSIX_HANDLERS_ACCESS_HPP
 
+#include "utils/common.hpp"
 #include "utils/filesystem.hpp"
-#include "utils/functions.hpp"
 
-inline off64_t capio_access(const std::string *pathname, mode_t mode, long tid) {
-    START_LOG(tid, "call(pathname=%s, mode=%o)", pathname->c_str(), mode);
+inline off64_t capio_access(const std::filesystem::path &pathname, mode_t mode, long tid) {
+    START_LOG(tid, "call(pathname=%s, mode=%o)", pathname.c_str(), mode);
 
-    const std::string abs_pathname = capio_posix_realpath(pathname);
+    const std::filesystem::path abs_pathname = capio_posix_realpath(pathname);
     if (abs_pathname.empty()) {
         errno = ENONET;
         return POSIX_SYSCALL_ERRNO;
@@ -18,12 +18,12 @@ inline off64_t capio_access(const std::string *pathname, mode_t mode, long tid) 
     }
 }
 
-inline off64_t capio_faccessat(int dirfd, const std::string *pathname, mode_t mode, int flags,
-                               long tid) {
-    START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o, flags=%X)", dirfd, pathname->c_str(), mode,
+inline off64_t capio_faccessat(int dirfd, const std::filesystem::path &pathname, mode_t mode,
+                               int flags, long tid) {
+    START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o, flags=%X)", dirfd, pathname.c_str(), mode,
               flags);
 
-    if (!is_absolute(pathname)) {
+    if (pathname.is_relative()) {
         if (dirfd == AT_FDCWD) {
             // pathname is interpreted relative to currdir
             return capio_access(pathname, mode, tid);
@@ -32,37 +32,37 @@ inline off64_t capio_faccessat(int dirfd, const std::string *pathname, mode_t mo
                 LOG("dirfd does not point to a directory");
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
-            std::string dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
-            std::string path = dir_path + "/" + *pathname;
+            const std::filesystem::path path = dir_path / pathname;
             return is_capio_path(path) ? access_request(path, tid) : -2;
         }
-    } else if (is_capio_path(*pathname)) {
-        return access_request(*pathname, tid);
+    } else if (is_capio_path(pathname)) {
+        return access_request(pathname, tid);
     } else {
         return POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
 int access_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::string pathname(reinterpret_cast<const char *>(arg0));
+    std::filesystem::path pathname(reinterpret_cast<const char *>(arg0));
     auto mode = static_cast<mode_t>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_access(&pathname, mode, tid), result);
+    return posix_return_value(capio_access(pathname, mode, tid), result);
 }
 
 int faccessat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                       long *result) {
     auto dirfd = static_cast<int>(arg0);
-    std::string pathname(reinterpret_cast<const char *>(arg1));
+    std::filesystem::path pathname(reinterpret_cast<const char *>(arg1));
     auto mode  = static_cast<mode_t>(arg2);
     auto flags = static_cast<int>(arg3);
     long tid   = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_faccessat(dirfd, &pathname, mode, flags, tid), result);
+    return posix_return_value(capio_faccessat(dirfd, pathname, mode, flags, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_ACCESS_HPP

--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -10,13 +10,13 @@
  */
 
 int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::string path(reinterpret_cast<const char *>(arg0));
+    std::filesystem::path path(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
     START_LOG(tid, "call(path=%s)", path.c_str());
 
-    if (!is_absolute(&path)) {
-        path = capio_posix_realpath(&path);
+    if (path.is_relative()) {
+        path = capio_posix_realpath(path);
         if (path.empty()) {
             *result = -errno;
             return POSIX_SYSCALL_SUCCESS;

--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -7,14 +7,15 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
 
     START_LOG(tid, "call(buf=0x%08x, size=%ld)", buf, size);
 
-    const std::string cwd(*get_current_dir());
+    const std::filesystem::path &cwd = get_current_dir();
+    const size_t length              = cwd.native().length();
 
-    if ((cwd.length() + 1) * sizeof(char) > size) {
+    if ((length + 1) * sizeof(char) > size) {
         *result = -ERANGE;
     } else {
         LOG("CWD: %s", cwd.c_str());
-        cwd.copy(buf, size);
-        buf[cwd.length()] = '\0';
+        cwd.native().copy(buf, size);
+        buf[length] = '\0';
     }
     return POSIX_SYSCALL_SUCCESS;
 }

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -1,8 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_GETDENTS_HPP
 #define CAPIO_POSIX_HANDLERS_GETDENTS_HPP
 
+#include "utils/common.hpp"
 #include "utils/data.hpp"
-#include "utils/functions.hpp"
 
 // TODO: too similar to capio_read, refactoring needed
 inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, bool is64bit) {

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -1,7 +1,7 @@
 #ifndef CAPIO_POSIX_HANDLERS_LSEEK_HPP
 #define CAPIO_POSIX_HANDLERS_LSEEK_HPP
 
-#include "utils/functions.hpp"
+#include "utils/common.hpp"
 
 // TODO: EOVERFLOW is not addressed
 inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -2,18 +2,17 @@
 #define CAPIO_POSIX_HANDLERS_OPENAT_HPP
 
 #include "lseek.hpp"
+
+#include "utils/common.hpp"
 #include "utils/filesystem.hpp"
-#include "utils/functions.hpp"
 
-inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
-    START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%X)", dirfd, pathname->c_str(), flags);
+inline int capio_openat(int dirfd, std::filesystem::path &pathname, int flags, long tid) {
+    START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%X)", dirfd, pathname.c_str(), flags);
 
-    std::string path_to_check(*pathname);
-
-    if (!is_absolute(pathname)) {
+    if (pathname.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            path_to_check = capio_posix_realpath(pathname);
-            if (path_to_check.empty()) {
+            pathname = capio_posix_realpath(pathname);
+            if (pathname.empty()) {
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
         } else {
@@ -21,24 +20,16 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
                 LOG("dirfd does not point to a directory");
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
-            std::string dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
 
-            if (pathname->substr(0, 2) == "./") {
-                path_to_check = dir_path + pathname->substr(1, pathname->length() - 1);
-            } else if (*pathname == ".") {
-                path_to_check = dir_path;
-            } else if (*pathname == "..") {
-                path_to_check = get_capio_parent_dir(dir_path);
-            } else {
-                path_to_check = dir_path + "/" + *pathname;
-            }
+            pathname = (dir_path / pathname).lexically_normal();
         }
     }
 
-    if (is_capio_path(path_to_check)) {
+    if (is_capio_path(pathname)) {
         int fd = static_cast<int>(syscall_no_intercept(SYS_open, "/dev/null", O_RDONLY));
         if (fd == -1) {
             ERR_EXIT("capio_open, /dev/null opening");
@@ -46,19 +37,19 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
         bool create = (flags & O_CREAT) == O_CREAT;
         bool excl   = (flags & O_EXCL) == O_EXCL;
         if (excl) {
-            off64_t return_code = create_exclusive_request(fd, path_to_check, tid);
+            off64_t return_code = create_exclusive_request(fd, pathname, tid);
             if (return_code == 1) {
                 errno = EEXIST;
                 return POSIX_SYSCALL_ERRNO;
             }
         } else if (create) {
-            off64_t return_code = create_request(fd, path_to_check, tid);
+            off64_t return_code = create_request(fd, pathname, tid);
             if (return_code == 1) {
                 errno = ENOENT;
                 return POSIX_SYSCALL_ERRNO;
             }
         } else {
-            off64_t return_code = open_request(fd, path_to_check, tid);
+            off64_t return_code = open_request(fd, pathname, tid);
             if (return_code == 1) {
                 errno = ENOENT;
                 return POSIX_SYSCALL_ERRNO;
@@ -68,7 +59,7 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
         if ((flags & O_DIRECTORY) == O_DIRECTORY) {
             actual_flags = actual_flags | O_LARGEFILE;
         }
-        add_capio_fd(tid, path_to_check, fd, 0, DEFAULT_FILE_INITIAL_SIZE, actual_flags,
+        add_capio_fd(tid, pathname, fd, 0, DEFAULT_FILE_INITIAL_SIZE, actual_flags,
                      (flags & O_CLOEXEC) == O_CLOEXEC);
         if ((flags & O_APPEND) == O_APPEND) {
             capio_lseek(fd, 0, SEEK_END, tid);
@@ -80,20 +71,20 @@ inline int capio_openat(int dirfd, std::string *pathname, int flags, long tid) {
 }
 
 int creat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::string pathname(reinterpret_cast<const char *>(arg0));
+    std::filesystem::path pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_openat(AT_FDCWD, &pathname, O_CREAT | O_WRONLY | O_TRUNC, tid),
+    return posix_return_value(capio_openat(AT_FDCWD, pathname, O_CREAT | O_WRONLY | O_TRUNC, tid),
                               result);
 }
 
 int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int dirfd = static_cast<int>(arg0);
-    std::string pathname(reinterpret_cast<const char *>(arg1));
+    std::filesystem::path pathname(reinterpret_cast<const char *>(arg1));
     int flags = static_cast<int>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_openat(dirfd, &pathname, flags, tid), result);
+    return posix_return_value(capio_openat(dirfd, pathname, flags, tid), result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_OPENAT_HPP

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -4,13 +4,13 @@
 #include "utils/filesystem.hpp"
 
 int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    const std::string oldpath(reinterpret_cast<const char *>(arg0));
-    const std::string newpath(reinterpret_cast<const char *>(arg1));
+    const std::filesystem::path oldpath(reinterpret_cast<const char *>(arg0));
+    const std::filesystem::path newpath(reinterpret_cast<const char *>(arg1));
     long tid = syscall_no_intercept(SYS_gettid);
     START_LOG(tid, "call(oldpath=%s, newpath=%s)", oldpath.c_str(), newpath.c_str());
 
-    std::string oldpath_abs = absolute(oldpath);
-    std::string newpath_abs = absolute(newpath);
+    auto oldpath_abs = capio_absolute(oldpath);
+    auto newpath_abs = capio_absolute(newpath);
 
     if (is_prefix(oldpath_abs, newpath_abs)) { // TODO: The check is more complex
         errno   = EINVAL;

--- a/src/posix/handlers/statfs.hpp
+++ b/src/posix/handlers/statfs.hpp
@@ -10,10 +10,9 @@ int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
     START_LOG(tid, "call(fd=%d, buf=0x%08x)", fd, buf);
 
     if (exists_capio_fd(fd)) {
-        std::string path             = get_capio_fd_path(fd);
-        const std::string *capio_dir = get_capio_dir();
+        const std::filesystem::path path(get_capio_fd_path(fd));
 
-        *result = static_cast<int>(syscall_no_intercept(SYS_statfs, capio_dir->c_str(), buf));
+        *result = static_cast<int>(syscall_no_intercept(SYS_statfs, get_capio_dir().c_str(), buf));
         return POSIX_SYSCALL_SUCCESS;
     }
     return POSIX_SYSCALL_SKIP;

--- a/src/posix/handlers/unlink.hpp
+++ b/src/posix/handlers/unlink.hpp
@@ -1,9 +1,9 @@
 #ifndef CAPIO_POSIX_HANDLERS_UNLINK_HPP
 #define CAPIO_POSIX_HANDLERS_UNLINK_HPP
 
-#include "utils/functions.hpp"
+#include "utils/common.hpp"
 
-off64_t capio_unlink_abs(const std::string &abs_path, long tid, bool is_dir) {
+off64_t capio_unlink_abs(const std::filesystem::path &abs_path, long tid, bool is_dir) {
     START_LOG(tid, "call(abs_path=%s, is_dir=%s)", abs_path.c_str(), is_dir ? "true" : "false");
     if (!is_capio_path(abs_path)) {
         if (is_capio_dir(abs_path)) {
@@ -20,29 +20,28 @@ off64_t capio_unlink_abs(const std::string &abs_path, long tid, bool is_dir) {
     }
 }
 
-inline off64_t capio_unlinkat(int dirfd, const std::string &pathname, int flags, long tid) {
+inline off64_t capio_unlinkat(int dirfd, std::filesystem::path &pathname, int flags, long tid) {
     START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%X)", dirfd, pathname.c_str(), flags);
 
     off64_t res;
     bool is_dir = flags & AT_REMOVEDIR;
-    if (!is_absolute(&pathname)) {
+    if (pathname.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            const std::string abs_path = capio_posix_realpath(&pathname);
-            if (abs_path.empty()) {
+            pathname = capio_posix_realpath(pathname);
+            if (pathname.empty()) {
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
-            res = capio_unlink_abs(abs_path, tid, is_dir);
+            res = capio_unlink_abs(pathname, tid, is_dir);
         } else {
             if (!is_directory(dirfd)) {
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
-            std::string dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
-            std::string path = dir_path + "/" + pathname;
-
-            res = capio_unlink_abs(path, tid, is_dir);
+            const std::filesystem::path path = (dir_path / pathname).lexically_normal();
+            res                              = capio_unlink_abs(path, tid, is_dir);
         }
     } else {
         res = capio_unlink_abs(pathname, tid, is_dir);
@@ -52,7 +51,7 @@ inline off64_t capio_unlinkat(int dirfd, const std::string &pathname, int flags,
 }
 
 int unlink_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::string pathname(reinterpret_cast<const char *>(arg0));
+    std::filesystem::path pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
     return posix_return_value(capio_unlinkat(AT_FDCWD, pathname, 0, tid), result);
@@ -61,7 +60,7 @@ int unlink_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
 int unlinkat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                      long *result) {
     int dirfd = static_cast<int>(arg0);
-    std::string pathname(reinterpret_cast<const char *>(arg1));
+    std::filesystem::path pathname(reinterpret_cast<const char *>(arg1));
     int flags = static_cast<int>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
 

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -1,7 +1,7 @@
 #ifndef CAPIO_POSIX_HANDLERS_WRITE_HPP
 #define CAPIO_POSIX_HANDLERS_WRITE_HPP
 
-#include "utils/functions.hpp"
+#include "utils/common.hpp"
 #include "utils/requests.hpp"
 
 inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) {

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -9,7 +9,6 @@
 
 #include <asm-generic/unistd.h>
 
-#include "capio/env.hpp"
 #include "capio/syscall.hpp"
 
 #include "utils/clone.hpp"

--- a/src/posix/utils/common.hpp
+++ b/src/posix/utils/common.hpp
@@ -14,15 +14,6 @@ int posix_return_value(long res, long *result) {
     return POSIX_SYSCALL_SKIP;
 }
 
-inline std::string absolute(const std::string &path) {
-    return is_absolute(&path) ? path : capio_posix_realpath(&path);
-}
-
-std::string get_capio_parent_dir(const std::string &path) {
-    auto pos = path.rfind('/');
-    return path.substr(0, pos);
-}
-
 inline off64_t round(off64_t bytes, bool is_getdents64) {
     off64_t res = 0;
     off64_t ld_size;

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -36,7 +36,7 @@ inline void register_listener(long tid) {
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 
-inline off64_t access_request(const std::string &path, const long tid) {
+inline off64_t access_request(const std::filesystem::path &path, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_ACCESS, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -57,8 +57,8 @@ inline void close_request(const int fd, const long tid) {
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
 }
 
-inline off64_t rename_request(const long tid, const std::string &old_path,
-                              const std::string &newpath) {
+inline off64_t rename_request(const long tid, const std::filesystem::path &old_path,
+                              const std::filesystem::path &newpath) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %s %s %ld", CAPIO_REQUEST_RENAME, old_path.c_str(), newpath.c_str(), tid);
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -67,7 +67,7 @@ inline off64_t rename_request(const long tid, const std::string &old_path,
     return res;
 }
 
-inline off64_t create_request(const int fd, const std::string &path, const long tid) {
+inline off64_t create_request(const int fd, const std::filesystem::path &path, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -76,7 +76,8 @@ inline off64_t create_request(const int fd, const std::string &path, const long 
     return res;
 }
 
-inline off64_t create_exclusive_request(const int fd, const std::string &path, const long tid) {
+inline off64_t create_exclusive_request(const int fd, const std::filesystem::path &path,
+                                        const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE_EXCLUSIVE, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -132,7 +133,7 @@ inline CPStatResponse_t fstat_request(const int fd, const long tid) {
     return {file_size, is_dir};
 }
 
-inline off64_t mkdir_request(const std::string &path, const long tid) {
+inline off64_t mkdir_request(const std::filesystem::path &path, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_MKDIR, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -141,7 +142,7 @@ inline off64_t mkdir_request(const std::string &path, const long tid) {
     return res;
 }
 
-inline off64_t open_request(const int fd, const std::string &path, const long tid) {
+inline off64_t open_request(const int fd, const std::filesystem::path &path, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_OPEN, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -159,8 +160,8 @@ inline off64_t read_request(const int fd, const off64_t count, const long tid) {
     return res;
 }
 
-inline off64_t rename_request(const std::string &oldpath, const std::string &newpath,
-                              const long tid) {
+inline off64_t rename_request(const std::filesystem::path &oldpath,
+                              const std::filesystem::path &newpath, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %s %s %ld", CAPIO_REQUEST_RENAME, oldpath.c_str(), newpath.c_str(), tid);
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -205,7 +206,7 @@ inline off64_t seek_request(const int fd, const off64_t offset, const long tid) 
     return res;
 }
 
-inline CPStatResponse_t stat_request(const std::string &path, const long tid) {
+inline CPStatResponse_t stat_request(const std::filesystem::path &path, const long tid) {
     START_LOG(tid, "call(path=%s)", path.c_str());
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_STAT, tid, path.c_str());
@@ -219,7 +220,7 @@ inline CPStatResponse_t stat_request(const std::string &path, const long tid) {
     return {file_size, is_dir};
 }
 
-inline off64_t unlink_request(const std::string &path, const long tid) {
+inline off64_t unlink_request(const std::filesystem::path &path, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_UNLINK, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
@@ -228,7 +229,7 @@ inline off64_t unlink_request(const std::string &path, const long tid) {
     return res;
 }
 
-inline off64_t rmdir_request(const std::string &dir_path, long tid) {
+inline off64_t rmdir_request(const std::filesystem::path &dir_path, long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %s %ld", CAPIO_REQUEST_RMDIR, dir_path.c_str(), tid);
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -68,15 +68,6 @@ CSRankToNodeMap_t rank_to_node;
  */
 CSPendingReadsMap_t pending_reads;
 
-/*
- * It contains all the read requested by other nodes for which the data is not
- * yet available path -> [(offset, numbytes, sem_pointer), ...]
- */
-
-CSClientsRemotePendingReads_t clients_remote_pending_reads;
-
-CSClientsRemotePendingStats_t clients_remote_pending_stat;
-
 // it contains the file saved on disk
 CSOnDiskMap_t on_disk;
 
@@ -134,9 +125,9 @@ void capio_server(int rank) {
     setup_signal_handlers();
     backend->handshake_servers(rank);
     open_files_location(rank);
-    int pid                      = getpid();
-    const std::string *capio_dir = get_capio_dir();
-    create_dir(pid, capio_dir->c_str(), rank,
+    pid_t pid                              = getpid();
+    const std::filesystem::path &capio_dir = get_capio_dir();
+    create_dir(pid, capio_dir.c_str(), rank,
                true); // TODO: can be a problem if a process execute readdir
     // on capio_dir
 
@@ -218,8 +209,8 @@ int parseCLI(int argc, char **argv, int rank) {
         std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "skipping config file parsing" << std::endl;
     } else {
         if (config) {
-            std::string token            = args::get(config);
-            const std::string *capio_dir = get_capio_dir();
+            std::string token                      = args::get(config);
+            const std::filesystem::path &capio_dir = get_capio_dir();
             std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "parsing config file: " << token
                       << std::endl;
             parse_conf_file(token, capio_dir);
@@ -235,7 +226,7 @@ int parseCLI(int argc, char **argv, int rank) {
         }
     }
 
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "CAPIO_DIR=" << get_capio_dir()->c_str()
+    std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "CAPIO_DIR=" << get_capio_dir().c_str()
               << std::endl;
 
     delete log;

--- a/src/server/handlers.hpp
+++ b/src/server/handlers.hpp
@@ -19,8 +19,6 @@
 #include "handlers/seek.hpp"
 #include "handlers/stat.hpp"
 #include "handlers/unlink.hpp"
-#include "handlers/utils/util_filesys.hpp"
-#include "handlers/utils/util_producer.hpp"
 #include "handlers/write.hpp"
 
 #endif // CAPIO_SERVER_HANDLERS_HPP

--- a/src/server/handlers/close.hpp
+++ b/src/server/handlers/close.hpp
@@ -2,7 +2,8 @@
 #define CAPIO_SERVER_HANDLERS_CLOSE_HPP
 
 #include "read.hpp"
-#include "utils/util_filesys.hpp"
+
+#include "utils/filesystem.hpp"
 
 inline void handle_close(int tid, int fd, int rank) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, rank=%d)", tid, fd, rank);

--- a/src/server/handlers/open.hpp
+++ b/src/server/handlers/open.hpp
@@ -1,9 +1,9 @@
 #ifndef CAPIO_SERVER_HANDLERS_OPEN_HPP
 #define CAPIO_SERVER_HANDLERS_OPEN_HPP
 
+#include "utils/filesystem.hpp"
 #include "utils/location.hpp"
 #include "utils/metadata.hpp"
-#include "utils/util_filesys.hpp"
 
 inline void update_file_metadata(const std::string &path, int tid, int fd, int rank,
                                  bool is_creat) {

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -5,8 +5,8 @@
 #include <thread>
 
 #include "utils/location.hpp"
+#include "utils/producer.hpp"
 #include "utils/types.hpp"
-#include "utils/util_producer.hpp"
 
 CSMyRemotePendingStats_t pending_remote_stats;
 std::mutex pending_remote_stats_mutex;
@@ -37,11 +37,11 @@ inline void reply_stat(int tid, const std::string &path, int rank) {
     Capio_file &c_file =
         (c_file_opt) ? c_file_opt->get() : create_capio_file(path, false, get_file_initial_size());
     LOG("Obtained capio file. ready to reply to client");
-    std::string_view mode        = c_file.get_mode();
-    bool complete                = c_file.complete;
-    const std::string *capio_dir = get_capio_dir();
+    std::string_view mode                  = c_file.get_mode();
+    bool complete                          = c_file.complete;
+    const std::filesystem::path &capio_dir = get_capio_dir();
     if (complete || strcmp(std::get<0>(file_location_opt->get()), node_name) == 0 ||
-        mode == CAPIO_FILE_MODE_NO_UPDATE || *capio_dir == path) {
+        mode == CAPIO_FILE_MODE_NO_UPDATE || capio_dir == path) {
         LOG("Sending response to client");
         write_response(tid, c_file.get_file_size());
         write_response(tid, static_cast<int>(c_file.is_dir() ? 1 : 0));

--- a/src/server/utils/metadata.hpp
+++ b/src/server/utils/metadata.hpp
@@ -245,8 +245,8 @@ inline void rename_capio_file(const char *const oldpath, const char *const newpa
     }
 }
 
-void update_metadata_conf(std::string &path, size_t pos, long int n_files, size_t batch_size,
-                          const std::string &committed, const std::string &mode,
+void update_metadata_conf(std::filesystem::path &path, size_t pos, long int n_files,
+                          size_t batch_size, const std::string &committed, const std::string &mode,
                           const std::string &app_name, bool permanent, long int n_close) {
     START_LOG(gettid(),
               "call(path=%s, pos=%ld, n_files=%ld, batch_size=%ld, committed=%s, "
@@ -258,7 +258,7 @@ void update_metadata_conf(std::string &path, size_t pos, long int n_files, size_
         metadata_conf[path] =
             std::make_tuple(committed, mode, app_name, n_files, permanent, n_close);
     } else {
-        std::string prefix_str = path.substr(0, pos);
+        std::string prefix_str = path.native().substr(0, pos);
         metadata_conf_globs.emplace_back(prefix_str, committed, mode, app_name, n_files, batch_size,
                                          permanent, n_close);
     }

--- a/src/server/utils/producer.hpp
+++ b/src/server/utils/producer.hpp
@@ -1,5 +1,9 @@
-#ifndef CAPIO_UTIL_PRODUCER_HPP
-#define CAPIO_UTIL_PRODUCER_HPP
+#ifndef CAPIO_SERVER_UTILS_PRODUCER_HPP
+#define CAPIO_SERVER_UTILS_PRODUCER_HPP
+
+#include <string>
+
+#include "metadata.hpp"
 
 std::string get_producer_name(const std::string &path) {
     START_LOG(gettid(), "call( %s)", path.c_str());
@@ -32,4 +36,4 @@ bool is_producer(int tid, const std::string &path) {
     return res;
 }
 
-#endif // CAPIO_UTIL_PRODUCER_HPP
+#endif // CAPIO_SERVER_UTILS_PRODUCER_HPP

--- a/tests/posix/src/realpath.cpp
+++ b/tests/posix/src/realpath.cpp
@@ -20,31 +20,29 @@ class FileSystemRegistrar : public Catch::EventListenerBase {
 CATCH_REGISTER_LISTENER(FileSystemRegistrar);
 
 TEST_CASE("Test absolute paths inside the CAPIO_DIR when path exists", "[posix]") {
-    const std::string PATHNAME =
-        std::filesystem::path(*get_capio_dir()) / std::filesystem::path("test");
+    const std::filesystem::path PATHNAME = get_capio_dir() / "test";
     REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
     REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
-    REQUIRE(capio_posix_realpath(&PATHNAME) == PATHNAME);
+    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
     REQUIRE(rmdir(PATHNAME.c_str()) != -1);
     REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
 }
 
 TEST_CASE("Test absolute paths inside the CAPIO_DIR when path does not exist", "[posix]") {
-    const std::string PATHNAME =
-        std::filesystem::path(*get_capio_dir()) / std::filesystem::path("test");
-    REQUIRE(capio_posix_realpath(&PATHNAME) == PATHNAME);
+    const std::filesystem::path PATHNAME = get_capio_dir() / "test";
+    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
 }
 
 TEST_CASE("Test absolute paths outside the CAPIO_DIR when path exists", "[posix]") {
-    const std::string PATHNAME = "/tmp/test";
+    const std::filesystem::path PATHNAME = "/tmp/test";
     REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
     REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
-    REQUIRE(capio_posix_realpath(&PATHNAME) == PATHNAME);
+    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
     REQUIRE(rmdir(PATHNAME.c_str()) != -1);
     REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
 }
 
 TEST_CASE("Test absolute paths outside the CAPIO_DIR when path does not exist", "[posix]") {
-    const std::string PATHNAME = "/tmp/test";
-    REQUIRE(capio_posix_realpath(&PATHNAME) == PATHNAME);
+    const std::filesystem::path PATHNAME = "/tmp/test";
+    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
 }


### PR DESCRIPTION
This commit improves the path handling in CAPIO by substituting custom functions that manipulate paths as strings with specific functions implemented in the `<filesystem>` standard library.