### PR TITLE
Skip `getcwd` when current dir is not CAPIO path

### DIFF
--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -43,7 +43,7 @@ const std::filesystem::path &get_capio_dir() {
         }
         capio_dir = std::filesystem::path(buf.get());
     }
-    LOG("CAPIO=DIR=%s", capio_dir.c_str());
+    LOG("CAPIO_DIR=%s", capio_dir.c_str());
 
     return capio_dir;
 }

--- a/src/posix/utils/clone.hpp
+++ b/src/posix/utils/clone.hpp
@@ -46,7 +46,7 @@ void hook_clone_child() {
 
 void hook_clone_parent(long child_tid) {
     long parent_tid = syscall_no_intercept(SYS_gettid);
-    START_LOG(parent_tid, "call(parent_tid=%d, child_tid=%ld)", parent_tid, child_tid);
+    START_LOG(parent_tid, "call(parent_tid=%d, child_tid=%d)", parent_tid, child_tid);
 
     if (child_tid < 0) {
         LOG("Skipping clone as child tid is set to %d: %s", child_tid, std::strerror(child_tid));


### PR DESCRIPTION
This commit returns control to the kernel when the `getcwd` is invoked and the current directory is not inside the `CAPIO_DIR`. This strategy fixes some timing issues with network file systems like NFS, that sometimes caused a `No such file or directory` error on the current directory.