### PR TITLE
Reformat constants and add CAPIO forbidden paths

### DIFF
--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -1,45 +1,53 @@
 #ifndef CAPIO_COMMON_CONSTANTS_HPP
 #define CAPIO_COMMON_CONSTANTS_HPP
 
+#include <array>
 #include <climits>
+#include <string_view>
+
 #include <sys/types.h>
 
-constexpr size_t DIR_INITIAL_SIZE = 1024L * 1024 * 1024;
+// CAPIO files constants
+constexpr size_t CAPIO_DEFAULT_DIR_INITIAL_SIZE   = 1024L * 1024 * 1024;
+constexpr off64_t CAPIO_DEFAULT_FILE_INITIAL_SIZE = 1024L * 1024 * 1024 * 4;
+constexpr std::array CAPIO_DIR_FORBIDDEN_PATHS    = {std::string_view{"/proc/"},
+                                                     std::string_view{"/sys/"}};
+constexpr int CAPIO_THEORETICAL_SIZE_DIRENT64     = sizeof(ino64_t) + sizeof(off64_t) +
+                                                sizeof(unsigned short) + sizeof(unsigned char) +
+                                                sizeof(char) * NAME_MAX;
 
-// default initial size for each file (can be overwritten by the user)
-off64_t DEFAULT_FILE_INITIAL_SIZE = 1024L * 1024 * 1024 * 4;
+// CAPIO semaphore constants
+constexpr int CAPIO_SEM_MAX_RETRIES          = 100;
+constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC = 10e5;
 
-constexpr char CAPIO_FILE_MODE_NO_UPDATE[]           = "no_update";
-constexpr char CAPIO_FILE_MODE_ON_CLOSE[]            = "on_close";
-constexpr char CAPIO_FILE_MODE_ON_TERMINATION[]      = "on_termination";
-constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_NAME[]  = "server_rank_\0";
-constexpr char CAPIO_APP_LOG_FILE_NAME[]             = "/dev/stderr\0";
-constexpr char LOG_PRE_MSG[]                         = "tid[%ld]-at[%s]: ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]         = "[ \033[1;32m SERVER \033[0m ] ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
-constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
-constexpr char LOG_CAPIO_START_REQUEST[]            = "\n+++++++++ [%ld] SYSCALL %s (%d) +++++++++";
-constexpr char LOG_CAPIO_END_REQUEST[]              = "--------- [%ld] END SYSCALL --------\n";
-constexpr char CAPIO_SERVER_LOG_START_REQUEST_MSG[] = "\n+++++++++++ [%ld] REQUEST +++++++++++";
-constexpr char CAPIO_SERVER_LOG_END_REQUEST_MSG[]   = "~~~~~~~~~ [%ld] END REQUEST ~~~~~~~~~\n";
-constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC        = 10e5;
-constexpr int N_ELEMS_DATA_BUFS                     = 10;
-constexpr int WINDOW_DATA_BUFS                      = 256 * 1024;
-constexpr int CAPIO_REQUEST_MAX_SIZE                = 256 * sizeof(char);
-constexpr int CAPIO_LOG_MAX_MSG_LEN                 = 2048;
-constexpr int CAPIO_SEM_RETRIES                     = 100;
-constexpr int THEORETICAL_SIZE_DIRENT64             = sizeof(ino64_t) + sizeof(off64_t) +
-                                          sizeof(unsigned short) + sizeof(unsigned char) +
-                                          sizeof(char) * NAME_MAX;
+// CAPIO communication constants
+constexpr int CAPIO_DATA_BUFFER_LENGTH         = 10;
+constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE   = 256 * 1024;
+constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE = sizeof(char) * (PATH_MAX + 81920);
+constexpr size_t CAPIO_REQUEST_MAX_SIZE        = 256 * sizeof(char);
 
-constexpr int POSIX_SYSCALL_SUCCESS      = 0;
-constexpr int POSIX_SYSCALL_SKIP         = 1;
-constexpr int POSIX_SYSCALL_ERRNO        = -1;
-constexpr int POSIX_SYSCALL_REQUEST_SKIP = -2;
+// CAPIO streaming semantics
+constexpr char CAPIO_FILE_MODE_NO_UPDATE[]      = "no_update";
+constexpr char CAPIO_FILE_MODE_ON_CLOSE[]       = "on_close";
+constexpr char CAPIO_FILE_MODE_ON_TERMINATION[] = "on_termination";
 
-constexpr size_t SERVER_MAX_REMOTE_REQUEST_SIZE = sizeof(char) * (PATH_MAX + 81920);
+// CAPIO POSIX return codes
+constexpr int CAPIO_POSIX_SYSCALL_ERRNO        = -1;
+constexpr int CAPIO_POSIX_SYSCALL_REQUEST_SKIP = -2;
+constexpr int CAPIO_POSIX_SYSCALL_SKIP         = 1;
+constexpr int CAPIO_POSIX_SYSCALL_SUCCESS      = 0;
 
-constexpr char CAPIO_BANNER[] =
+// CAPIO logger - common
+constexpr int CAPIO_LOG_MAX_MSG_LEN = 2048;
+constexpr char CAPIO_LOG_PRE_MSG[]  = "tid[%ld]-at[%s]: ";
+
+// CAPIO logger - POSIX
+constexpr char CAPIO_LOG_POSIX_DEFAULT_FILE_NAME[] = "/dev/stderr\0";
+constexpr char CAPIO_LOG_POSIX_SYSCALL_START[]     = "\n+++++++++ [%ld] SYSCALL %s (%d) +++++++++";
+constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]       = "--------- [%ld] END SYSCALL --------\n";
+
+// CAPIO logger - server
+constexpr char CAPIO_LOG_SERVER_BANNER[] =
     "\n\n "
     "\033[1;34m /$$$$$$   /$$$$$$  /$$$$$$$\033[0;96m  /$$$$$$  /$$$$$$ \n"
     "\033[1;34m /$$__  $$ /$$__  $$| $$__  $$\033[0;96m|_  $$_/ /$$__  $$\n"
@@ -53,8 +61,10 @@ constexpr char CAPIO_BANNER[] =
     "\\______/\n\n"
     "\033[0m   CAPIO - Cross Application Programmable IO         \n"
     "                    V. " CAPIO_VERSION "\n\n";
-
-constexpr char CAPIO_LOG_CLI_WARNING[] =
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_INFO[]    = "[ \033[1;32m SERVER \033[0m ] ";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
+constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING[] =
     "[ \033[1;33m SERVER \033[0m ] "
     "|==================================================================|\n"
     "[ \033[1;33m SERVER \033[0m ] | you are running a build of CAPIO with "
@@ -67,11 +77,13 @@ constexpr char CAPIO_LOG_CLI_WARNING[] =
     "                       |\n"
     "[ \033[1;33m SERVER \033[0m ] "
     "|==================================================================|\n";
-
-constexpr char CAPIO_LOG_CLI_WARNING_LOG_SET_NOT_COMPILED[] =
+constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE[] =
     "CAPIO_LOG set but log support was not compiled into CAPIO!";
+constexpr char CAPIO_LOG_SERVER_DEFAULT_FILE_NAME[] = "server_rank_\0";
+constexpr char CAPIO_LOG_SERVER_REQUEST_START[]     = "\n+++++++++++ [%ld] REQUEST +++++++++++";
+constexpr char CAPIO_LOG_SERVER_REQUEST_END[]       = "~~~~~~~~~ [%ld] END REQUEST ~~~~~~~~~\n";
 
-// constant strings for argument parser and capio server help
+// CAPIO server argument parser
 constexpr char CAPIO_SERVER_ARG_PARSER_PRE[] =
     "Cross Application Programmable IO application. developed by Alberto "
     "Riccardo Martinelli (UniTO), Massimo Torquati(UniPI), Marco Aldinucci (UniTO), Iacopo "
@@ -85,7 +97,6 @@ constexpr char CAPIO_SERVER_ARG_PARSER_LOGILE_OPT_HELP[] =
     "Filename to which capio_server will log to, without extension";
 constexpr char CAPIO_SERVER_ARG_PARSER_CONFIG_OPT_HELP[] =
     "JSON Configuration file for capio_server";
-
 constexpr char CAPIO_SERVER_ARG_PARSER_CONFIG_NO_CONF_FILE_HELP[] =
     "If specified, server application will start without a config file, using default settings.";
 #endif // CAPIO_COMMON_CONSTANTS_HPP

--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -24,7 +24,7 @@ const std::filesystem::path &get_capio_dir() {
         if (val == nullptr) {
 
             std::cout << "\n"
-                      << CAPIO_SERVER_CLI_LOG_SERVER_ERROR << "Fatal: CAPIO_DIR not provided!"
+                      << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Fatal: CAPIO_DIR not provided!"
                       << std::endl;
             ERR_EXIT("Fatal:  CAPIO_DIR not provided!");
 
@@ -33,7 +33,7 @@ const std::filesystem::path &get_capio_dir() {
             const char *realpath_res = capio_realpath(val, buf.get());
             if (realpath_res == nullptr) {
                 std::cout << "\n"
-                          << CAPIO_SERVER_CLI_LOG_SERVER_ERROR
+                          << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                           << "Fatal: CAPIO_DIR set, but folder does not exists on filesystem!"
                           << std::endl;
                 ERR_EXIT("error CAPIO_DIR: directory %s does not "
@@ -42,6 +42,11 @@ const std::filesystem::path &get_capio_dir() {
             }
         }
         capio_dir = std::filesystem::path(buf.get());
+        for (auto &forbidden_path : CAPIO_DIR_FORBIDDEN_PATHS) {
+            if (capio_dir.native().rfind(forbidden_path, 0) == 0) {
+                ERR_EXIT("CAPIO_DIR inside %s file system is not supported", forbidden_path);
+            }
+        }
     }
     LOG("CAPIO_DIR=%s", capio_dir.c_str());
 
@@ -57,7 +62,7 @@ inline int get_capio_log_level() {
         } else {
             auto [ptr, ec] = std::from_chars(log_level, log_level + strlen(log_level), level);
             if (ec != std::errc()) {
-                std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING << "invalid CAPIO_LOG_LEVEL value"
+                std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "invalid CAPIO_LOG_LEVEL value"
                           << std::endl;
                 level = 0;
             }

--- a/src/common/capio/filesystem.hpp
+++ b/src/common/capio/filesystem.hpp
@@ -1,6 +1,7 @@
 #ifndef CAPIO_COMMON_FILESYSTEM_HPP
 #define CAPIO_COMMON_FILESYSTEM_HPP
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <filesystem>
@@ -48,7 +49,14 @@ inline bool is_prefix(const std::filesystem::path &path_1, const std::filesystem
     return !relpath.empty() && relpath.native().rfind("..", 0) != 0;
 }
 
-static inline bool is_capio_dir(const std::filesystem::path &path_to_check) {
+inline bool is_forbidden_path(const std::string_view &path) {
+    return std::any_of(CAPIO_DIR_FORBIDDEN_PATHS.cbegin(), CAPIO_DIR_FORBIDDEN_PATHS.cend(),
+                       [&path](const std::string_view &forbidden_path) {
+                           return path.rfind(forbidden_path, 0) == 0;
+                       });
+}
+
+inline bool is_capio_dir(const std::filesystem::path &path_to_check) {
     START_LOG(capio_syscall(SYS_gettid), "call(path_to_check=%s)", path_to_check.c_str());
 
     const auto res = get_capio_dir().compare(path_to_check) == 0;
@@ -56,7 +64,7 @@ static inline bool is_capio_dir(const std::filesystem::path &path_to_check) {
     return res;
 }
 
-static inline bool is_capio_path(const std::filesystem::path &path_to_check) {
+inline bool is_capio_path(const std::filesystem::path &path_to_check) {
     START_LOG(capio_syscall(SYS_gettid), "call(path_to_check=%s)", path_to_check.c_str());
 
     // check if path_to_check begins with CAPIO_DIR

--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -4,60 +4,57 @@
 #include "utils/common.hpp"
 #include "utils/filesystem.hpp"
 
-inline off64_t capio_access(const std::filesystem::path &pathname, mode_t mode, long tid) {
-    START_LOG(tid, "call(pathname=%s, mode=%o)", pathname.c_str(), mode);
-
-    const std::filesystem::path abs_pathname = capio_posix_realpath(pathname);
-    if (abs_pathname.empty()) {
-        errno = ENONET;
-        return POSIX_SYSCALL_ERRNO;
-    } else if (is_capio_path(abs_pathname)) {
-        return access_request(abs_pathname, tid);
-    } else {
-        return POSIX_SYSCALL_REQUEST_SKIP;
-    }
-}
-
-inline off64_t capio_faccessat(int dirfd, const std::filesystem::path &pathname, mode_t mode,
-                               int flags, long tid) {
-    START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o, flags=%X)", dirfd, pathname.c_str(), mode,
+inline off64_t capio_faccessat(int dirfd, const std::string_view &pathname, mode_t mode, int flags,
+                               long tid) {
+    START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o, flags=%X)", dirfd, pathname.data(), mode,
               flags);
 
-    if (pathname.is_relative()) {
+    if (is_forbidden_path(pathname)) {
+        LOG("Path %s is forbidden: skip", pathname.data());
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
+    }
+
+    std::filesystem::path path(pathname);
+    if (path.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            // pathname is interpreted relative to currdir
-            return capio_access(pathname, mode, tid);
+            path = capio_posix_realpath(pathname);
+            if (path.empty()) {
+                errno = ENONET;
+                return CAPIO_POSIX_SYSCALL_ERRNO;
+            }
         } else {
             if (!is_directory(dirfd)) {
                 LOG("dirfd does not point to a directory");
-                return POSIX_SYSCALL_REQUEST_SKIP;
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
             const std::filesystem::path dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return POSIX_SYSCALL_REQUEST_SKIP;
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
-            const std::filesystem::path path = dir_path / pathname;
+            path = (dir_path / path).lexically_normal();
             return is_capio_path(path) ? access_request(path, tid) : -2;
         }
-    } else if (is_capio_path(pathname)) {
-        return access_request(pathname, tid);
+    }
+
+    if (is_capio_path(path)) {
+        return access_request(path, tid);
     } else {
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
 int access_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::filesystem::path pathname(reinterpret_cast<const char *>(arg0));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     auto mode = static_cast<mode_t>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_access(pathname, mode, tid), result);
+    return posix_return_value(capio_faccessat(AT_FDCWD, pathname, mode, 0, tid), result);
 }
 
 int faccessat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                       long *result) {
     auto dirfd = static_cast<int>(arg0);
-    std::filesystem::path pathname(reinterpret_cast<const char *>(arg1));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     auto mode  = static_cast<mode_t>(arg2);
     auto flags = static_cast<int>(arg3);
     long tid   = syscall_no_intercept(SYS_gettid);

--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -10,27 +10,33 @@
  */
 
 int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::filesystem::path path(reinterpret_cast<const char *>(arg0));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
-    START_LOG(tid, "call(path=%s)", path.c_str());
+    START_LOG(tid, "call(path=%s)", pathname.data());
 
+    if (is_forbidden_path(pathname)) {
+        LOG("Path %s is forbidden: skip", pathname.data());
+        return CAPIO_POSIX_SYSCALL_SKIP;
+    }
+
+    std::filesystem::path path(pathname);
     if (path.is_relative()) {
         path = capio_posix_realpath(path);
         if (path.empty()) {
             *result = -errno;
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
     }
 
     if (is_capio_path(path)) {
         set_current_dir(path);
         errno = 0;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
 
     // if not a capio path, then control is given to kernel
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_CHDIR_HPP

--- a/src/posix/handlers/close.hpp
+++ b/src/posix/handlers/close.hpp
@@ -13,7 +13,7 @@ int close_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         delete_capio_fd(fd);
         *result = 0;
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_CLOSE_HPP

--- a/src/posix/handlers/dup.hpp
+++ b/src/posix/handlers/dup.hpp
@@ -14,15 +14,15 @@ int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5
         int res = open("/dev/null", O_WRONLY);
         if (res == -1) {
             *result = -errno;
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
         dup_request(fd, res, tid);
         dup_capio_fd(tid, fd, res, false);
 
         *result = res;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -38,16 +38,16 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         int res = static_cast<int>(syscall_no_intercept(SYS_dup2, fd, fd2));
         if (res == -1) {
             *result = -errno;
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
         if (fd != res) {
             dup_request(fd, res, tid);
             dup_capio_fd(tid, fd, res, false);
         }
         *result = res;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -69,16 +69,16 @@ int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         int res = static_cast<int>(syscall_no_intercept(SYS_dup3, fd, fd2, flags));
         if (res == -1) {
             *result = -errno;
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
         bool is_cloexec = (flags & O_CLOEXEC) == O_CLOEXEC;
         dup_request(fd, res, tid);
         dup_capio_fd(tid, fd, res, is_cloexec);
 
         *result = res;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_DUP_HPP

--- a/src/posix/handlers/execve.hpp
+++ b/src/posix/handlers/execve.hpp
@@ -9,7 +9,7 @@ int execve_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
 
     create_snapshot(tid);
 
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_EXECVE_HPP

--- a/src/posix/handlers/exit_group.hpp
+++ b/src/posix/handlers/exit_group.hpp
@@ -22,7 +22,7 @@ int exit_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         remove_capio_tid(tid);
     }
 
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_EXIT_GROUP_HPP

--- a/src/posix/handlers/fchmod.hpp
+++ b/src/posix/handlers/fchmod.hpp
@@ -6,11 +6,11 @@ int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
 
     if (!exists_capio_fd(fd)) {
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
     *result = -errno;
 
-    return POSIX_SYSCALL_SUCCESS;
+    return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCHMOD_HPP

--- a/src/posix/handlers/fchown.hpp
+++ b/src/posix/handlers/fchown.hpp
@@ -6,11 +6,11 @@ int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
 
     if (!exists_capio_fd(fd)) {
-        return POSIX_SYSCALL_SKIP;
+        return CAPIO_POSIX_SYSCALL_SKIP;
     }
     *result = -errno;
 
-    return POSIX_SYSCALL_SUCCESS;
+    return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCHOWN_HPP

--- a/src/posix/handlers/fcntl.hpp
+++ b/src/posix/handlers/fcntl.hpp
@@ -17,22 +17,22 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
         switch (cmd) {
         case F_GETFD: {
             *result = get_capio_fd_cloexec(fd);
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
 
         case F_SETFD: {
             set_capio_fd_cloexec(fd, arg);
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
 
         case F_GETFL: {
             *result = get_capio_fd_flags(fd);
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
 
         case F_SETFL: {
             set_capio_fd_flags(fd, arg);
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
 
         case F_DUPFD_CLOEXEC: {
@@ -50,14 +50,14 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
             dup_capio_fd(tid, fd, res, true);
             dup_request(fd, res, tid);
 
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         }
 
         default:
             ERR_EXIT("fcntl with cmd %d is not yet supported", cmd);
         }
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FCNTL_HPP

--- a/src/posix/handlers/fgetxattr.hpp
+++ b/src/posix/handlers/fgetxattr.hpp
@@ -14,12 +14,12 @@ int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
         if (std::equal(name.begin(), name.end(), "system.posix_acl_access")) {
             errno   = ENODATA;
             *result = -errno;
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         } else {
             ERR_EXIT("fgetxattr with name %s is not yet supported in CAPIO", name.c_str());
         }
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FGETXATTR_HPP

--- a/src/posix/handlers/fork.hpp
+++ b/src/posix/handlers/fork.hpp
@@ -19,7 +19,7 @@ int fork_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         *result = pid;
     }
 
-    return POSIX_SYSCALL_SUCCESS;
+    return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_FORK_HPP

--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -15,7 +15,7 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
      * file systems such as NFS.
      */
     if (!is_capio_path(cwd)) {
-        return POSIX_SYSCALL_SKIP;
+        return CAPIO_POSIX_SYSCALL_SKIP;
     }
 
     const size_t length = cwd.native().length();
@@ -26,7 +26,7 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
         cwd.native().copy(buf, size);
         buf[length] = '\0';
     }
-    return POSIX_SYSCALL_SUCCESS;
+    return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_GETCWD_HPP

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -34,11 +34,11 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
         set_capio_fd_offset(fd, offset + bytes_read);
 
         *result = bytes_read;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     } else {
         LOG("fd=%d, is not a capio file descriptor", fd);
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 inline int getdents_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,

--- a/src/posix/handlers/ioctl.hpp
+++ b/src/posix/handlers/ioctl.hpp
@@ -10,9 +10,9 @@ int ioctl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     if (exists_capio_fd(fd)) {
         errno   = ENOTTY;
         *result = -errno;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_REQUEST_SKIP;
+    return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_IOCTL_HPP

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -16,7 +16,7 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
                 return offset;
             } else {
                 errno = EINVAL;
-                return POSIX_SYSCALL_ERRNO;
+                return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else if (whence == SEEK_CUR) {
             off64_t new_offset = file_offset + offset;
@@ -26,10 +26,10 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
                 return new_offset;
             } else {
                 errno = EINVAL;
-                return POSIX_SYSCALL_ERRNO;
+                return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else if (whence == SEEK_END) {
-            off64_t file_size  = seek_end_request(fd, tid);
+            seek_end_request(fd, tid);
             off64_t new_offset = file_offset + offset;
             set_capio_fd_offset(fd, new_offset);
             return new_offset;
@@ -43,10 +43,10 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
             return new_offset;
         } else {
             errno = EINVAL;
-            return POSIX_SYSCALL_ERRNO;
+            return CAPIO_POSIX_SYSCALL_ERRNO;
         }
     } else {
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 

--- a/src/posix/handlers/mkdir.hpp
+++ b/src/posix/handlers/mkdir.hpp
@@ -4,79 +4,91 @@
 #include "utils/common.hpp"
 #include "utils/filesystem.hpp"
 
-inline off64_t capio_mkdirat(int dirfd, std::filesystem::path &pathname, mode_t mode, long tid) {
-    START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o)", dirfd, pathname.c_str(), mode);
+inline off64_t capio_mkdirat(int dirfd, const std::string_view &pathname, mode_t mode, long tid) {
+    START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o)", dirfd, pathname.data(), mode);
 
-    if (pathname.is_relative()) {
+    if (is_forbidden_path(pathname)) {
+        LOG("Path %s is forbidden: skip", pathname.data());
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
+    }
+
+    std::filesystem::path path(pathname);
+    if (path.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            pathname = capio_posix_realpath(pathname);
-            if (pathname.empty()) {
-                return POSIX_SYSCALL_REQUEST_SKIP;
+            path = capio_posix_realpath(path);
+            if (path.empty()) {
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
         } else {
             if (!is_directory(dirfd)) {
-                return POSIX_SYSCALL_REQUEST_SKIP;
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
             const std::filesystem::path dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return POSIX_SYSCALL_REQUEST_SKIP;
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
-            pathname = dir_path / pathname;
+            path = (dir_path / path).lexically_normal();
         }
     }
 
-    if (is_capio_path(pathname)) {
-        if (exists_capio_path(pathname)) {
+    if (is_capio_path(path)) {
+        if (exists_capio_path(path)) {
             errno = EEXIST;
-            return POSIX_SYSCALL_ERRNO;
+            return CAPIO_POSIX_SYSCALL_ERRNO;
         }
-        off64_t res = mkdir_request(pathname, tid);
+        off64_t res = mkdir_request(path, tid);
         if (res == 1) {
-            return POSIX_SYSCALL_ERRNO;
+            return CAPIO_POSIX_SYSCALL_ERRNO;
         } else {
-            LOG("Adding %s to capio_files_path", pathname.c_str());
-            add_capio_path(pathname);
+            LOG("Adding %s to capio_files_path", path.c_str());
+            add_capio_path(path);
             return res;
         }
     } else {
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
-inline off64_t capio_rmdir(std::filesystem::path &pathname, long tid) {
-    START_LOG(tid, "call(pathname=%s)", pathname.c_str());
+inline off64_t capio_rmdir(const std::string_view &pathname, long tid) {
+    START_LOG(tid, "call(pathname=%s)", pathname.data());
 
-    if (pathname.is_relative()) {
-        pathname = capio_posix_realpath(pathname);
-        if (pathname.empty()) {
+    if (is_forbidden_path(pathname)) {
+        LOG("Path %s is forbidden: skip", pathname.data());
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
+    }
+
+    std::filesystem::path path(pathname);
+    if (path.is_relative()) {
+        path = capio_posix_realpath(path);
+        if (path.empty()) {
             LOG("path_to_check.len = 0!");
-            return POSIX_SYSCALL_REQUEST_SKIP;
+            return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
         }
     }
 
-    if (is_capio_path(pathname)) {
-        if (!exists_capio_path(pathname)) {
+    if (is_capio_path(path)) {
+        if (!exists_capio_path(path)) {
             LOG("capio_files_path.find == end. errno = "
                 "ENOENT");
             errno = ENOENT;
-            return POSIX_SYSCALL_ERRNO;
+            return CAPIO_POSIX_SYSCALL_ERRNO;
         }
-        off64_t res = rmdir_request(pathname, tid);
+        off64_t res = rmdir_request(path, tid);
         if (res == 2) {
             LOG("res == 2. errno = ENOENT");
             errno = ENOENT;
-            return POSIX_SYSCALL_ERRNO;
+            return CAPIO_POSIX_SYSCALL_ERRNO;
         } else {
-            delete_capio_path(pathname);
+            delete_capio_path(path);
             return res;
         }
     } else {
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
 int mkdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::filesystem::path pathname(reinterpret_cast<const char *>(arg0));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     auto mode = static_cast<mode_t>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
@@ -86,7 +98,7 @@ int mkdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
 int mkdirat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                     long *result) {
     int dirfd = static_cast<int>(arg0);
-    std::filesystem::path pathname(reinterpret_cast<const char *>(arg1));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     auto mode = static_cast<mode_t>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
 
@@ -94,7 +106,7 @@ int mkdirat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
 }
 
 int rmdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::filesystem::path pathname(reinterpret_cast<const char *>(arg0));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
     return posix_return_value(capio_rmdir(pathname, tid), result);

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -6,30 +6,36 @@
 #include "utils/common.hpp"
 #include "utils/filesystem.hpp"
 
-inline int capio_openat(int dirfd, std::filesystem::path &pathname, int flags, long tid) {
-    START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%X)", dirfd, pathname.c_str(), flags);
+inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, long tid) {
+    START_LOG(tid, "call(dirfd=%d, pathname=%s, flags=%X)", dirfd, pathname.data(), flags);
 
-    if (pathname.is_relative()) {
+    if (is_forbidden_path(pathname)) {
+        LOG("Path %s is forbidden: skip", pathname.data());
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
+    }
+
+    std::filesystem::path path(pathname);
+    if (path.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            pathname = capio_posix_realpath(pathname);
-            if (pathname.empty()) {
-                return POSIX_SYSCALL_REQUEST_SKIP;
+            path = capio_posix_realpath(path);
+            if (path.empty()) {
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
         } else {
             if (!is_directory(dirfd)) {
                 LOG("dirfd does not point to a directory");
-                return POSIX_SYSCALL_REQUEST_SKIP;
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
             const std::filesystem::path dir_path = get_dir_path(dirfd);
             if (dir_path.empty()) {
-                return POSIX_SYSCALL_REQUEST_SKIP;
+                return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
 
-            pathname = (dir_path / pathname).lexically_normal();
+            path = (dir_path / path).lexically_normal();
         }
     }
 
-    if (is_capio_path(pathname)) {
+    if (is_capio_path(path)) {
         int fd = static_cast<int>(syscall_no_intercept(SYS_open, "/dev/null", O_RDONLY));
         if (fd == -1) {
             ERR_EXIT("capio_open, /dev/null opening");
@@ -37,41 +43,41 @@ inline int capio_openat(int dirfd, std::filesystem::path &pathname, int flags, l
         bool create = (flags & O_CREAT) == O_CREAT;
         bool excl   = (flags & O_EXCL) == O_EXCL;
         if (excl) {
-            off64_t return_code = create_exclusive_request(fd, pathname, tid);
+            off64_t return_code = create_exclusive_request(fd, path, tid);
             if (return_code == 1) {
                 errno = EEXIST;
-                return POSIX_SYSCALL_ERRNO;
+                return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else if (create) {
-            off64_t return_code = create_request(fd, pathname, tid);
+            off64_t return_code = create_request(fd, path, tid);
             if (return_code == 1) {
                 errno = ENOENT;
-                return POSIX_SYSCALL_ERRNO;
+                return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else {
-            off64_t return_code = open_request(fd, pathname, tid);
+            off64_t return_code = open_request(fd, path, tid);
             if (return_code == 1) {
                 errno = ENOENT;
-                return POSIX_SYSCALL_ERRNO;
+                return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         }
         int actual_flags = flags & ~O_CLOEXEC;
         if ((flags & O_DIRECTORY) == O_DIRECTORY) {
             actual_flags = actual_flags | O_LARGEFILE;
         }
-        add_capio_fd(tid, pathname, fd, 0, DEFAULT_FILE_INITIAL_SIZE, actual_flags,
+        add_capio_fd(tid, path, fd, 0, CAPIO_DEFAULT_FILE_INITIAL_SIZE, actual_flags,
                      (flags & O_CLOEXEC) == O_CLOEXEC);
         if ((flags & O_APPEND) == O_APPEND) {
             capio_lseek(fd, 0, SEEK_END, tid);
         }
         return fd;
     } else {
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
 int creat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    std::filesystem::path pathname(reinterpret_cast<const char *>(arg0));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     long tid = syscall_no_intercept(SYS_gettid);
 
     return posix_return_value(capio_openat(AT_FDCWD, pathname, O_CREAT | O_WRONLY | O_TRUNC, tid),
@@ -80,7 +86,7 @@ int creat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
 
 int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int dirfd = static_cast<int>(arg0);
-    std::filesystem::path pathname(reinterpret_cast<const char *>(arg1));
+    const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     int flags = static_cast<int>(arg2);
     long tid  = syscall_no_intercept(SYS_gettid);
 

--- a/src/posix/handlers/read.hpp
+++ b/src/posix/handlers/read.hpp
@@ -21,9 +21,9 @@ int read_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
         read_data(tid, buffer, bytes_read);
         set_capio_fd_offset(fd, offset + bytes_read);
         *result = bytes_read;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_READ_HPP

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -15,21 +15,21 @@ int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     if (is_prefix(oldpath_abs, newpath_abs)) { // TODO: The check is more complex
         errno   = EINVAL;
         *result = -errno;
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
 
     if (is_capio_path(oldpath_abs)) {
         rename_capio_path(oldpath_abs, newpath_abs);
         auto res = rename_request(tid, oldpath_abs, newpath_abs);
         *result  = (res < 0 ? -errno : res);
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     } else {
         if (is_capio_path(newpath_abs)) {
             std::filesystem::copy(oldpath_abs, newpath_abs);
             *result = -errno;
-            return POSIX_SYSCALL_SUCCESS;
+            return CAPIO_POSIX_SYSCALL_SUCCESS;
         } else {
-            return POSIX_SYSCALL_SKIP;
+            return CAPIO_POSIX_SYSCALL_SKIP;
         }
     }
 }

--- a/src/posix/handlers/statfs.hpp
+++ b/src/posix/handlers/statfs.hpp
@@ -13,9 +13,9 @@ int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
         const std::filesystem::path path(get_capio_fd_path(fd));
 
         *result = static_cast<int>(syscall_no_intercept(SYS_statfs, get_capio_dir().c_str(), buf));
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 #endif // CAPIO_POSIX_HANDLERS_STATFS_HPP

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -18,7 +18,7 @@ inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) 
 
         return count;
     } else {
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
@@ -41,13 +41,13 @@ inline ssize_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long ti
             ++i;
         }
         if (res == -1) {
-            return POSIX_SYSCALL_ERRNO;
+            return CAPIO_POSIX_SYSCALL_ERRNO;
         } else {
             return tot_bytes;
         }
     } else {
         LOG("fd %d is not a capio fd. returning -2", fd);
-        return POSIX_SYSCALL_REQUEST_SKIP;
+        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 

--- a/src/posix/utils/common.hpp
+++ b/src/posix/utils/common.hpp
@@ -5,19 +5,19 @@
 
 int posix_return_value(long res, long *result) {
     START_LOG(capio_syscall(SYS_gettid), "cal(res=%ld)", res);
-    if (res != POSIX_SYSCALL_REQUEST_SKIP) {
+    if (res != CAPIO_POSIX_SYSCALL_REQUEST_SKIP) {
         *result = (res < 0 ? -errno : res);
         LOG("SYSCALL handled by capio. errno is: %s", res < 0 ? strerror(-errno) : "none");
-        return POSIX_SYSCALL_SUCCESS;
+        return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
     LOG("SYSCALL delegated to the kernel");
-    return POSIX_SYSCALL_SKIP;
+    return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
 inline off64_t round(off64_t bytes, bool is_getdents64) {
     off64_t res = 0;
     off64_t ld_size;
-    ld_size = THEORETICAL_SIZE_DIRENT64;
+    ld_size = CAPIO_THEORETICAL_SIZE_DIRENT64;
 
     while (res + ld_size <= bytes) {
         res += ld_size;

--- a/src/posix/utils/data.hpp
+++ b/src/posix/utils/data.hpp
@@ -17,12 +17,12 @@ inline void init_data_plane() { threads_data_bufs = new CPThreadDataBufs_t; }
  * @return
  */
 inline void register_data_listener(long tid) {
-    auto *write_queue = new SPSC_queue<char>("capio_write_data_buffer_tid_" + std::to_string(tid),
-                                             N_ELEMS_DATA_BUFS, WINDOW_DATA_BUFS,
-                                             CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_RETRIES);
-    auto *read_queue =
-        new SPSC_queue<char>("capio_read_data_buffer_tid_" + std::to_string(tid), N_ELEMS_DATA_BUFS,
-                             WINDOW_DATA_BUFS, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_RETRIES);
+    auto *write_queue = new SPSC_queue<char>(
+        "capio_write_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
+        CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+    auto *read_queue = new SPSC_queue<char>(
+        "capio_read_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
+        CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     threads_data_bufs->insert({static_cast<int>(tid), {write_queue, read_queue}});
 }
 
@@ -36,15 +36,15 @@ inline void register_data_listener(long tid) {
 inline void read_data(long tid, const void *buffer, off64_t count) {
     START_LOG(tid, "call(buffer=0x%08x, count=%ld)", buffer, count);
     auto data_buf  = threads_data_bufs->at(tid).second;
-    size_t n_reads = count / WINDOW_DATA_BUFS;
-    size_t r       = count % WINDOW_DATA_BUFS;
+    size_t n_reads = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
+    size_t r       = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
     size_t i       = 0;
     while (i < n_reads) {
-        data_buf->read((char *) buffer + i * WINDOW_DATA_BUFS);
+        data_buf->read((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
         ++i;
     }
     if (r) {
-        data_buf->read((char *) buffer + i * WINDOW_DATA_BUFS, r);
+        data_buf->read((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
     }
 }
 
@@ -58,16 +58,16 @@ inline void read_data(long tid, const void *buffer, off64_t count) {
 inline void write_data(long tid, const void *buffer, off64_t count) {
     START_LOG(tid, "call(buffer=0x%08x, count=%ld)", buffer, count);
     auto data_buf   = threads_data_bufs->at(tid).first;
-    size_t n_writes = count / WINDOW_DATA_BUFS;
-    size_t r        = count % WINDOW_DATA_BUFS;
+    size_t n_writes = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
+    size_t r        = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
 
     size_t i = 0;
     while (i < n_writes) {
-        data_buf->write((char *) buffer + i * WINDOW_DATA_BUFS);
+        data_buf->write((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
         ++i;
     }
     if (r) {
-        data_buf->write((char *) buffer + i * WINDOW_DATA_BUFS, r);
+        data_buf->write((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
     }
 }
 

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -19,7 +19,7 @@ CPBufResponse_t *bufs_response;
 inline void init_client() {
     // TODO: replace number with constexpr
     buf_requests  = new CPBufRequest_t("circular_buffer", 1024 * 1024, CAPIO_REQUEST_MAX_SIZE,
-                                       CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_RETRIES);
+                                       CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     bufs_response = new CPBufResponse_t();
 }
 
@@ -32,7 +32,7 @@ inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
     auto *p_buf_response =
         new Circular_buffer<off_t>("buf_response_" + std::to_string(tid), 8 * 1024 * 1024,
-                                   sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_RETRIES);
+                                   sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -139,13 +139,13 @@ void capio_server(int rank) {
 
     auto str = std::unique_ptr<char[]>(new char[CAPIO_REQUEST_MAX_SIZE]);
     while (true) {
-        LOG(CAPIO_SERVER_LOG_START_REQUEST_MSG);
+        LOG(CAPIO_LOG_SERVER_REQUEST_START);
         int code = read_next_request(str.get());
         if (code < 0 || code > CAPIO_NR_REQUESTS) {
             ERR_EXIT("Received an invalid request code %d", code);
         }
         request_handlers[code](str.get(), rank);
-        LOG(CAPIO_SERVER_LOG_END_REQUEST_MSG);
+        LOG(CAPIO_LOG_SERVER_REQUEST_END);
     }
 }
 
@@ -194,29 +194,30 @@ int parseCLI(int argc, char **argv, int rank) {
         std::string filename = token + "_" + std::to_string(rank) + ".log";
         logfile.open(filename, std::ofstream::out);
         log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "started logging to: " << filename << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to: " << filename
+                  << std::endl;
     } else {
         // log file not given. starting with default name
-        const std::string logname(CAPIO_SERVER_DEFAULT_LOG_FILE_NAME + std::to_string(rank) +
+        const std::string logname(CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::to_string(rank) +
                                   ".log");
         logfile.open(logname, std::ofstream::out);
         log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "started logging to default logfile " << logname
-                  << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to default logfile "
+                  << logname << std::endl;
     }
 
     if (noConfigFile) {
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "skipping config file parsing" << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "skipping config file parsing" << std::endl;
     } else {
         if (config) {
             std::string token                      = args::get(config);
             const std::filesystem::path &capio_dir = get_capio_dir();
-            std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "parsing config file: " << token
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "parsing config file: " << token
                       << std::endl;
             parse_conf_file(token, capio_dir);
         } else {
             std::cout
-                << CAPIO_SERVER_CLI_LOG_SERVER_ERROR
+                << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                 << "Error: no config file provided. To skip config file use --no-config option!"
                 << std::endl;
 #ifdef CAPIOLOG
@@ -226,32 +227,33 @@ int parseCLI(int argc, char **argv, int rank) {
         }
     }
 
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "CAPIO_DIR=" << get_capio_dir().c_str()
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "CAPIO_DIR=" << get_capio_dir().c_str()
               << std::endl;
 
     delete log;
 
 #ifdef CAPIOLOG
     CAPIO_LOG_LEVEL = get_capio_log_level();
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "LOG_LEVEL set to: " << CAPIO_LOG_LEVEL
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "LOG_LEVEL set to: " << CAPIO_LOG_LEVEL
               << std::endl;
-    std::cout << CAPIO_LOG_CLI_WARNING;
+    std::cout << CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING;
 
 #else
     if (std::getenv("CAPIO_LOG_LEVEL") != nullptr) {
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING
-                  << CAPIO_LOG_CLI_WARNING_LOG_SET_NOT_COMPILED << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
+                  << CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE << std::endl;
     }
 #endif
 
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "server initialization completed!" << std::flush;
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "server initialization completed!"
+              << std::flush;
     return 0;
 }
 
 int main(int argc, char **argv) {
     int rank, provided;
 
-    std::cout << CAPIO_BANNER;
+    std::cout << CAPIO_LOG_SERVER_BANNER;
     backend = new MPI_backend();
 
     parseCLI(argc, argv, rank);

--- a/src/server/communication_service/backends/mpi.hpp
+++ b/src/server/communication_service/backends/mpi.hpp
@@ -69,10 +69,10 @@ class MPI_backend : public backend_interface {
     RemoteRequest *read_next_request() override {
         START_LOG(gettid(), "call()");
         MPI_Status status;
-        char *buff = new char[SERVER_MAX_REMOTE_REQUEST_SIZE];
+        char *buff = new char[CAPIO_SERVER_REQUEST_MAX_SIZE];
 #ifdef CAPIOSYNC
         LOG("initiating a synchronized MPI receive");
-        MPI_Recv(buff, SERVER_MAX_REMOTE_REQUEST_SIZE, MPI_CHAR, MPI_ANY_SOURCE, 0, MPI_COMM_WORLD,
+        MPI_Recv(buff, CAPIO_SERVER_REQUEST_MAX_SIZE, MPI_CHAR, MPI_ANY_SOURCE, 0, MPI_COMM_WORLD,
                  &status); // receive from server
 #else
         LOG("initiating a lightweight MPI receive");
@@ -80,7 +80,7 @@ class MPI_backend : public backend_interface {
         int received = 0;
 
         // receive from server
-        MPI_Irecv(buff, SERVER_MAX_REMOTE_REQUEST_SIZE, MPI_CHAR, MPI_ANY_SOURCE, 0, MPI_COMM_WORLD,
+        MPI_Irecv(buff, CAPIO_SERVER_REQUEST_MAX_SIZE, MPI_CHAR, MPI_ANY_SOURCE, 0, MPI_COMM_WORLD,
                   &request);
         struct timespec sleepTime {};
         struct timespec returnTime {};

--- a/src/server/communication_service/remote_listener.hpp
+++ b/src/server/communication_service/remote_listener.hpp
@@ -71,7 +71,7 @@ void solve_remote_reads(size_t bytes_received, size_t offset, size_t file_size, 
             }
             if (is_getdent) {
                 off64_t dir_size  = c_file.get_stored_size();
-                off64_t n_entries = dir_size / THEORETICAL_SIZE_DIRENT64;
+                off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
                 char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
                 end_of_sector     = store_dirent(p, p_getdents, dir_size);
                 write_response(tid, end_of_sector);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -33,7 +33,7 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
     }
     if (is_getdents) {
         off64_t dir_size  = c_file.get_stored_size();
-        off64_t n_entries = dir_size / THEORETICAL_SIZE_DIRENT64;
+        off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
         char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
         end_of_sector     = store_dirent(p, p_getdents, dir_size);
         write_response(tid, end_of_sector);
@@ -75,7 +75,7 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool dir, bool is_
             char *p = c_file.get_buffer();
             if (is_getdents || dir) {
                 off64_t dir_size  = c_file.get_stored_size();
-                off64_t n_entries = dir_size / THEORETICAL_SIZE_DIRENT64;
+                off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
                 char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
                 end_of_sector     = store_dirent(p, p_getdents, dir_size);
                 write_response(tid, end_of_sector);
@@ -94,7 +94,7 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool dir, bool is_
         bytes_read = count;
         if (is_getdents) {
             off64_t dir_size  = c_file.get_stored_size();
-            off64_t n_entries = dir_size / THEORETICAL_SIZE_DIRENT64;
+            off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
             char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
             end_of_sector     = store_dirent(p, p_getdents, dir_size);
             write_response(tid, end_of_read);

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -13,8 +13,8 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count, in
     Capio_file &c_file    = init_capio_file(path.data(), true);
     size_t file_shm_size  = c_file.get_buf_size();
     auto *data_buf        = data_buffers[tid].first;
-    size_t n_reads        = count / WINDOW_DATA_BUFS;
-    size_t r              = count % WINDOW_DATA_BUFS;
+    size_t n_reads        = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
+    size_t r              = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
     size_t i              = 0;
     char *p;
     if (data_size > file_shm_size) {
@@ -23,11 +23,11 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count, in
     p = c_file.get_buffer();
     p = p + base_offset;
     while (i < n_reads) {
-        data_buf->read(p + i * WINDOW_DATA_BUFS);
+        data_buf->read(p + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
         ++i;
     }
     if (r) {
-        data_buf->read(p + i * WINDOW_DATA_BUFS, r);
+        data_buf->read(p + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
     }
     int pid                   = pids[tid];
     writers[pid][path.data()] = true;

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -20,12 +20,12 @@ inline off64_t store_dirent(char *incoming, char *target_buffer, off64_t incomin
     struct linux_dirent64 to_store {};
     struct linux_dirent64 *dir_entity;
 
-    to_store.d_reclen = THEORETICAL_SIZE_DIRENT64;
+    to_store.d_reclen = CAPIO_THEORETICAL_SIZE_DIRENT64;
     while (i < incoming_size) {
         dir_entity = (struct linux_dirent64 *) (incoming + i);
 
         to_store.d_ino  = dir_entity->d_ino;
-        to_store.d_off  = stored_size + THEORETICAL_SIZE_DIRENT64;
+        to_store.d_off  = stored_size + CAPIO_THEORETICAL_SIZE_DIRENT64;
         to_store.d_type = dir_entity->d_type;
 
         strcpy(to_store.d_name, dir_entity->d_name);
@@ -33,7 +33,7 @@ inline off64_t store_dirent(char *incoming, char *target_buffer, off64_t incomin
 
         LOG("DIRENT NAME: %s - TARGET NAME: %s", dir_entity->d_name, to_store.d_name);
 
-        i += THEORETICAL_SIZE_DIRENT64;
+        i += CAPIO_THEORETICAL_SIZE_DIRENT64;
         stored_size += to_store.d_reclen;
     }
 

--- a/src/server/utils/env.hpp
+++ b/src/server/utils/env.hpp
@@ -14,7 +14,7 @@ off64_t get_file_initial_size() {
         if (val != nullptr) {
             file_initial_size = std::strtol(val, nullptr, 10);
         } else {
-            file_initial_size = DEFAULT_FILE_INITIAL_SIZE;
+            file_initial_size = CAPIO_DEFAULT_FILE_INITIAL_SIZE;
         }
     }
 

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -84,7 +84,7 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path, const std:
 
     strcpy(ld.d_name, file_name.c_str());
     LOG("FILENAME LD: %s", ld.d_name);
-    long int ld_size = THEORETICAL_SIZE_DIRENT64;
+    long int ld_size = CAPIO_THEORETICAL_SIZE_DIRENT64;
     ld.d_reclen      = ld_size;
 
     Capio_file &c_file   = init_capio_file(dir.c_str(), true);
@@ -138,7 +138,7 @@ off64_t create_dir(int tid, const char *pathname, int rank, bool root_dir) {
               root_dir ? "true" : "false");
 
     if (!get_file_location_opt(pathname)) {
-        Capio_file &c_file = create_capio_file(pathname, true, DIR_INITIAL_SIZE);
+        Capio_file &c_file = create_capio_file(pathname, true, CAPIO_DEFAULT_DIR_INITIAL_SIZE);
         if (c_file.first_write) {
             c_file.first_write = false;
             // TODO: it works only if there is one prod per file

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -19,7 +19,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
     try {
         json = simdjson::padded_string::load(conf_file);
     } catch (const simdjson::simdjson_error &e) {
-        std::cerr << CAPIO_SERVER_CLI_LOG_SERVER_ERROR
+        std::cerr << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                   << "Exception thrown while opening config file: " << e.what() << std::endl;
         ERR_EXIT("Exception thrown while opening config file: %s", e.what());
     }
@@ -27,7 +27,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
     entries                              = parser.iterate(json);
     const std::string_view workflow_name = entries["name"].get_string();
 
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
               << "Parsing configuration for workflow: " << workflow_name << std::endl;
 
     auto io_graph = entries["IO_Graph"];
@@ -35,30 +35,30 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
     for (auto app : io_graph) {
         std::string_view app_name = app["name"].get_string();
 
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "Parsing config for app " << app_name
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Parsing config for app " << app_name
                   << std::endl;
 
         if (app["input_stream"].get_array().get(input_stream)) {
-            std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No input_stream section found for app " << app_name << std::endl;
         } else {
             // TODO: parse input_stream
-            std::cout << CAPIO_SERVER_CLI_LOG_SERVER
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "Completed input_stream parsing for app: " << app_name << std::endl;
         }
 
         if (app["output_stream"].get_array().get(output_stream)) {
-            std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No output_stream section found for app " << app_name << std::endl;
         } else {
             // TODO: parse output stream
-            std::cout << CAPIO_SERVER_CLI_LOG_SERVER
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "Completed output_stream parsing for app: " << app_name << std::endl;
         }
 
         // PARSING STREAMING FILES
         if (app["streaming"].get_array().get(streaming)) {
-            std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No streaming section found for app: " << app_name << std::endl;
         } else {
             for (auto file : streaming) {
@@ -76,7 +76,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                     if (pos != -1) {
                         commit_rule = committed_str.substr(0, pos);
                         if (commit_rule != CAPIO_FILE_MODE_ON_CLOSE) {
-                            std::cout << CAPIO_SERVER_CLI_LOG_SERVER_ERROR << "commit rule "
+                            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "commit rule "
                                       << commit_rule << std::endl;
                             ERR_EXIT("error conf file");
                         }
@@ -85,7 +85,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                             committed_str.substr(pos + 1, committed_str.length());
 
                         if (!is_int(n_close_str)) {
-                            std::cout << CAPIO_SERVER_CLI_LOG_SERVER_ERROR
+                            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                                       << "commit rule on_close invalid number" << std::endl;
                             ERR_EXIT("error conf file");
                         }
@@ -94,7 +94,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                         commit_rule = std::string(committed);
                     }
                 } else {
-                    std::cout << CAPIO_SERVER_CLI_LOG_SERVER_ERROR
+                    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                               << "commit rule is mandatory in streaming section" << std::endl;
                     ERR_EXIT("error conf file");
                 }
@@ -121,7 +121,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                                      std::string(mode), std::string(app_name), false, n_close);
             }
 
-            std::cout << CAPIO_SERVER_CLI_LOG_SERVER
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "completed parsing of streaming section for app: " << app_name
                       << std::endl;
         } // END PARSING STREAMING FILES
@@ -130,7 +130,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
 
     long int batch_size = 0;
     if (entries["permanent"].get_array().get(permanent_files)) { // PARSING PERMANENT FILES
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                   << "No permanent section found for workflow: " << workflow_name << std::endl;
     } else {
         for (auto file : permanent_files) {
@@ -165,11 +165,11 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                 }
             }
         }
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "Completed parsing of permanent files"
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Completed parsing of permanent files"
                   << std::endl;
     } // END PARSING PERMANENT FILES
 
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "Completed parsing of io_graph" << std::endl;
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Completed parsing of io_graph" << std::endl;
 }
 
 #endif // CAPIO_SERVER_UTILS_JSON_HPP

--- a/src/server/utils/metadata.hpp
+++ b/src/server/utils/metadata.hpp
@@ -134,7 +134,7 @@ Capio_file &create_capio_file(const std::string &path, bool is_dir, size_t init_
         long int pos = match_globs(path);
         if (pos == -1) {
             if (is_dir) {
-                init_size = DIR_INITIAL_SIZE;
+                init_size = CAPIO_DEFAULT_DIR_INITIAL_SIZE;
             }
             c_file = new Capio_file(is_dir, false, init_size);
             add_capio_file(path, c_file);
@@ -146,7 +146,7 @@ Capio_file &create_capio_file(const std::string &path, bool is_dir, size_t init_
                 n_files = 0;
             }
             if (n_files > 0) {
-                init_size = DIR_INITIAL_SIZE;
+                init_size = CAPIO_DEFAULT_DIR_INITIAL_SIZE;
                 is_dir    = true;
             }
             metadata_conf[path] =
@@ -160,7 +160,7 @@ Capio_file &create_capio_file(const std::string &path, bool is_dir, size_t init_
         auto &[committed, mode, app_name, n_files, permanent, n_close] = it->second;
         if (n_files > 0) {
             is_dir    = true;
-            init_size = DIR_INITIAL_SIZE;
+            init_size = CAPIO_DEFAULT_DIR_INITIAL_SIZE;
         }
         c_file = new Capio_file(committed, mode, is_dir, n_files, permanent, init_size, n_close);
         add_capio_file(path, c_file);

--- a/src/server/utils/requests.hpp
+++ b/src/server/utils/requests.hpp
@@ -16,7 +16,7 @@ CSBufResponse_t *bufs_response;
 inline void init_server() {
     // TODO: replace number with constexpr
     buf_requests  = new CSBufRequest_t("circular_buffer", 1024 * 1024, CAPIO_REQUEST_MAX_SIZE,
-                                       CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_RETRIES);
+                                       CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     bufs_response = new CSBufResponse_t();
 }
 
@@ -26,14 +26,14 @@ inline void init_server() {
  */
 inline void destroy_server() {
     buf_requests->free_shm();
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING << "buf_requests cleanup completed"
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "buf_requests cleanup completed"
               << std::endl;
 
     for (auto &pair : *bufs_response) {
         pair.second->free_shm();
         delete pair.second;
     }
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING << "buf_response cleanup completed"
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "buf_response cleanup completed"
               << std::endl;
 }
 
@@ -46,7 +46,7 @@ inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
     auto *p_buf_response =
         new Circular_buffer<off_t>("buf_response_" + std::to_string(tid), 8 * 1024 * 1024,
-                                   sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_RETRIES);
+                                   sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 

--- a/src/server/utils/signals.hpp
+++ b/src/server/utils/signals.hpp
@@ -7,10 +7,10 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     START_LOG(gettid(), "call(signal=[%d] %s)", signum, strsignal(signum));
 
     std::cout << std::endl
-              << CAPIO_SERVER_CLI_LOG_SERVER_WARNING << "shutting down server" << std::endl;
+              << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "shutting down server" << std::endl;
 
     if (signum == SIGSEGV) {
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER_ERROR << "Segfault detected!" << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Segfault detected!" << std::endl;
     }
 
     // free all the memory used
@@ -19,18 +19,18 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
             delete_capio_file_from_tid(it.first, fd);
         }
     }
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING << "shm cleanup completed" << std::endl;
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "shm cleanup completed" << std::endl;
 
     for (auto &p : data_buffers) {
         p.second.first->free_shm();
         p.second.second->free_shm();
     }
 
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER_WARNING << "data_buffers cleanup completed"
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "data_buffers cleanup completed"
               << std::endl;
 
     destroy_server();
-    std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "shutdown completed" << std::endl;
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "shutdown completed" << std::endl;
     MPI_Finalize();
     exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
This commit adds support for forbidden paths for the `CAPIO_DIR`, which result in early exit of CAPIO logic without memory allocations. This is crucial to support those (rare) cases when `malloc` and other primitive libc functions read the file system.

In addition, this commit uniforms the CAPIO constants names and reorders them in the `constants.hpp` file to improve code readability.