### PR TITLE
Rewrite logic of `load_file_location` function

### DIFF
--- a/src/server/comm/remote_listener.hpp
+++ b/src/server/comm/remote_listener.hpp
@@ -49,7 +49,7 @@ void wait_for_stat(int tid, const std::string &path, int rank,
                    std::mutex *pending_remote_stats_mutex) {
     START_LOG(gettid(), "call(tid=%d, path=%s)", tid, path.c_str());
 
-    loop_check_files_location(path, rank);
+    loop_load_file_location(path);
     // check if the file is local or remote
     Capio_file &c_file = get_capio_file(path.c_str());
 
@@ -73,7 +73,7 @@ void wait_for_file(int tid, int fd, off64_t count, bool dir, bool is_getdents, i
               dir ? "true" : "false", is_getdents ? "true" : "false");
 
     auto path_to_check = get_capio_file_path(tid, fd).data();
-    loop_check_files_location(path_to_check, rank);
+    loop_load_file_location(path_to_check);
 
     // check if the file is local or remote
     if (strcmp(std::get<0>(get_file_location(path_to_check)), node_name) == 0) {

--- a/src/server/handlers/open.hpp
+++ b/src/server/handlers/open.hpp
@@ -37,7 +37,7 @@ inline void update_file_metadata(const std::string &path, int tid, int fd, int r
 inline void handle_create(int tid, int fd, const char *path_cstr, int rank) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, path_cstr=%s, rank=%d)", tid, fd, path_cstr, rank);
 
-    bool is_creat = !(get_file_location_opt(path_cstr) || check_file_location(rank, path_cstr));
+    bool is_creat = !(get_file_location_opt(path_cstr) || load_file_location(path_cstr));
     update_file_metadata(path_cstr, tid, fd, rank, is_creat);
     write_response(tid, 0);
 }
@@ -59,7 +59,7 @@ inline void handle_open(int tid, int fd, const char *path_cstr, int rank) {
     // it is important that check_files_location is the last because is the
     // slowest (short circuit evaluation)
     if (get_file_location_opt(path_cstr) || metadata_conf.find(path_cstr) != metadata_conf.end() ||
-        match_globs(path_cstr) != -1 || check_file_location(rank, path_cstr)) {
+        match_globs(path_cstr) != -1 || load_file_location(path_cstr)) {
         update_file_metadata(path_cstr, tid, fd, rank, false);
     } else {
         write_response(tid, 1);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -118,7 +118,7 @@ inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getden
     LOG("got to first checkpoint");
     if (!file_location_opt && !is_prod) {
         LOG("got to second checkpoint");
-        bool found = check_file_location(rank, path.data());
+        bool found = load_file_location(path.data());
         if (!found) {
             LOG("got to third checkpoint");
             // launch a thread that checks when the file is created


### PR DESCRIPTION
Before this commit, this function was named `check_file_location` and its behaviour was unclear. This function does not only verify if a file exists on any node: it also loads its location to the current node cache if possible. The function returns `false` only when the file is not present on any CAPIO node.

There were two different versions of this function. This commit merges them into a single one, as the innermost one was never called directly.

Finally, this commit reduces the calls to the `load_file_location` function. Since this function is quite heavy, especially in large deplyoments, it is better to call it only when strictly necessary.