### PR TITLE
Fix `hook_clone_child` SIGSEGV in glibc

### DIFF
--- a/src/posix/handlers/exit_group.hpp
+++ b/src/posix/handlers/exit_group.hpp
@@ -16,7 +16,11 @@ int exit_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     long tid = syscall_no_intercept(SYS_gettid);
     START_LOG(tid, "call()");
 
-    exit_group_request(tid);
+    if (is_capio_tid(tid)) {
+        LOG("Thread %d is a CAPIO thread: clean up", tid);
+        exit_group_request(tid);
+        remove_capio_tid(tid);
+    }
 
     return POSIX_SYSCALL_SKIP;
 }

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -201,6 +201,7 @@ static __attribute__((constructor)) void init() {
     init_client();
     init_data_plane();
     init_filesystem();
+    init_threading_support();
 
     long tid = syscall_no_intercept(SYS_gettid);
 
@@ -210,6 +211,7 @@ static __attribute__((constructor)) void init() {
     }
 
     init_process(tid);
+    register_capio_tid(tid);
 
     intercept_hook_point_clone_child  = hook_clone_child;
     intercept_hook_point_clone_parent = hook_clone_parent;

--- a/src/posix/utils/clone.hpp
+++ b/src/posix/utils/clone.hpp
@@ -11,7 +11,24 @@
 
 std::mutex clone_mutex;
 std::condition_variable clone_cv;
-std::unordered_set<long> tids;
+std::unordered_set<long> *tids;
+
+inline bool is_capio_tid(const long tid) {
+    const std::lock_guard<std::mutex> lg(clone_mutex);
+    return tids->find(tid) != tids->end();
+}
+
+inline void register_capio_tid(const long tid) {
+    const std::lock_guard<std::mutex> lg(clone_mutex);
+    tids->insert(tid);
+}
+
+inline void remove_capio_tid(const long tid) {
+    const std::lock_guard<std::mutex> lg(clone_mutex);
+    tids->erase(tid);
+}
+
+void init_threading_support() { tids = new std::unordered_set<long>{}; }
 
 void init_process(long tid) {
     START_LOG(syscall_no_intercept(SYS_gettid), "call(tid=%ld)", tid);
@@ -38,8 +55,15 @@ void hook_clone_child() {
 
     std::unique_lock<std::mutex> lock(clone_mutex);
     LOG("Waiting initialization from parent thread");
-    clone_cv.wait(lock, [&tid] { return tids.find(tid) != tids.end(); });
-    tids.erase(tid);
+    clone_cv.wait(lock, [&tid] { return tids->find(tid) != tids->end(); });
+
+    /**
+     * Freeing memory here through `tids.erase()` can cause a SIGSEGV error
+     * in the libc, which tries to load the `__ctype_b_loc` table but fails
+     * because it is not initialized yet. For this reason, a thread's `tid`
+     * is removed from the `tids` set only when the thread terminates.
+     */
+
     lock.unlock();
     LOG("Starting child thread %d", tid);
 }
@@ -58,11 +82,8 @@ void hook_clone_parent(long child_tid) {
     clone_request(parent_tid, child_tid);
     LOG("Child thread %d initialized", child_tid);
 
-    {
-        std::lock_guard<std::mutex> lg(clone_mutex);
-        tids.insert(child_tid);
-    }
-    clone_cv.notify_one();
+    register_capio_tid(child_tid);
+    clone_cv.notify_all();
 }
 
 #endif // CAPIO_POSIX_UTILS_CLONE_HPP

--- a/tests/syscall/src/clone.cpp
+++ b/tests/syscall/src/clone.cpp
@@ -10,7 +10,7 @@ constexpr int ARRAY_SIZE = 100;
 
 sem_t *sem;
 
-int func(int *num) {
+int func(const int *num) {
     REQUIRE(*num == 12345);
     return 0;
 }


### PR DESCRIPTION
Freeing memory inside the `hook_clone_child` function is dangerous, as the `free` glibc function tries to access the `__ctype_b_loc` table but sometimes it could not be initialized yet, causing a SIGSEGV error. THis commit moves the `tids.erease()` call in the `exit_group_handler` function, when a process is deleted. Plus, this commit ensures that all threads waiting on the `clone_cv` are notified when a child is initialized, preventing deadlocks.