### PR TITLE
Fix error handling in `stat` syscall family

### DIFF
--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -46,6 +46,10 @@ inline int capio_fstat(int fd, struct stat *statbuf, long tid) {
 
     if (exists_capio_fd(fd)) {
         auto [file_size, is_dir] = fstat_request(fd, tid);
+        if (file_size == -1) {
+            errno = ENOENT;
+            return POSIX_SYSCALL_ERRNO;
+        }
         fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(get_capio_fd_path(fd)));
         return POSIX_SYSCALL_SUCCESS;
     } else {
@@ -58,6 +62,10 @@ inline int capio_lstat(const std::filesystem::path &absolute_path, struct stat *
 
     if (is_capio_path(absolute_path)) {
         auto [file_size, is_dir] = stat_request(absolute_path, tid);
+        if (file_size == -1) {
+            errno = ENOENT;
+            return POSIX_SYSCALL_ERRNO;
+        }
         fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path));
         return POSIX_SYSCALL_SUCCESS;
     } else {
@@ -70,7 +78,8 @@ inline int capio_lstat_wrapper(const std::filesystem::path &path, struct stat *s
 
     const std::filesystem::path absolute_path = capio_posix_realpath(path);
     if (absolute_path.empty()) {
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        errno = ENOENT;
+        return POSIX_SYSCALL_ERRNO;
     }
     return capio_lstat(absolute_path, statbuf, tid);
 }
@@ -80,32 +89,25 @@ inline int capio_fstatat(int dirfd, std::filesystem::path &pathname, struct stat
     START_LOG(tid, "call(dirfd=%ld, pathname=%s, statbuf=0x%08x, flags=%X)", dirfd,
               pathname.c_str(), statbuf, flags);
 
-    if ((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH) {
+    if (pathname.empty() && (flags & AT_EMPTY_PATH) == AT_EMPTY_PATH) {
         if (dirfd == AT_FDCWD) { // operate on currdir
             return capio_lstat(get_current_dir(), statbuf, tid);
         } else { // operate on dirfd. in this case dirfd can refer to any type of file
-            if (pathname.empty()) {
-                return capio_fstat(dirfd, statbuf, tid);
-            } else {
-                // TODO: set errno
-                return POSIX_SYSCALL_ERRNO;
-            }
+            return capio_fstat(dirfd, statbuf, tid);
         }
-    }
-
-    if (pathname.is_relative()) {
+    } else if (pathname.is_relative()) {
         if (dirfd == AT_FDCWD) {
             // pathname is interpreted relative to currdir
             return capio_lstat_wrapper(pathname, statbuf, tid);
         } else {
             if (!is_directory(dirfd)) {
-                return POSIX_SYSCALL_REQUEST_SKIP;
+                errno = ENOTDIR;
+                return POSIX_SYSCALL_ERRNO;
             }
             const std::filesystem::path dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
                 return POSIX_SYSCALL_REQUEST_SKIP;
             }
-
             pathname = (dir_path / pathname).lexically_normal();
             return capio_lstat(pathname, statbuf, tid);
         }
@@ -134,6 +136,14 @@ int fstatat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
 }
 
 int lstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+    std::filesystem::path path(reinterpret_cast<const char *>(arg0));
+    auto *buf = reinterpret_cast<struct stat *>(arg1);
+    long tid  = syscall_no_intercept(SYS_gettid);
+
+    return posix_return_value(capio_lstat(path, buf, tid), result);
+}
+
+int stat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     std::filesystem::path path(reinterpret_cast<const char *>(arg0));
     auto *buf = reinterpret_cast<struct stat *>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -146,7 +146,7 @@ static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
     _syscallTable[SYS_rename] = rename_handler;
 #endif
 #ifdef SYS_stat
-    _syscallTable[SYS_stat] = lstat_handler;
+    _syscallTable[SYS_stat] = stat_handler;
 #endif
 #ifdef SYS_statx
     _syscallTable[SYS_statx] = statx_handler;

--- a/src/posix/utils/filesystem.hpp
+++ b/src/posix/utils/filesystem.hpp
@@ -250,8 +250,7 @@ std::filesystem::path get_dir_path(int dirfd) {
         char proclnk[128];
         char dir_pathname[PATH_MAX];
         sprintf(proclnk, "/proc/self/fd/%d", dirfd);
-        ssize_t r = readlink(proclnk, dir_pathname, PATH_MAX);
-        if (r < 0) {
+        if (syscall_no_intercept(SYS_readlink, proclnk, dir_pathname, PATH_MAX) < 0) {
             fprintf(stderr, "failed to readlink\n");
             return {};
         }

--- a/tests/syscall/src/statx.cpp
+++ b/tests/syscall/src/statx.cpp
@@ -83,7 +83,7 @@ TEST_CASE("Test statx syscall on file in a different directory using dirfd", "[s
     REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
     REQUIRE(close(fd) != -1);
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    REQUIRE(statx(dirfd, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
     check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
     REQUIRE(unlinkat(dirfd, PATHNAME, 0) != -1);
     REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
@@ -98,9 +98,70 @@ TEST_CASE("Test statx syscall on folder in a different directory using dirfd", "
     REQUIRE(mkdirat(dirfd, PATHNAME, S_IRWXU) != -1);
     REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    REQUIRE(statx(dirfd, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
     check_statxbuf(statxbuf, 4096);
     REQUIRE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR) != -1);
     REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
     REQUIRE(close(dirfd) != -1);
+}
+
+TEST_CASE("Test statx syscall using AT_EMPTY_PATH and AT_FDCWD", "[syscall]") {
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, 4096);
+}
+
+TEST_CASE("Test statx syscall on file using AT_EMPTY_PATH and dirfd", "[syscall]") {
+    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *BUFFER =
+        "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
+    int dirfd = openat(AT_FDCWD, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    REQUIRE(write(dirfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    struct statx statxbuf {};
+    REQUIRE(statx(dirfd, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
+    REQUIRE(close(dirfd) != -1);
+    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test statx syscall on folder using AT_EMPTY_PATH and dirfd", "[syscall]") {
+    constexpr const char *PATHNAME = "test";
+    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    int dirfd = openat(AT_FDCWD, PATHNAME, O_RDONLY | O_DIRECTORY);
+    REQUIRE(dirfd != -1);
+    struct statx statxbuf {};
+    REQUIRE(statx(dirfd, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    check_statxbuf(statxbuf, 4096);
+    REQUIRE(close(dirfd) != -1);
+    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
+    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+}
+
+TEST_CASE("Test statx syscall on nonexistent file", "[syscall]") {
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, "test", 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == -1);
+    REQUIRE(errno == ENOENT);
+}
+
+TEST_CASE("Test statx syscall on relative path with invalid dirfd", "[syscall]") {
+    constexpr const char *PATHNAME = "test";
+    struct statx statxbuf {};
+    REQUIRE(statx(-1, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == -1);
+    REQUIRE(errno == EBADF);
+}
+
+TEST_CASE("Test statx syscall with STATX__RESERVED set", "[syscall]") {
+    constexpr const char *PATHNAME = "test";
+    struct statx statxbuf {};
+    REQUIRE(statx(-1, PATHNAME, 0, STATX__RESERVED, &statxbuf) == -1);
+    REQUIRE(errno == EINVAL);
+}
+
+TEST_CASE("Test statx syscall with empty path and no AT_EMPTY_PATH flag", "[syscall]") {
+    struct statx statxbuf {};
+    REQUIRE(statx(AT_FDCWD, "", 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == -1);
+    REQUIRE(errno == ENOENT);
 }


### PR DESCRIPTION
This commit fixes error handling logic in the `stat` family of system calls, ensuring that the correct `errno` value is returned when something goes wrong. Before this commit, this part was flawed and sometimes CAPIO returned succesfully even in presence of errors, e.g., when stat was executed on a nonexistent file.