### PR TITLE
Use `std::filesystem` whenever possible

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -140,6 +140,9 @@ jobs:
             --output-on-failure \
             --stop-on-failure \
             --test-dir build/tests
-      - name: "Show server log on failure"
+      - name: "Show client logs on failure"
         if: ${{ always() && steps.run-tests.outcome == 'failure' && matrix.build_type == 'Debug' }}
-        run: cat server_rank_*.log
+        run: tail -v -n +1 capio_logs/posix/$(hostname)/posix_thread_*.log
+      - name: "Show server logs on failure"
+        if: ${{ always() && steps.run-tests.outcome == 'failure' && matrix.build_type == 'Debug' }}
+        run: tail -v -n +1 capio_logs/server/$(hostname)/server_thread_*.log

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -69,9 +69,6 @@ CSRankToNodeMap_t rank_to_node;
  */
 CSPendingReadsMap_t pending_reads;
 
-// it contains the file saved on disk
-CSOnDiskMap_t on_disk;
-
 CSClientsRemotePendingNFilesMap_t clients_remote_pending_nfiles;
 
 sem_t internal_server_sem;
@@ -126,10 +123,8 @@ void capio_server(int rank) {
     setup_signal_handlers();
     backend->handshake_servers(rank);
     open_files_location(rank);
-    pid_t pid                              = getpid();
-    const std::filesystem::path &capio_dir = get_capio_dir();
-    create_dir(pid, capio_dir.c_str(), rank,
-               true); // TODO: can be a problem if a process execute readdir
+    create_dir(getpid(), get_capio_dir(),
+               rank); // TODO: can be a problem if a process execute readdir
     // on capio_dir
 
     init_server();

--- a/src/server/comm/interfaces.hpp
+++ b/src/server/comm/interfaces.hpp
@@ -1,5 +1,5 @@
-#ifndef CAPIO_INTERFACES_HPP
-#define CAPIO_INTERFACES_HPP
+#ifndef CAPIO_SERVER_COMM_INTERFACES_HPP
+#define CAPIO_SERVER_COMM_INTERFACES_HPP
 
 class RemoteRequest {
   private:
@@ -96,8 +96,8 @@ class backend_interface {
      * @param nbytes
      * @param complete
      */
-    virtual void serve_remote_read(const char *path_c, int dest, long int offset, long int nbytes,
-                                   int complete) = 0;
+    virtual void serve_remote_read(const std::filesystem::path &path, int dest, long int offset,
+                                   long int nbytes, int complete) = 0;
 
     /**
      * Handle a remote read request
@@ -124,7 +124,8 @@ class backend_interface {
      * @param dest
      * @return
      */
-    virtual bool handle_nreads(const std::string &path, const std::string &app_name, int dest) = 0;
+    virtual bool handle_nreads(const std::filesystem::path &path, const std::string &app_name,
+                               int dest) = 0;
 
     /**
      * Handle a remote stat
@@ -142,7 +143,7 @@ class backend_interface {
      * @param pending_remote_stats
      * @param pending_remote_stats_mutex
      */
-    virtual void handle_remote_stat(int tid, const std::string &path, int rank,
+    virtual void handle_remote_stat(int tid, const std::filesystem::path &path, int rank,
                                     CSMyRemotePendingStats_t *pending_remote_stats,
                                     std::mutex *pending_remote_stats_mutex) = 0;
 
@@ -161,7 +162,8 @@ class backend_interface {
  */
 
 inline bool read_from_local_mem(int tid, off64_t process_offset, off64_t end_of_read,
-                                off64_t end_of_sector, off64_t count, const std::string &path);
+                                off64_t end_of_sector, off64_t count,
+                                const std::filesystem::path &path);
 
 inline void solve_remote_reads(size_t bytes_received, size_t offset, size_t file_size,
                                const char *path_c, bool complete,
@@ -176,4 +178,4 @@ inline void wait_for_file(int tid, int fd, off64_t count, bool dir, bool is_getd
                           std::mutex *pending_remote_reads_mutex,
                           void (*handle_local_read)(int, int, off64_t, bool, bool, bool));
 
-#endif // CAPIO_INTERFACES_HPP
+#endif // CAPIO_SERVER_COMM_INTERFACES_HPP

--- a/src/server/handlers/access.hpp
+++ b/src/server/handlers/access.hpp
@@ -6,11 +6,7 @@
 inline void handle_access(long tid, char *path) {
     START_LOG(gettid(), "call(tid=%ld, path=%s)", tid, path);
 
-    if (!get_file_location_opt(path)) {
-        write_response(tid, -1);
-    } else {
-        write_response(tid, 0);
-    }
+    write_response(tid, get_file_location_opt(path) ? 0 : -1);
 }
 
 void access_handler(const char *const str, int rank) {

--- a/src/server/handlers/common.hpp
+++ b/src/server/handlers/common.hpp
@@ -50,7 +50,7 @@ void free_resources(int tid) {
     }
 }
 
-void handle_pending_remote_nfiles(const std::string &path) {
+void handle_pending_remote_nfiles(const std::filesystem::path &path) {
     START_LOG(gettid(), "call(%s)", path.c_str());
 
     if (sem_wait(&clients_remote_pending_nfiles_sem) == -1) {
@@ -64,11 +64,11 @@ void handle_pending_remote_nfiles(const std::string &path) {
         while (it != app_pending_nfiles.end()) {
             auto &[prefix, n_files, dest, files_path, sem] = *it;
             std::unordered_set<std::string> &files         = files_sent[app];
-            auto file_location_opt                         = get_file_location_opt(path.c_str());
+            auto file_location_opt                         = get_file_location_opt(path);
             auto next_it                                   = std::next(it);
             if (files.find(path) == files.end() && file_location_opt &&
                 strcmp(std::get<0>(file_location_opt->get()), node_name) == 0 &&
-                path.compare(0, strlen(prefix), prefix) == 0) {
+                path.native().compare(0, strlen(prefix), prefix) == 0) {
                 files_path->push_back(path);
                 files.insert(path);
                 if (files_path->size() == n_files) {

--- a/src/server/handlers/mkdir.hpp
+++ b/src/server/handlers/mkdir.hpp
@@ -1,17 +1,11 @@
 #ifndef CAPIO_SERVER_HANDLERS_MKDIR_HPP
 #define CAPIO_SERVER_HANDLERS_MKDIR_HPP
 
-inline void handle_mkdir(int tid, const char *pathname, int rank) {
-    START_LOG(gettid(), "call(tid=%d, pathname=%s, rank=%d)", tid, pathname, rank);
-
-    write_response(tid, create_dir(tid, pathname, rank, false));
-}
-
 void mkdir_handler(const char *const str, int rank) {
     pid_t tid;
     char pathname[PATH_MAX];
     sscanf(str, "%d %s", &tid, pathname);
-    handle_mkdir(tid, pathname, rank);
+    write_response(tid, create_dir(tid, pathname, rank));
 }
 
 #endif // CAPIO_SERVER_HANDLERS_MKDIR_HPP

--- a/src/server/handlers/rename.hpp
+++ b/src/server/handlers/rename.hpp
@@ -3,9 +3,10 @@
 
 #include "utils/location.hpp"
 
-void handle_rename(int tid, const char *oldpath, const char *newpath, int rank) {
-    START_LOG(gettid(), "call(tid=%d, oldpath=%s, newpath=%s, rank=%d)", tid, oldpath, newpath,
-              rank);
+void handle_rename(int tid, const std::filesystem::path &oldpath,
+                   const std::filesystem::path &newpath, int rank) {
+    START_LOG(gettid(), "call(tid=%d, oldpath=%s, newpath=%s, rank=%d)", tid, oldpath.c_str(),
+              newpath.c_str(), rank);
 
     if (get_capio_file_opt(oldpath)) {
         rename_capio_file(oldpath, newpath);

--- a/src/server/handlers/rmdir.hpp
+++ b/src/server/handlers/rmdir.hpp
@@ -3,8 +3,9 @@
 
 #include "utils/location.hpp"
 
-inline void handle_rmdir(int tid, const char *dir_to_remove, int rank) {
-    START_LOG(gettid(), "call(tid=%d, dir_to_remove=%s, rank=%d)", tid, dir_to_remove, rank);
+inline void handle_rmdir(int tid, const std::filesystem::path &dir_to_remove, int rank) {
+    START_LOG(gettid(), "call(tid=%d, dir_to_remove=%s, rank=%d)", tid, dir_to_remove.c_str(),
+              rank);
 
     long res = delete_from_file_locations("files_location.txt", dir_to_remove, rank);
     erase_from_files_location(dir_to_remove);

--- a/src/server/handlers/seek.hpp
+++ b/src/server/handlers/seek.hpp
@@ -6,14 +6,14 @@
 inline void handle_lseek(int tid, int fd, size_t offset) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, offset=%ld)", tid, fd, offset);
 
-    Capio_file &c_file = get_capio_file(get_capio_file_path(tid, fd).data());
+    Capio_file &c_file = get_capio_file(get_capio_file_path(tid, fd));
     write_response(tid, c_file.get_sector_end(offset));
 }
 
 void handle_seek_data(int tid, int fd, size_t offset) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, offset=%ld)", tid, fd, offset);
 
-    Capio_file &c_file = get_capio_file(get_capio_file_path(tid, fd).data());
+    Capio_file &c_file = get_capio_file(get_capio_file_path(tid, fd));
     write_response(tid, c_file.seek_data(offset));
 }
 
@@ -21,13 +21,13 @@ inline void handle_seek_end(int tid, int fd, int rank) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, rank=%d)", tid, fd, rank);
 
     // seek_end here behaves as stat because we want the file size
-    reply_stat(tid, get_capio_file_path(tid, fd).data(), rank);
+    reply_stat(tid, get_capio_file_path(tid, fd), rank);
 }
 
 inline void handle_seek_hole(int tid, int fd, size_t offset) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, offset=%ld)", tid, fd, offset);
 
-    Capio_file &c_file = get_capio_file(get_capio_file_path(tid, fd).data());
+    Capio_file &c_file = get_capio_file(get_capio_file_path(tid, fd));
     write_response(tid, c_file.seek_hole(offset));
 }
 

--- a/src/server/handlers/unlink.hpp
+++ b/src/server/handlers/unlink.hpp
@@ -1,8 +1,8 @@
 #ifndef CAPIO_SERVER_HANDLERS_UNLINK_HPP
 #define CAPIO_SERVER_HANDLERS_UNLINK_HPP
 
-inline void handle_unlink(int tid, const char *path, int rank) {
-    START_LOG(gettid(), "call(tid=%d, path=%s, rank=%d)", tid, path, rank);
+inline void handle_unlink(int tid, const std::filesystem::path &path, int rank) {
+    START_LOG(gettid(), "call(tid=%d, path=%s, rank=%d)", tid, path.c_str(), rank);
 
     auto c_file_opt = get_capio_file_opt(path);
     if (c_file_opt) { // TODO: it works only in the local case

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -132,16 +132,15 @@ class Capio_file {
      * To be called when a process
      * execute a read or a write syscall
      */
-    void create_buffer(const std::string &path, bool home_node) {
+    void create_buffer(const std::filesystem::path &path, bool home_node) {
         START_LOG(gettid(), "call(path=%s, home_node=%s)", path.c_str(),
                   home_node ? "true" : "false");
 
         _home_node = home_node;
         if (_permanent && home_node) {
             if (_directory) {
-                if (mkdir(path.c_str(), 0700) == -1) {
-                    ERR_EXIT("mkdir capio_file create_buffer");
-                }
+                std::filesystem::create_directory(path);
+                std::filesystem::permissions(path, std::filesystem::perms::owner_all);
                 _buf = new char[_buf_size];
             } else {
                 LOG("creating mem mapped file");
@@ -195,7 +194,7 @@ class Capio_file {
         }
     }
 
-    [[nodiscard]] inline std::string_view get_mode() const { return _mode; }
+    [[nodiscard]] inline const std::string_view &get_mode() const { return _mode; }
 
     /*
      * Returns the offset to the end of the sector

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -5,15 +5,9 @@
 
 #include "capio/constants.hpp"
 #include "capio/data_structure.hpp"
+
 #include "capio_file.hpp"
 #include "types.hpp"
-
-inline char *expand_memory_for_file(const std::string &path, off64_t data_size,
-                                    Capio_file &c_file) {
-    START_LOG(capio_syscall(SYS_gettid), "call(path=%s)", path.c_str());
-    char *new_p = c_file.expand_buffer(data_size);
-    return new_p;
-}
 
 inline off64_t store_dirent(char *incoming, char *target_buffer, off64_t incoming_size) {
     START_LOG(gettid(), "call(%s, %s, %to_store)", incoming, target_buffer, incoming_size);

--- a/src/server/utils/producer.hpp
+++ b/src/server/utils/producer.hpp
@@ -5,7 +5,7 @@
 
 #include "metadata.hpp"
 
-std::string get_producer_name(const std::string &path) {
+std::string get_producer_name(const std::filesystem::path &path) {
     START_LOG(gettid(), "call( %s)", path.c_str());
     std::string producer_name;
     // we handle also prefixes
@@ -22,12 +22,11 @@ std::string get_producer_name(const std::string &path) {
     return producer_name;
 }
 
-bool is_producer(int tid, const std::string &path) {
+bool is_producer(int tid, const std::filesystem::path &path) {
     START_LOG(tid, "call(%d, %s)", tid, path.c_str());
     bool res = false;
-    auto it  = apps.find(tid);
 
-    if (it != apps.end()) {
+    if (apps.find(tid) != apps.end()) {
         std::string app_name  = apps[tid];
         std::string prod_name = get_producer_name(path);
         res                   = app_name == prod_name;

--- a/src/server/utils/requests.hpp
+++ b/src/server/utils/requests.hpp
@@ -89,15 +89,15 @@ inline auto read_next_request(char *str) {
  * @param offset
  * @return
  */
-inline auto write_response(int tid, off64_t offset) {
+inline void write_response(int tid, off64_t offset) {
     START_LOG(gettid(), "call(tid=%d, offset=%ld)", tid, offset);
 
     return bufs_response->at(tid)->write(&offset);
 }
 
-inline void stat_reply_request(const char *const path, off64_t size, int dir) {
+inline void stat_reply_request(const std::filesystem::path &path, off64_t size, int dir) {
     char req[CAPIO_REQUEST_MAX_SIZE];
-    sprintf(req, "%04d %s %ld %d", CAPIO_REQUEST_STAT_REPLY, path, size, dir);
+    sprintf(req, "%04d %s %ld %d", CAPIO_REQUEST_STAT_REPLY, path.c_str(), size, dir);
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
 }
 

--- a/src/server/utils/types.hpp
+++ b/src/server/utils/types.hpp
@@ -15,7 +15,8 @@ typedef std::unordered_map<int, std::string> CSAppsMap_t;
 typedef std::unordered_map<std::string, std::unordered_set<std::string>> CSFilesSentMap_t;
 typedef std::unordered_map<int, std::unordered_map<int, std::pair<Capio_file *, off64_t *>>>
     CSProcessFileMap_t;
-typedef std::unordered_map<int, std::unordered_map<int, std::string>> CSProcessFileMetadataMap_t;
+typedef std::unordered_map<int, std::unordered_map<int, std::filesystem::path>>
+    CSProcessFileMetadataMap_t;
 typedef std::unordered_map<int, std::pair<SPSC_queue<char> *, SPSC_queue<char> *>>
     CSDataBufferMap_t;
 typedef std::unordered_map<std::string, Capio_file *> CSFilesMetadata_t;
@@ -38,7 +39,6 @@ typedef std::unordered_map<std::string, std::list<int>> CSMyRemotePendingStats_t
 typedef std::unordered_map<std::string, std::list<std::tuple<size_t, size_t, sem_t *>>>
     CSClientsRemotePendingReads_t;
 typedef std::unordered_map<std::string, std::list<sem_t *>> CSClientsRemotePendingStats_t;
-typedef std::unordered_set<std::string> CSOnDiskMap_t;
 typedef std::unordered_map<
     std::string, std::list<std::tuple<char *, size_t, int, std::vector<std::string> *, sem_t *>>>
     CSClientsRemotePendingNFilesMap_t;


### PR DESCRIPTION
THis commit uniforms the server function APIs to use `std::filesystem` whenever they refer to fiels or folders. Before this commit, different functions accepted different object types, including `std::string`, `std::string_view`, and bare `const char *` pointers.