### PR TITLE
Fix `capio_posix_realpath` with relative paths

### DIFF
--- a/src/posix/utils/filesystem.hpp
+++ b/src/posix/utils/filesystem.hpp
@@ -89,13 +89,15 @@ std::filesystem::path capio_posix_realpath(const std::filesystem::path &pathname
         if (pathname.is_absolute()) {
             LOG("Path=%s is already absolute", pathname.c_str());
             return {pathname};
-        } else if (is_capio_path(*current_dir)) {
-            const std::filesystem::path new_path = (*current_dir / pathname).lexically_normal();
-            LOG("Computed absolute path = %s", new_path.c_str());
-            return new_path;
         } else {
-            LOG("file %s is not a posix file, nor a capio file!", pathname.c_str());
-            return {};
+            std::filesystem::path new_path = (*current_dir / pathname).lexically_normal();
+            if (is_capio_path(new_path)) {
+                LOG("Computed absolute path = %s", new_path.c_str());
+                return new_path;
+            } else {
+                LOG("file %s is not a posix file, nor a capio file!", pathname.c_str());
+                return {};
+            }
         }
     }
 

--- a/tests/posix/src/realpath.cpp
+++ b/tests/posix/src/realpath.cpp
@@ -46,3 +46,25 @@ TEST_CASE("Test absolute paths outside the CAPIO_DIR when path does not exist", 
     const std::filesystem::path PATHNAME = "/tmp/test";
     REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
 }
+
+TEST_CASE("Test relative paths inside the CAPIO_DIR when cwd is the CAPIO_DIR") {
+    const std::filesystem::path &capio_dir = get_capio_dir();
+    const std::filesystem::path PATHNAME   = capio_dir / "test";
+    set_current_dir(capio_dir);
+    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
+    REQUIRE(capio_posix_realpath("test") == PATHNAME);
+    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+}
+
+TEST_CASE("Test relative paths inside the CAPIO_DIR when cwd is a parent of the CAPIO_DIR") {
+    const std::filesystem::path &capio_dir = get_capio_dir();
+    const std::filesystem::path PATHNAME   = capio_dir / "test";
+    set_current_dir(capio_dir.parent_path());
+    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
+    REQUIRE(capio_posix_realpath(capio_dir.filename() / "test") == PATHNAME);
+    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
+    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+}


### PR DESCRIPTION
When the current directory is a parent of the `CAPIO_DIR` and a path is relative, CAPIO was always excluding it from being a CAPIO path. This commit fixes this behaviour by composing the full absolute path before checking.