### PR TITLE
Fixed code for multinode

### DIFF
--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -28,6 +28,7 @@ constexpr size_t CAPIO_REQUEST_MAX_SIZE        = 256 * sizeof(char);
 
 // CAPIO streaming semantics
 constexpr char CAPIO_FILE_MODE_NO_UPDATE[]      = "no_update";
+constexpr char CAPIO_FILE_MODE_UPDATE[]         = "update";
 constexpr char CAPIO_FILE_MODE_ON_CLOSE[]       = "on_close";
 constexpr char CAPIO_FILE_MODE_ON_TERMINATION[] = "on_termination";
 

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -17,7 +17,7 @@
 #endif
 
 #ifndef __CAPIO_POSIX
-static thread_local std::ofstream logfile; // if building for server, self contained logfile
+std::ofstream logfile; // if building for server, self contained logfile
 #else
 FILE *logfileFP;
 bool logfileOpen = false;
@@ -82,12 +82,9 @@ class Logger {
         if (!logfile.is_open()) {
             // NOTE: should never get to this point as capio_server opens up the log file while
             // parsing command line arguments. This is only for failsafe purpose
-            auto hostname = new char[HOST_NAME_MAX];
-            gethostname(hostname, HOST_NAME_MAX);
-            logfile.open(std::string(CAPIO_LOG_SERVER_DEFAULT_FILE_NAME) + hostname + "-" +
-                             std::to_string(capio_syscall(SYS_gettid)) + ".log",
+            logfile.open(std::string(CAPIO_LOG_SERVER_DEFAULT_FILE_NAME) + std::to_string(tid) +
+                             ".log",
                          std::ofstream::out);
-            delete[] hostname;
         }
 #else
         if (!logfileOpen) {

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -17,7 +17,7 @@
 #endif
 
 #ifndef __CAPIO_POSIX
-std::ofstream logfile; // if building for server, self contained logfile
+static thread_local std::ofstream logfile; // if building for server, self contained logfile
 #else
 FILE *logfileFP;
 bool logfileOpen = false;
@@ -71,7 +71,6 @@ class SyscallLoggingSuspender {
 
 class Logger {
   private:
-    long int tid;
     char invoker[256]{0};
     char file[256]{0};
     char format[CAPIO_LOG_MAX_MSG_LEN]{0};
@@ -85,7 +84,8 @@ class Logger {
             // parsing command line arguments. This is only for failsafe purpose
             auto hostname = new char[HOST_NAME_MAX];
             gethostname(hostname, HOST_NAME_MAX);
-            logfile.open(std::string(CAPIO_LOG_SERVER_DEFAULT_FILE_NAME) + hostname + ".log",
+            logfile.open(std::string(CAPIO_LOG_SERVER_DEFAULT_FILE_NAME) + hostname + "-" +
+                             std::to_string(capio_syscall(SYS_gettid)) + ".log",
                          std::ofstream::out);
             delete[] hostname;
         }
@@ -103,11 +103,10 @@ class Logger {
 #endif
         strncpy(this->invoker, invoker, sizeof(this->invoker));
         strncpy(this->file, file, sizeof(this->file));
-        this->tid = tid;
 
         va_list argp, argpc;
 
-        sprintf(format, CAPIO_LOG_PRE_MSG, this->tid, this->invoker);
+        sprintf(format, CAPIO_LOG_PRE_MSG, capio_syscall(SYS_gettid), this->invoker);
         size_t pre_msg_len = strlen(format);
 
         strcpy(format + pre_msg_len, message);
@@ -143,7 +142,7 @@ class Logger {
     inline void log(const char *message, ...) {
         va_list argp, argpc;
 
-        sprintf(format, CAPIO_LOG_PRE_MSG, this->tid, this->invoker);
+        sprintf(format, CAPIO_LOG_PRE_MSG, capio_syscall(SYS_gettid), this->invoker);
         size_t pre_msg_len = strlen(format);
 
         strcpy(format + pre_msg_len, message);
@@ -155,7 +154,7 @@ class Logger {
              strcmp(CAPIO_LOG_SERVER_REQUEST_END, message) == 0)) {
             auto buf1 = reinterpret_cast<char *>(capio_syscall(
                 SYS_mmap, nullptr, 50, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-            sprintf(buf1, message, this->tid);
+            sprintf(buf1, message, capio_syscall(SYS_gettid));
             logfile << buf1 << std::endl;
             capio_syscall(SYS_munmap, buf1, 50);
             return;
@@ -179,7 +178,7 @@ class Logger {
 
     inline ~Logger() {
         current_log_level--;
-        sprintf(format, CAPIO_LOG_PRE_MSG, this->tid, this->invoker);
+        sprintf(format, CAPIO_LOG_PRE_MSG, capio_syscall(SYS_gettid), this->invoker);
         size_t pre_msg_len = strlen(format);
         strcpy(format + pre_msg_len, "returned");
 
@@ -188,7 +187,7 @@ class Logger {
         if (current_log_level == 0 && logging_syscall) {
             auto buf1 = reinterpret_cast<char *>(capio_syscall(
                 SYS_mmap, nullptr, 50, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-            sprintf(buf1, CAPIO_LOG_POSIX_SYSCALL_END, this->tid);
+            sprintf(buf1, CAPIO_LOG_POSIX_SYSCALL_END, capio_syscall(SYS_gettid));
             log_write_to(buf1, strlen(buf1));
             capio_syscall(SYS_munmap, buf1, 50);
         }

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -43,18 +43,21 @@ inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, 
         bool create = (flags & O_CREAT) == O_CREAT;
         bool excl   = (flags & O_EXCL) == O_EXCL;
         if (excl) {
+            LOG("excl");
             off64_t return_code = create_exclusive_request(fd, path, tid);
             if (return_code == 1) {
                 errno = EEXIST;
                 return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else if (create) {
+            LOG("create");
             off64_t return_code = create_request(fd, path, tid);
             if (return_code == 1) {
                 errno = ENOENT;
                 return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else {
+            LOG("!excl && !create");
             off64_t return_code = open_request(fd, path, tid);
             if (return_code == 1) {
                 errno = ENOENT;

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -190,16 +190,12 @@ int parseCLI(int argc, char **argv, int rank) {
             token.erase(token.length() - 4); // delete .log if for some reason
             // is given as parameter
         }
-        auto hostname = new char[HOST_NAME_MAX];
-        gethostname(hostname, HOST_NAME_MAX);
 
-        std::string filename =
-            token + "_" + hostname + "-" + std::to_string(capio_syscall(SYS_gettid)) + +".log";
+        std::string filename = token + "-" + std::to_string(capio_syscall(SYS_gettid)) + +".log";
         logfile.open(filename, std::ofstream::out);
         log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to: " << filename
                   << std::endl;
-        delete[] hostname;
 #else
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                   << "Capio logfile provided, but logging capabilities not compiled into capio!"
@@ -209,7 +205,7 @@ int parseCLI(int argc, char **argv, int rank) {
 #ifdef CAPIOLOG
         // log file not given. starting with default name
         const std::string logname =
-            CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::to_string(capio_syscall(SYS_gettid)) + ".log";
+            CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::to_string(rank) + ".log";
         logfile.open(logname, std::ofstream::out);
         log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to default logfile "

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -284,7 +284,9 @@ int main(int argc, char **argv) {
         ERR_EXIT("sem_init clients_remote_pending_nfiles_sem in main");
     }
     std::thread server_thread(capio_server, rank);
-    std::thread helper_thread(capio_remote_listener);
+    LOG("capio_server thread started");
+    std::thread helper_thread(capio_remote_listener, rank);
+    LOG("capio_remote_listener thread started.");
     server_thread.join();
     helper_thread.join();
 

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -193,7 +193,8 @@ int parseCLI(int argc, char **argv, int rank) {
         auto hostname = new char[HOST_NAME_MAX];
         gethostname(hostname, HOST_NAME_MAX);
 
-        std::string filename = token + "_" + hostname + ".log";
+        std::string filename =
+            token + "_" + hostname + "-" + std::to_string(capio_syscall(SYS_gettid)) + +".log";
         logfile.open(filename, std::ofstream::out);
         log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to: " << filename
@@ -210,8 +211,8 @@ int parseCLI(int argc, char **argv, int rank) {
         auto hostname = new char[HOST_NAME_MAX];
         gethostname(hostname, HOST_NAME_MAX);
 
-        const std::string logname =
-            CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::string(hostname) + ".log";
+        const std::string logname = CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::string(hostname) +
+                                    "-" + std::to_string(capio_syscall(SYS_gettid)) + ".log";
         logfile.open(logname, std::ofstream::out);
         log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to default logfile "

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -208,16 +208,12 @@ int parseCLI(int argc, char **argv, int rank) {
     } else {
 #ifdef CAPIOLOG
         // log file not given. starting with default name
-        auto hostname = new char[HOST_NAME_MAX];
-        gethostname(hostname, HOST_NAME_MAX);
-
-        const std::string logname = CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::string(hostname) +
-                                    "-" + std::to_string(capio_syscall(SYS_gettid)) + ".log";
+        const std::string logname =
+            CAPIO_LOG_SERVER_DEFAULT_FILE_NAME + std::to_string(capio_syscall(SYS_gettid)) + ".log";
         logfile.open(logname, std::ofstream::out);
         log = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to default logfile "
                   << logname << std::endl;
-        delete[] hostname;
 #endif
     }
 

--- a/src/server/comm/backends/mpi.hpp
+++ b/src/server/comm/backends/mpi.hpp
@@ -96,7 +96,7 @@ class MPI_backend : public backend_interface {
     }
 
     void send_file(char *shm, long int nbytes, int dest) override {
-        START_LOG(gettid(), "call(%s), %ld, %d", shm, nbytes, dest);
+        START_LOG(gettid(), "call(%s, %ld, %d)", shm, nbytes, dest);
 
         long int elem_to_snd = 0;
 
@@ -104,7 +104,9 @@ class MPI_backend : public backend_interface {
             (nbytes - k > MPI_MAX_ELEM_COUNT) ? elem_to_snd = MPI_MAX_ELEM_COUNT
                                               : elem_to_snd = nbytes - k;
 
+            LOG("Sending %d bytes to %d", elem_to_snd, dest);
             MPI_Isend(shm + k, elem_to_snd, MPI_BYTE, dest, 0, MPI_COMM_WORLD, &req);
+            LOG("Sent chunk of %d bytes", elem_to_snd);
         }
     }
 
@@ -191,6 +193,7 @@ class MPI_backend : public backend_interface {
         if (c_file.is_complete() &&
             (end_of_read <= end_of_sector ||
              (end_of_sector == -1 ? 0 : end_of_sector) == c_file.real_file_size)) {
+            LOG("Handling local read");
             handle_local_read(tid, fd, count, dir, is_getdents, true);
             return;
         }
@@ -198,6 +201,7 @@ class MPI_backend : public backend_interface {
         if (read_from_local_mem(tid, process_offset, end_of_read, end_of_sector, count,
                                 path.data())) {
             // it means end_of_read < end_of_sector
+            LOG("end_of_read < end_of_sector");
             return;
         }
 
@@ -209,7 +213,7 @@ class MPI_backend : public backend_interface {
         auto message = std::to_string(CAPIO_SERVER_REQUEST_READ) + " " + std::string(path) + " " +
                        std::to_string(rank) + " " + std::to_string(offset) + " " +
                        std::to_string(count);
-
+        LOG("Message = %s", message.c_str());
         MPI_Send(message.c_str(), message.length() + 1, MPI_CHAR, dest, 0, MPI_COMM_WORLD);
         (*pending_remote_reads)[path.data()].emplace_back(tid, fd, count, is_getdents);
     }
@@ -263,16 +267,18 @@ class MPI_backend : public backend_interface {
     }
 
     inline void recv_file(char *shm, int source, long int bytes_expected) override {
-        START_LOG(gettid(), "call(%ld, %d, %ld)", shm, source, bytes_expected);
+        START_LOG(gettid(), "call(shm=%ld, source=%d, length=%ld)", shm, source, bytes_expected);
         MPI_Status status;
         int bytes_received, count;
 
         for (long int k = 0; k < bytes_expected; k += bytes_received) {
             (bytes_expected - k > MPI_MAX_ELEM_COUNT) ? count = MPI_MAX_ELEM_COUNT
                                                       : count = bytes_expected - k;
-
+            LOG("Expected %ld bytes from %d", count, source);
             MPI_Recv(shm + k, count, MPI_BYTE, source, 0, MPI_COMM_WORLD, &status);
+            LOG("Received chunk");
             MPI_Get_count(&status, MPI_BYTE, &bytes_received);
+            LOG("Chunk size is %ld bytes", bytes_received);
         }
     }
 

--- a/src/server/comm/backends/mpi.hpp
+++ b/src/server/comm/backends/mpi.hpp
@@ -255,8 +255,10 @@ class MPI_backend : public backend_interface {
         auto dest = nodes_helper_rank[std::get<0>(get_file_location(path.c_str()))];
         auto msg =
             std::to_string(CAPIO_SERVER_REQUEST_STAT) + " " + std::to_string(rank) + " " + path;
+        LOG("destination=%d, message=%s", dest, msg.c_str());
 
         MPI_Send(msg.c_str(), msg.length() + 1, MPI_CHAR, dest, 0, MPI_COMM_WORLD);
+        LOG("message sent");
         (*pending_remote_stats)[path].emplace_back(tid);
     }
 

--- a/src/server/comm/backends/mpi.hpp
+++ b/src/server/comm/backends/mpi.hpp
@@ -103,7 +103,7 @@ class MPI_backend : public backend_interface {
         int elem_to_snd = 0;
 
         for (long int k = 0; k < nbytes; k += elem_to_snd) {
-            //Compute the maximum amount to send for this chunk
+            // Compute the maximum amount to send for this chunk
             elem_to_snd = static_cast<int>(std::min(nbytes - k, MPI_MAX_ELEM_COUNT));
 
             LOG("Sending %d bytes to %d with offset from beginning odf k=%ld", elem_to_snd, dest,

--- a/src/server/comm/backends/mpi.hpp
+++ b/src/server/comm/backends/mpi.hpp
@@ -188,7 +188,7 @@ class MPI_backend : public backend_interface {
         off64_t end_of_read    = process_offset + count;
         off64_t end_of_sector  = c_file.get_sector_end(process_offset);
 
-        if (c_file.complete &&
+        if (c_file.is_complete() &&
             (end_of_read <= end_of_sector ||
              (end_of_sector == -1 ? 0 : end_of_sector) == c_file.real_file_size)) {
             handle_local_read(tid, fd, count, dir, is_getdents, true);

--- a/src/server/comm/backends/mpi.hpp
+++ b/src/server/comm/backends/mpi.hpp
@@ -103,12 +103,8 @@ class MPI_backend : public backend_interface {
         int elem_to_snd = 0;
 
         for (long int k = 0; k < nbytes; k += elem_to_snd) {
-
-            if (nbytes - k > MPI_MAX_ELEM_COUNT) {
-                elem_to_snd = static_cast<int>(MPI_MAX_ELEM_COUNT);
-            } else {
-                elem_to_snd = static_cast<int>(nbytes - k);
-            }
+            //Compute the maximum amount to send for this chunk
+            elem_to_snd = static_cast<int>(std::min(nbytes - k, MPI_MAX_ELEM_COUNT));
 
             LOG("Sending %d bytes to %d with offset from beginning odf k=%ld", elem_to_snd, dest,
                 k);
@@ -283,11 +279,7 @@ class MPI_backend : public backend_interface {
                            : "NO! a nullptr was given to receive. this will make mpi crash!");
         for (long int k = 0; k < bytes_expected; k += bytes_received) {
 
-            if (bytes_expected - k > MPI_MAX_ELEM_COUNT) {
-                count = static_cast<int>(MPI_MAX_ELEM_COUNT);
-            } else {
-                count = static_cast<int>(bytes_expected - k);
-            }
+            count = static_cast<int>(std::min(bytes_expected - k, MPI_MAX_ELEM_COUNT));
 
             LOG("Expected %ld bytes from %d with offset from beginning odf k=%ld", count, source,
                 k);

--- a/src/server/comm/remote_listener.hpp
+++ b/src/server/comm/remote_listener.hpp
@@ -38,7 +38,7 @@ void wait_for_data(char *const path, off64_t offset, int dest, off64_t nbytes,
               nbytes);
 
     SEM_WAIT_CHECK(data_is_available, "data_is_available");
-    backend->serve_remote_read(path, dest, offset, nbytes, get_capio_file(path).complete);
+    backend->serve_remote_read(path, dest, offset, nbytes, get_capio_file(path).is_complete());
 
     delete data_is_available;
     delete[] path;
@@ -53,7 +53,7 @@ void wait_for_stat(int tid, const std::string &path, int rank,
     // check if the file is local or remote
     Capio_file &c_file = get_capio_file(path.c_str());
 
-    if (c_file.complete || c_file.get_mode() == CAPIO_FILE_MODE_NO_UPDATE ||
+    if (c_file.is_complete() || c_file.get_mode() == CAPIO_FILE_MODE_NO_UPDATE ||
         strcmp(std::get<0>(get_file_location(path.c_str())), node_name) == 0) {
 
         write_response(tid, c_file.get_file_size());
@@ -80,7 +80,7 @@ void wait_for_file(int tid, int fd, off64_t count, bool dir, bool is_getdents, i
         handle_local_read(tid, fd, count, dir, is_getdents, false);
     } else {
         Capio_file &c_file = get_capio_file(path_to_check);
-        if (!c_file.complete) {
+        if (!c_file.is_complete()) {
             auto remote_app = apps.find(tid);
 
             if (remote_app != apps.end()) {
@@ -115,7 +115,7 @@ void solve_remote_reads(size_t bytes_received, size_t offset, size_t file_size, 
     Capio_file &c_file    = get_capio_file(path_c);
     c_file.real_file_size = file_size;
     c_file.insert_sector(offset, offset + bytes_received);
-    c_file.complete = complete;
+    c_file.set_complete(complete);
     std::string path(path_c);
     const std::lock_guard<std::mutex> lg(*pending_remote_reads_mutex);
     std::list<std::tuple<int, int, long int, bool>> &list_remote_reads =
@@ -195,7 +195,7 @@ std::vector<std::string> *files_available(const std::string &prefix, const std::
 
     if (capio_file_opt) {
         Capio_file &c_file = capio_file_opt->get();
-        if (c_file.complete) {
+        if (c_file.is_complete()) {
             files_to_send->emplace_back(path_file);
             files.insert(path_file);
         }
@@ -211,7 +211,7 @@ std::vector<std::string> *files_available(const std::string &prefix, const std::
             path.compare(0, prefix.length(), prefix) == 0) {
 
             Capio_file &c_file = get_capio_file(path.data());
-            if (c_file.complete && !c_file.is_dir()) {
+            if (c_file.is_complete() && !c_file.is_dir()) {
                 files_to_send->emplace_back(path.data());
                 files.insert(path.data());
             }
@@ -256,9 +256,9 @@ void recv_nfiles(RemoteRequest *request, void *arg1, void *arg2) {
             p_shm              = new char[file_size];
             Capio_file &c_file = create_capio_file(path, false, file_size);
             c_file.insert_sector(0, file_size);
-            c_file.complete       = true;
             c_file.real_file_size = file_size;
             c_file.first_write    = false;
+            c_file.set_complete();
         }
         backend->recv_file((char *) p_shm, source, file_size);
     }
@@ -277,8 +277,8 @@ void remote_listener_handle_stat_reply(RemoteRequest *request, void *arg1, void 
 
     char *path_c = new char[1024];
     off64_t size;
-    int dir, trash;
-    sscanf(request->getRequest(), "%d %s %ld %d", &trash, path_c, &size, &dir);
+    int dir;
+    sscanf(request->getRequest(), "%s %ld %d", path_c, &size, &dir);
     stat_reply_request(path_c, size, dir);
     delete[] path_c;
 }
@@ -292,7 +292,7 @@ void remote_listener_stat_req(RemoteRequest *request, void *arg1, void *arg2) {
     sscanf(buf_recv, "%d %s", &dest, path_c);
 
     Capio_file &c_file = get_capio_file(path_c);
-    if (c_file.complete) {
+    if (c_file.is_complete()) {
         LOG("file is complete. serving file");
         backend->serve_remote_stat(path_c, dest, c_file);
     } else { // wait for completion
@@ -316,8 +316,7 @@ void remote_listener_nreads_req(RemoteRequest *request, void *arg1, void *arg2) 
     auto app_name  = new char[512];
     std::size_t n_files;
     auto sem = new sem_t;
-    int trash;
-    sscanf(request->getRequest(), "%d %zu %s %s %s", &trash, &n_files, app_name, prefix, path_file);
+    sscanf(request->getRequest(), "%zu %s %s %s", &n_files, app_name, prefix, path_file);
     n_files = find_batch_size(prefix, metadata_conf_globs);
 
     SEM_WAIT_CHECK(&clients_remote_pending_nfiles_sem, "clients_remote_pending_nfiles_sem");
@@ -356,16 +355,16 @@ void remote_listener_remote_read(RemoteRequest *request, void *arg1, void *arg2)
     START_LOG(gettid(), "call()");
     auto path_c = new char[PATH_MAX];
 
-    int dest, trash;
+    int dest;
     long int offset, nbytes;
-    sscanf(request->getRequest(), "%d %s %d %ld %ld", &trash, path_c, &dest, &offset, &nbytes);
+    sscanf(request->getRequest(), "%s %d %ld %ld", path_c, &dest, &offset, &nbytes);
 
     // check if the data is available
     Capio_file &c_file = get_capio_file(path_c);
 
     bool data_available = (offset + nbytes <= c_file.get_stored_size());
-    if (c_file.complete || (c_file.get_mode() == CAPIO_FILE_MODE_NO_UPDATE && data_available)) {
-        backend->serve_remote_read(path_c, dest, offset, nbytes, c_file.complete);
+    if (c_file.is_complete() || (c_file.get_mode() == CAPIO_FILE_MODE_NO_UPDATE && data_available)) {
+        backend->serve_remote_read(path_c, dest, offset, nbytes, c_file.is_complete());
     } else {
         auto sem = new sem_t;
 
@@ -382,10 +381,10 @@ void remote_listener_remote_sending(RemoteRequest *request, void *arg1, void *ar
     off64_t bytes_received, offset;
     std::string path;
     path.reserve(1024);
-    int complete_tmp, trash;
+    int complete_tmp;
     size_t file_size;
-    sscanf(request->getRequest(), "%d %s %ld %ld %d %zu", &trash, path.data(), &offset,
-           &bytes_received, &complete_tmp, &file_size);
+    sscanf(request->getRequest(), "%s %ld %ld %d %zu", path.data(), &offset, &bytes_received,
+           &complete_tmp, &file_size);
     bool complete      = complete_tmp;
     void *file_shm     = nullptr;
     Capio_file &c_file = init_capio_file(path.c_str(), file_shm);

--- a/src/server/comm/remote_listener.hpp
+++ b/src/server/comm/remote_listener.hpp
@@ -287,14 +287,16 @@ void remote_listener_stat_req(RemoteRequest *request, void *arg1, void *arg2) {
     const char *buf_recv = request->getRequest();
     START_LOG(gettid(), "call(%s)", buf_recv);
     auto path_c = new char[PATH_MAX];
-    int dest, trash;
+    int dest;
 
-    sscanf(buf_recv, "%d %d %s", &trash, &dest, path_c);
+    sscanf(buf_recv, "%d %s", &dest, path_c);
 
     Capio_file &c_file = get_capio_file(path_c);
     if (c_file.complete) {
+        LOG("file is complete. serving file");
         backend->serve_remote_stat(path_c, dest, c_file);
     } else { // wait for completion
+        LOG("File is not complete. awaiting completion on different thread");
         auto sem = new sem_t;
 
         if (sem_init(sem, 0, 0) == -1) {

--- a/src/server/comm/remote_listener.hpp
+++ b/src/server/comm/remote_listener.hpp
@@ -379,6 +379,7 @@ void remote_listener_remote_read(RemoteRequest *request, void *arg1, void *arg2)
 }
 
 void remote_listener_remote_sending(RemoteRequest *request, void *arg1, void *arg2) {
+    START_LOG(capio_syscall(SYS_gettid), "call(request=%s)", request->getRequest());
     off64_t bytes_received, offset;
     std::string path;
     path.reserve(1024);
@@ -394,7 +395,10 @@ void remote_listener_remote_sending(RemoteRequest *request, void *arg1, void *ar
         auto file_size_recv = offset + bytes_received;
         if (file_size_recv > file_shm_size) {
             file_shm = expand_memory_for_file(path, file_size_recv, c_file);
+        } else {
+            file_shm = c_file.get_buffer();
         }
+
         backend->recv_file((char *) file_shm + offset, request->getSource(), bytes_received);
         bytes_received *= sizeof(char);
     }

--- a/src/server/comm/remote_listener.hpp
+++ b/src/server/comm/remote_listener.hpp
@@ -403,8 +403,8 @@ void remote_listener_remote_sending(RemoteRequest *request, void *arg1, void *ar
                        &pending_remote_reads, &pending_remote_reads_mutex);
 }
 
-void capio_remote_listener() {
-    START_LOG(gettid(), "call()");
+void capio_remote_listener(int rank) {
+    START_LOG(gettid(), "call(rank=%d)", rank);
 
     std::array<CComsHandler_t, CAPIO_SERVER_NR_REQUEST> remote_request_map{};
     remote_request_map[CAPIO_SERVER_REQUEST_READ]    = remote_listener_remote_read;

--- a/src/server/comm/remote_listener.hpp
+++ b/src/server/comm/remote_listener.hpp
@@ -363,7 +363,8 @@ void remote_listener_remote_read(RemoteRequest *request, void *arg1, void *arg2)
     Capio_file &c_file = get_capio_file(path_c);
 
     bool data_available = (offset + nbytes <= c_file.get_stored_size());
-    if (c_file.is_complete() || (c_file.get_mode() == CAPIO_FILE_MODE_NO_UPDATE && data_available)) {
+    if (c_file.is_complete() ||
+        (c_file.get_mode() == CAPIO_FILE_MODE_NO_UPDATE && data_available)) {
         backend->serve_remote_read(path_c, dest, offset, nbytes, c_file.is_complete());
     } else {
         auto sem = new sem_t;

--- a/src/server/handlers/close.hpp
+++ b/src/server/handlers/close.hpp
@@ -16,9 +16,10 @@ inline void handle_close(int tid, int fd, int rank) {
 
     Capio_file &c_file = get_capio_file(path.data());
     c_file.close();
-    if (c_file.get_committed() == "on_close" && c_file.is_closed()) {
+    if (c_file.get_committed() == CAPIO_FILE_MODE_ON_CLOSE && c_file.is_closed()) {
+        LOG("Capio_file is closed and mode is on_close");
         c_file.set_complete();
-        auto it         = pending_reads.find(path.data());
+        auto it = pending_reads.find(path.data());
         if (it != pending_reads.end()) {
             auto &pending_reads_this_file = it->second;
             auto it_vec                   = pending_reads_this_file.begin();
@@ -43,6 +44,7 @@ inline void handle_close(int tid, int fd, int rank) {
         delete_capio_file(path.data());
         delete_from_file_locations(path.data(), rank);
     } else {
+        LOG("Deleting capio file from tid=%d", tid);
         delete_capio_file_from_tid(tid, fd);
     }
 }

--- a/src/server/handlers/close.hpp
+++ b/src/server/handlers/close.hpp
@@ -17,7 +17,7 @@ inline void handle_close(int tid, int fd, int rank) {
     Capio_file &c_file = get_capio_file(path.data());
     c_file.close();
     if (c_file.get_committed() == "on_close" && c_file.is_closed()) {
-        c_file.complete = true;
+        c_file.set_complete();
         auto it         = pending_reads.find(path.data());
         if (it != pending_reads.end()) {
             auto &pending_reads_this_file = it->second;

--- a/src/server/handlers/exig.hpp
+++ b/src/server/handlers/exig.hpp
@@ -4,10 +4,13 @@
 inline void handle_exit_group(int tid, int rank) {
     START_LOG(gettid(), "call(tid=%d, rank=%d)", tid, rank);
 
-    int pid    = pids[tid];
+    LOG("retrieving pid for process with tid = %d", tid);
+    int pid = pids[tid];
+    LOG("retrieving files from writers for process with pid = %d", pid);
     auto files = writers[pid];
     for (auto &pair : files) {
         std::string path = pair.first;
+        LOG("Path %s found. handling? %s", path.c_str(), pair.second ? "yes" : "no");
         if (pair.second) {
             LOG("Handling file %s", path.c_str());
             auto it_conf = metadata_conf.find(path);
@@ -45,6 +48,7 @@ inline void handle_exit_group(int tid, int rank) {
             }
         }
     }
+
     for (auto &fd : get_capio_fds_for_tid(tid)) {
         handle_close(tid, fd, rank);
     }

--- a/src/server/handlers/exig.hpp
+++ b/src/server/handlers/exig.hpp
@@ -9,18 +9,22 @@ inline void handle_exit_group(int tid, int rank) {
     for (auto &pair : files) {
         std::string path = pair.first;
         if (pair.second) {
+            LOG("Handling file %s", path.c_str());
             auto it_conf = metadata_conf.find(path);
             if (it_conf == metadata_conf.end() ||
-                std::get<0>(it_conf->second) == "on_termination" ||
+                std::get<0>(it_conf->second) == CAPIO_FILE_MODE_ON_TERMINATION ||
                 std::get<0>(it_conf->second).empty()) {
                 Capio_file &c_file = get_capio_file(path.c_str());
                 if (c_file.is_dir()) {
+                    LOG("file %s is dir", path.c_str());
                     long int n_committed = c_file.n_files_expected;
                     if (n_committed <= c_file.n_files) {
                         reply_remote_stats(path);
+                        LOG("Setting file %s to complete", path.c_str());
                         c_file.complete = true;
                     }
                 } else {
+                    LOG("Setting file %s to complete", path.c_str());
                     c_file.complete = true;
                     c_file.commit();
                 }
@@ -28,6 +32,7 @@ inline void handle_exit_group(int tid, int rank) {
 
             auto it = pending_reads.find(path);
             if (it != pending_reads.end()) {
+                LOG("Handling pending reads for file %s", path.c_str());
                 auto &pending_reads_this_file = it->second;
                 auto it_vec                   = pending_reads_this_file.begin();
                 while (it_vec != pending_reads_this_file.end()) {

--- a/src/server/handlers/exig.hpp
+++ b/src/server/handlers/exig.hpp
@@ -21,11 +21,11 @@ inline void handle_exit_group(int tid, int rank) {
                     if (n_committed <= c_file.n_files) {
                         reply_remote_stats(path);
                         LOG("Setting file %s to complete", path.c_str());
-                        c_file.complete = true;
+                        c_file.set_complete();
                     }
                 } else {
                     LOG("Setting file %s to complete", path.c_str());
-                    c_file.complete = true;
+                    c_file.set_complete();
                     c_file.commit();
                 }
             }

--- a/src/server/handlers/open.hpp
+++ b/src/server/handlers/open.hpp
@@ -7,8 +7,8 @@
 
 inline void update_file_metadata(const std::string &path, int tid, int fd, int rank,
                                  bool is_creat) {
-    START_LOG(tid, "call(path=%s, fd=%d, rank=%d, is_creat=%s)", path.c_str(), fd, rank,
-              is_creat ? "true" : "false");
+    START_LOG(tid, "call(path=%s, client_tid=%d fd=%d, rank=%d, is_creat=%s)", path.c_str(), tid,
+              fd, rank, is_creat ? "true" : "false");
 
     // TODO: check the size that the user wrote in the configuration file
     //*caching_info[tid].second += 2;
@@ -20,10 +20,12 @@ inline void update_file_metadata(const std::string &path, int tid, int fd, int r
     auto it_files = writers.find(pid);
     if (it_files != writers.end()) {
         if (it_files->second.find(path) == it_files->second.end()) {
+            LOG("setting writers[%ld][%s]=false 1", pid, path.c_str());
             writers[pid][path] = false;
         }
     } else {
-        writers[pid][path] = false;
+        LOG("setting writers[%ld][%s]=true", pid, path.c_str());
+        writers[pid][path] = true;
     }
     if (c_file.first_write && is_creat) {
         c_file.first_write = false;

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -115,20 +115,25 @@ inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getden
     const std::filesystem::path &capio_dir = get_capio_dir();
     bool is_prod                           = is_producer(tid, path.data());
     auto file_location_opt                 = get_file_location_opt(path.data());
-
+    LOG("got to first checkpoint");
     if (!file_location_opt && !is_prod) {
+        LOG("got to second checkpoint");
         bool found = check_file_location(rank, path.data());
         if (!found) {
+            LOG("got to third checkpoint");
             // launch a thread that checks when the file is created
             std::thread t(wait_for_file, tid, fd, count, dir, is_getdents, rank,
                           &pending_remote_reads, &pending_remote_reads_mutex, handle_local_read);
             t.detach();
         }
+        LOG("got to fourth checkpoint");
     }
     if (is_prod || strcmp(std::get<0>(file_location_opt->get()), node_name) == 0 ||
         capio_dir == path) {
+        LOG("got to 5 checkpoint");
         handle_local_read(tid, fd, count, dir, is_getdents, is_prod);
     } else {
+        LOG("got to 6 checkpoint");
         Capio_file &c_file = get_capio_file(path.data());
         if (!c_file.is_complete()) {
             auto it  = apps.find(tid);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -61,10 +61,10 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool dir, bool is_
     off64_t end_of_sector  = c_file.get_sector_end(process_offset);
     off64_t end_of_read    = process_offset + count;
     std::string_view mode  = c_file.get_mode();
-    if (mode != CAPIO_FILE_MODE_NO_UPDATE && !c_file.complete && !writer && !is_prod && !dir) {
+    if (mode != CAPIO_FILE_MODE_NO_UPDATE && !c_file.is_complete() && !writer && !is_prod && !dir) {
         pending_reads[path.data()].emplace_back(tid, fd, count, is_getdents);
     } else if (end_of_read > end_of_sector) {
-        if (!is_prod && !writer && !c_file.complete && !dir) {
+        if (!is_prod && !writer && !c_file.is_complete() && !dir) {
             pending_reads[path.data()].emplace_back(tid, fd, count, is_getdents);
         } else {
             if (end_of_sector == -1) {
@@ -130,7 +130,7 @@ inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getden
         handle_local_read(tid, fd, count, dir, is_getdents, is_prod);
     } else {
         Capio_file &c_file = get_capio_file(path.data());
-        if (!c_file.complete) {
+        if (!c_file.is_complete()) {
             auto it  = apps.find(tid);
             bool res = false;
             if (it != apps.end()) {

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -55,6 +55,8 @@ inline void reply_stat(int tid, const std::string &path, int rank) {
         write_response(tid, static_cast<int>(c_file.is_dir() ? 1 : 0));
     } else {
         LOG("Delegating backend to reply to remote stats");
+        // init a capio file that is remote so that buffer is going to be allocated
+        init_capio_file(path.c_str(), false);
         backend->handle_remote_stat(tid, path, rank, &pending_remote_stats,
                                     &pending_remote_stats_mutex);
     }

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -42,13 +42,12 @@ inline void reply_stat(int tid, const std::string &path, int rank) {
     auto c_file =
         (c_file_opt) ? c_file_opt->get() : create_capio_file(path, false, get_file_initial_size());
     LOG("Obtained capio file. ready to reply to client");
-    std::string_view mode = c_file.get_mode().data();
-    LOG("Mode: %s", mode);
+    std::string_view mode = c_file.get_mode();
+    LOG("Mode: %s", mode.data());
     bool complete = c_file.complete;
     LOG("complete: %s", complete ? "Yes" : "No");
-    bool file_is_local = strcmp(std::get<0>(file_location_opt->get()), node_name) == 0;
-    LOG("file_is_local? %s", file_is_local ? "Yes" : "No");
-    if (complete || file_is_local || mode == CAPIO_FILE_MODE_NO_UPDATE || get_capio_dir() == path) {
+
+    if (complete || !file_is_remote || mode == CAPIO_FILE_MODE_NO_UPDATE || get_capio_dir() == path) {
         LOG("Sending response to client");
         write_response(tid, c_file.get_file_size());
         write_response(tid, static_cast<int>(c_file.is_dir() ? 1 : 0));

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -44,7 +44,7 @@ inline void reply_stat(int tid, const std::string &path, int rank) {
     LOG("Obtained capio file. ready to reply to client");
     std::string_view mode = c_file.get_mode();
     LOG("Mode: %s", mode.data());
-    bool complete = c_file.complete;
+    bool complete = c_file.is_complete();
     LOG("complete: %s", complete ? "Yes" : "No");
 
     if (complete || !file_is_remote || mode == CAPIO_FILE_MODE_NO_UPDATE || get_capio_dir() == path) {

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -20,6 +20,7 @@ inline void reply_stat(int tid, const std::string &path, int rank) {
 
     auto file_location_opt = get_file_location_opt(path.c_str());
     if (!file_location_opt) {
+        LOG("get_file_location_opt returned an empty object!");
         check_file_location(rank, path);
         // if it is in configuration file then wait otherwise fails
         if ((metadata_conf.find(path) != metadata_conf.end() || match_globs(path) != -1) &&

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -93,11 +93,7 @@ class Capio_file {
         }
     }
 
-    inline void set_complete() {
-        START_LOG(capio_syscall(SYS_gettid), "Setting capio_file to complete");
-        this->complete = true;
-    }
-    inline void set_complete(bool _complete) {
+    inline void set_complete(bool _complete = true) {
         START_LOG(capio_syscall(SYS_gettid), "setting capio_file.complete=%s",
                   _complete ? "true" : "false");
         this->complete = _complete;

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -31,12 +31,12 @@ class Capio_file {
   private:
     char *_buf = nullptr; // buffer containing the data
     std::size_t _buf_size;
-    std::string_view _committed = CAPIO_FILE_MODE_NO_UPDATE;
+    std::string_view _committed = CAPIO_FILE_MODE_UPDATE;
     bool _directory             = false;
     // _fd is useful only when the file is memory-mapped
     int _fd                     = -1;
     bool _home_node             = false;
-    std::string_view _mode      = CAPIO_FILE_MODE_ON_CLOSE;
+    std::string_view _mode      = CAPIO_FILE_MODE_ON_TERMINATION;
     int _n_links                = 1;
     long int _n_close           = 0;
     long int _n_close_expected  = -1;
@@ -49,7 +49,7 @@ class Capio_file {
     std::vector<std::pair<int, int>> _threads_fd;
 
   public:
-    bool complete              = false;
+    bool complete              = false; //whether the file is completed / committed
     bool first_write           = true;
     long int n_files           = 0;  // useful for directories
     long int n_files_expected  = -1; // useful for directories

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -47,9 +47,9 @@ class Capio_file {
     std::set<std::pair<off64_t, off64_t>, compare> _sectors;
     // vector of (tid, fd)
     std::vector<std::pair<int, int>> _threads_fd;
+    bool complete = false; // whether the file is completed / committed
 
   public:
-    bool complete              = false; //whether the file is completed / committed
     bool first_write           = true;
     long int n_files           = 0;  // useful for directories
     long int n_files_expected  = -1; // useful for directories
@@ -90,6 +90,21 @@ class Capio_file {
         } else {
             delete[] _buf;
         }
+    }
+
+    inline void set_complete() {
+        START_LOG(capio_syscall(SYS_gettid), "Setting capio_file to complete");
+        this->complete = true;
+    }
+    inline void set_complete(bool _complete) {
+        START_LOG(capio_syscall(SYS_gettid), "setting capio_file.complete=%s",
+                  _complete ? "true" : "false");
+        this->complete = _complete;
+    }
+    [[nodiscard]] inline bool is_complete() const {
+        START_LOG(capio_syscall(SYS_gettid), "capio_file is complete? %s",
+                  this->complete ? "true" : "false");
+        return this->complete;
     }
 
     inline void add_fd(int tid, int fd) { _threads_fd.emplace_back(tid, fd); }

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -31,17 +31,17 @@ class Capio_file {
   private:
     char *_buf = nullptr; // buffer containing the data
     std::size_t _buf_size;
-    std::string_view _committed;
-    bool _directory;
+    std::string_view _committed = CAPIO_FILE_MODE_NO_UPDATE;
+    bool _directory             = false;
     // _fd is useful only when the file is memory-mapped
-    int _fd         = -1;
-    bool _home_node = false;
-    std::string_view _mode;
-    int _n_links               = 1;
-    long int _n_close          = 0;
-    long int _n_close_expected = -1;
-    int _n_opens               = 0;
-    bool _permanent;
+    int _fd                     = -1;
+    bool _home_node             = false;
+    std::string_view _mode      = CAPIO_FILE_MODE_ON_CLOSE;
+    int _n_links                = 1;
+    long int _n_close           = 0;
+    long int _n_close_expected  = -1;
+    int _n_opens                = 0;
+    bool _permanent             = false;
     // _sectors stored in memory of the files (only the home node is forced to
     // be up to date)
     std::set<std::pair<off64_t, off64_t>, compare> _sectors;

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -77,6 +77,7 @@ class Capio_file {
 
     ~Capio_file() {
         START_LOG(gettid(), "call()");
+        LOG("Deleting capio_file");
 
         if (_permanent && _home_node) {
             if (_directory) {

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -10,6 +10,7 @@
 
 inline char *expand_memory_for_file(const std::string &path, off64_t data_size,
                                     Capio_file &c_file) {
+    START_LOG(capio_syscall(SYS_gettid), "call(path=%s)", path.c_str());
     char *new_p = c_file.expand_buffer(data_size);
     return new_p;
 }

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -112,13 +112,13 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path, const std:
     writers[pid][dir] = true;
 
     if (c_file.n_files == c_file.n_files_expected) {
-        c_file.complete = true;
+        c_file.set_complete();
         reply_remote_stats(dir);
     }
 
     std::string_view mode = c_file.get_mode();
     if (mode == CAPIO_FILE_MODE_NO_UPDATE) {
-        handle_pending_remote_reads(dir, data_size, c_file.complete);
+        handle_pending_remote_reads(dir, data_size, c_file.is_complete());
     }
 }
 

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -144,9 +144,9 @@ int check_file_location(std::size_t index, int rank, const std::string &path_to_
         }
         std::string line_str(line), *path, *node;
         auto separator = line_str.find_first_of(' ');
-        path = new std::string(line_str.substr(0, separator));
-        node = new std::string(
-            line_str.substr(separator + 1, line_str.length() - 1)); // remove ' ' and \n
+        path           = new std::string(line_str.substr(0, separator));
+        node = new std::string(line_str.substr(separator + 1, line_str.length())); // remove ' '
+        node->pop_back(); //remove \n from node name
 
         LOG("found [%s]@[%s]", path->c_str(), node->c_str());
 

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -144,8 +144,9 @@ int check_file_location(std::size_t index, int rank, const std::string &path_to_
         }
         std::string line_str(line), *path, *node;
         auto separator = line_str.find_first_of(' ');
-        path           = new std::string(line_str.substr(0, separator));
-        node           = new std::string(line_str.substr(separator, line_str.length()));
+        path = new std::string(line_str.substr(0, separator));
+        node = new std::string(
+            line_str.substr(separator + 1, line_str.length() - 1)); // remove ' ' and \n
 
         LOG("found [%s]@[%s]", path->c_str(), node->c_str());
 
@@ -155,7 +156,7 @@ int check_file_location(std::size_t index, int rank, const std::string &path_to_
         if (offset == -1) {
             ERR_EXIT("ftell in check_file_location");
         }
-        add_file_location(path->c_str(), node_str, offset);
+        add_file_location(*path, node_str, offset);
         if (*path == path_to_check) {
             delete[] line;
 

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -62,7 +62,7 @@ get_file_location_opt(const char *const path) {
         LOG("File was not found in files_locations. returning empty object");
         return {};
     } else {
-        LOG("File found on remote node %s", it->second);
+        LOG("File found on node %s", it->second);
         return {it->second};
     }
 }
@@ -146,7 +146,7 @@ int check_file_location(std::size_t index, int rank, const std::string &path_to_
         auto separator = line_str.find_first_of(' ');
         path           = new std::string(line_str.substr(0, separator));
         node = new std::string(line_str.substr(separator + 1, line_str.length())); // remove ' '
-        node->pop_back(); //remove \n from node name
+        node->pop_back(); // remove \n from node name
 
         LOG("found [%s]@[%s]", path->c_str(), node->c_str());
 
@@ -169,6 +169,12 @@ int check_file_location(std::size_t index, int rank, const std::string &path_to_
     return 2;
 }
 
+/**
+ * Returns true if path_to_check is present on node with my_rank, false otherwise
+ * @param my_rank
+ * @param path_to_check
+ * @return
+ */
 [[nodiscard]] bool check_file_location(int my_rank, const std::string &path_to_check) {
     START_LOG(gettid(), "call(my_rank=%d, path_to_check=%s)", my_rank, path_to_check.c_str());
 

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -169,7 +169,7 @@ int check_file_location(std::size_t index, int rank, const std::string &path_to_
     return 2;
 }
 
-bool check_file_location(int my_rank, const std::string &path_to_check) {
+[[nodiscard]] bool check_file_location(int my_rank, const std::string &path_to_check) {
     START_LOG(gettid(), "call(my_rank=%d, path_to_check=%s)", my_rank, path_to_check.c_str());
 
     for (int rank = 0; rank < n_servers; rank++) {

--- a/src/server/utils/signals.hpp
+++ b/src/server/utils/signals.hpp
@@ -4,7 +4,8 @@
 #include <csignal>
 
 void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
-    START_LOG(gettid(), "call(signal=[%d] %s)", signum, strsignal(signum));
+    START_LOG(gettid(), "call(signal=[%d] (%s) from process with pid=%ld)", signum,
+              strsignal(signum), info->si_pid);
 
     std::cout << std::endl
               << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "shutting down server" << std::endl;


### PR DESCRIPTION
This commit introduces the following changes:

- More logging has been added
- In open.hpp:update_file_metadata() a branch had  writers[pid][path] set to false on both branches of if.  this  was wrong and caused the exit handler to not properly set a file to be commited (completed) once the program normally terminated.
- in server/comm/remote_listener.hpp::remote_listener_remote_sending() function, file_shm allways resulted in being not initialized. which caused an error in mpi recive. This was due to missing else branch on checking for file size.