### PR TITLE
Improve logger for multiple threads

### DIFF
--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -18,17 +18,17 @@ constexpr char LOG_PRE_MSG[]                         = "tid[%ld]-at[%s]: ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]         = "[ \033[1;32m SERVER \033[0m ] ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
-constexpr char LOG_CAPIO_START_REQUEST[]             = "\n+++++++++++ SYSCALL %s (%d) +++++++++++";
-constexpr char LOG_CAPIO_END_REQUEST[]               = "----------- END SYSCALL ----------\n";
-constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[]  = "+++++++++++++++++REQUEST+++++++++++++++++";
-constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]    = "~~~~~~~~~~~~~~~END REQUEST~~~~~~~~~~~~~~~";
-constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC         = 10e5;
-constexpr int N_ELEMS_DATA_BUFS                      = 10;
-constexpr int WINDOW_DATA_BUFS                       = 256 * 1024;
-constexpr int CAPIO_REQUEST_MAX_SIZE                 = 256 * sizeof(char);
-constexpr int CAPIO_LOG_MAX_MSG_LEN                  = 2048;
-constexpr int CAPIO_SEM_RETRIES                      = 100;
-constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(off64_t) +
+constexpr char LOG_CAPIO_START_REQUEST[]            = "\n+++++++++ [%ld] SYSCALL %s (%d) +++++++++";
+constexpr char LOG_CAPIO_END_REQUEST[]              = "--------- [%ld] END SYSCALL --------\n";
+constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[] = "\n+++++++++++ [%ld] REQUEST +++++++++++";
+constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]   = "~~~~~~~~~ [%ld] END REQUEST ~~~~~~~~~\n";
+constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC        = 10e5;
+constexpr int N_ELEMS_DATA_BUFS                     = 10;
+constexpr int WINDOW_DATA_BUFS                      = 256 * 1024;
+constexpr int CAPIO_REQUEST_MAX_SIZE                = 256 * sizeof(char);
+constexpr int CAPIO_LOG_MAX_MSG_LEN                 = 2048;
+constexpr int CAPIO_SEM_RETRIES                     = 100;
+constexpr int THEORETICAL_SIZE_DIRENT64             = sizeof(ino64_t) + sizeof(off64_t) +
                                           sizeof(unsigned short) + sizeof(unsigned char) +
                                           sizeof(char) * NAME_MAX;
 

--- a/src/posix/utils/clone.hpp
+++ b/src/posix/utils/clone.hpp
@@ -45,6 +45,7 @@ void hook_clone_child() {
 }
 
 void hook_clone_parent(long child_tid) {
+    SUSPEND_SYSCALL_LOGGING();
     long parent_tid = syscall_no_intercept(SYS_gettid);
     START_LOG(parent_tid, "call(parent_tid=%d, child_tid=%d)", parent_tid, child_tid);
 


### PR DESCRIPTION
This commit adds the `tid` marker also on the header and footer messages of POSIX syscalls and server requests in the CAPIO `Logger`, to improve readability when multiple threads are running.

This commit also stop header and footer from showing up when a new thread is called through the `hook_clone_child` function, as they reported misleading syscall numbers that could cause confusion. This is achieved by introducing a new `SyscallLoggingSuspender` class that adheres to the C++ RAII principle.