### PR TITLE
Streaming fixes

### DIFF
--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -41,10 +41,10 @@ constexpr int THEORETICAL_SIZE_DIRENT64              = sizeof(ino64_t) + sizeof(
                                           sizeof(char) * NAME_MAX;
 
 // CAPIO streaming semantics
-constexpr char CAPIO_FILE_MODE_NO_UPDATE[]      = "no_update";
-constexpr char CAPIO_FILE_MODE_UPDATE[]         = "update";
-constexpr char CAPIO_FILE_MODE_ON_CLOSE[]       = "on_close";
-constexpr char CAPIO_FILE_MODE_ON_TERMINATION[] = "on_termination";
+constexpr char CAPIO_FILE_MODE_NO_UPDATE[]           = "no_update";
+constexpr char CAPIO_FILE_MODE_UPDATE[]              = "update";
+constexpr char CAPIO_FILE_COMMITTED_ON_CLOSE[]       = "on_close";
+constexpr char CAPIO_FILE_COMMITTED_ON_TERMINATION[] = "on_termination";
 
 // CAPIO POSIX return codes
 constexpr int CAPIO_POSIX_SYSCALL_ERRNO        = -1;

--- a/src/server/handlers/close.hpp
+++ b/src/server/handlers/close.hpp
@@ -17,7 +17,7 @@ inline void handle_close(int tid, int fd, int rank) {
     Capio_file &c_file = get_capio_file(path);
     c_file.close();
     if (c_file.get_committed() == CAPIO_FILE_COMMITTED_ON_CLOSE && c_file.is_closed()) {
-        LOG("Capio_file is closed and mode is on_close");
+        LOG("Capio_file is closed and commit rule is on_close");
         c_file.set_complete();
         auto it = pending_reads.find(path);
         if (it != pending_reads.end()) {
@@ -32,7 +32,7 @@ inline void handle_close(int tid, int fd, int rank) {
             pending_reads.erase(it);
         }
         if (c_file.is_dir()) {
-            reply_remote_stats(path);
+            wake_pending_remote_stats(path);
         }
         // TODO: error if seek are done and also do this on exit
         handle_pending_remote_reads(path, c_file.get_sector_end(0), true);

--- a/src/server/handlers/close.hpp
+++ b/src/server/handlers/close.hpp
@@ -16,7 +16,7 @@ inline void handle_close(int tid, int fd, int rank) {
 
     Capio_file &c_file = get_capio_file(path);
     c_file.close();
-    if (c_file.get_committed() == CAPIO_FILE_MODE_ON_CLOSE && c_file.is_closed()) {
+    if (c_file.get_committed() == CAPIO_FILE_COMMITTED_ON_CLOSE && c_file.is_closed()) {
         LOG("Capio_file is closed and mode is on_close");
         c_file.set_complete();
         auto it = pending_reads.find(path);

--- a/src/server/handlers/exig.hpp
+++ b/src/server/handlers/exig.hpp
@@ -15,7 +15,7 @@ inline void handle_exit_group(int tid, int rank) {
             LOG("Handling file %s", path.c_str());
             auto it_conf = metadata_conf.find(path);
             if (it_conf == metadata_conf.end() ||
-                std::get<0>(it_conf->second) == CAPIO_FILE_MODE_ON_TERMINATION ||
+                std::get<0>(it_conf->second) == CAPIO_FILE_COMMITTED_ON_TERMINATION ||
                 std::get<0>(it_conf->second).empty()) {
                 Capio_file &c_file = get_capio_file(path.c_str());
                 if (c_file.is_dir()) {

--- a/src/server/handlers/exig.hpp
+++ b/src/server/handlers/exig.hpp
@@ -22,7 +22,7 @@ inline void handle_exit_group(int tid, int rank) {
                     LOG("file %s is dir", path.c_str());
                     long int n_committed = c_file.n_files_expected;
                     if (n_committed <= c_file.n_files) {
-                        reply_remote_stats(path);
+                        wake_pending_remote_stats(path);
                         LOG("Setting file %s to complete", path.c_str());
                         c_file.set_complete();
                     }

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -61,7 +61,8 @@ class Capio_file {
     std::size_t real_file_size = 0;
 
     Capio_file()
-        : _buf_size(0), _committed("on_termination"), _directory(false), _permanent(false) {}
+        : _buf_size(0), _committed(CAPIO_FILE_COMMITTED_ON_TERMINATION), _directory(false),
+          _permanent(false) {}
 
     Capio_file(const std::string_view &committed, const std::string_view &mode, bool directory,
                long int n_files_expected, bool permanent, std::size_t init_size,
@@ -72,8 +73,8 @@ class Capio_file {
 
     Capio_file(bool directory, bool permanent, std::size_t init_size,
                long int n_close_expected = -1)
-        : _buf_size(init_size), _committed("on_termination"), _directory(directory),
-          _n_close_expected(n_close_expected), _permanent(permanent) {}
+        : _buf_size(init_size), _committed(CAPIO_FILE_COMMITTED_ON_TERMINATION),
+          _directory(directory), _n_close_expected(n_close_expected), _permanent(permanent) {}
 
     ~Capio_file() {
         START_LOG(gettid(), "call()");

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -31,12 +31,12 @@ class Capio_file {
   private:
     char *_buf = nullptr; // buffer containing the data
     std::size_t _buf_size;
-    std::string_view _committed = CAPIO_FILE_MODE_UPDATE;
+    std::string_view _committed = CAPIO_FILE_MODE_ON_TERMINATION;
     bool _directory             = false;
     // _fd is useful only when the file is memory-mapped
     int _fd                     = -1;
     bool _home_node             = false;
-    std::string_view _mode      = CAPIO_FILE_MODE_ON_TERMINATION;
+    std::string_view _mode      = CAPIO_FILE_MODE_UPDATE;
     int _n_links                = 1;
     long int _n_close           = 0;
     long int _n_close_expected  = -1;

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -31,7 +31,7 @@ class Capio_file {
   private:
     char *_buf = nullptr; // buffer containing the data
     std::size_t _buf_size;
-    std::string_view _committed = CAPIO_FILE_MODE_ON_TERMINATION;
+    std::string_view _committed = CAPIO_FILE_COMMITTED_ON_TERMINATION;
     bool _directory             = false;
     // _fd is useful only when the file is memory-mapped
     int _fd                     = -1;

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -135,7 +135,7 @@ void update_dir(int tid, const std::filesystem::path &file_path, int rank) {
 }
 
 off64_t create_dir(int tid, const std::filesystem::path &path, int rank) {
-    START_LOG(gettid(), "call(path=%s, rank=%d, root_dir=%s)", path.c_str(), rank);
+    START_LOG(tid, "call(path=%s, rank=%d)", path.c_str(), rank);
 
     if (!get_file_location_opt(path)) {
         Capio_file &c_file = create_capio_file(path, true, CAPIO_DEFAULT_DIR_INITIAL_SIZE);

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -100,8 +100,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                 }
                 // END PARSING COMMITTED
 
-                std::string_view mode;
-                error = file["mode"].get_string().get(mode);
+                std::string mode = CAPIO_FILE_MODE_UPDATE;
 
                 long n_files;
                 if (file["n_files"].get_int64().get(n_files)) {
@@ -118,7 +117,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                 }
                 std::size_t pos = path.native().find('*');
                 update_metadata_conf(path, pos, n_files, batch_size, std::string(commit_rule),
-                                     std::string(mode), std::string(app_name), false, n_close);
+                                     mode, std::string(app_name), false, n_close);
             }
 
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -21,6 +21,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
     } catch (const simdjson::simdjson_error &e) {
         std::cerr << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                   << "Exception thrown while opening config file: " << e.what() << std::endl;
+        LOG("Exception thrown while opening config file: %s", e.what());
         ERR_EXIT("Exception thrown while opening config file: %s", e.what());
     }
 
@@ -29,6 +30,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
 
     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
               << "Parsing configuration for workflow: " << workflow_name << std::endl;
+    LOG("Parsing configuration for workflow: %s", workflow_name);
 
     auto io_graph = entries["IO_Graph"];
 
@@ -37,29 +39,35 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
 
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Parsing config for app " << app_name
                   << std::endl;
+        LOG("Parsing config for app %s", app_name);
 
         if (app["input_stream"].get_array().get(input_stream)) {
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No input_stream section found for app " << app_name << std::endl;
+            LOG("No input_stream section found for app %s", app_name);
         } else {
             // TODO: parse input_stream
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "Completed input_stream parsing for app: " << app_name << std::endl;
+            LOG("Completed input_stream parsing for app: %s", app_name);
         }
 
         if (app["output_stream"].get_array().get(output_stream)) {
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No output_stream section found for app " << app_name << std::endl;
+            LOG("No output_stream section found for app %s", app_name);
         } else {
             // TODO: parse output stream
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "Completed output_stream parsing for app: " << app_name << std::endl;
+            LOG("Completed output_stream parsing for app: %s", app_name);
         }
 
         // PARSING STREAMING FILES
         if (app["streaming"].get_array().get(streaming)) {
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No streaming section found for app: " << app_name << std::endl;
+            LOG("No streaming section found for app: %s", app_name);
         } else {
             for (auto file : streaming) {
                 std::string_view name, committed;
@@ -78,7 +86,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                         if (commit_rule != CAPIO_FILE_MODE_ON_CLOSE) {
                             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "commit rule "
                                       << commit_rule << std::endl;
-                            ERR_EXIT("error conf file");
+                            ERR_EXIT("error commit rule: %s", commit_rule.c_str());
                         }
 
                         std::string n_close_str =
@@ -87,7 +95,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                         if (!is_int(n_close_str)) {
                             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                                       << "commit rule on_close invalid number" << std::endl;
-                            ERR_EXIT("error conf file");
+                            ERR_EXIT("error commit rule on_close invalid number: !is_int()");
                         }
                         n_close = std::stol(n_close_str);
                     } else {
@@ -96,7 +104,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                 } else {
                     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                               << "commit rule is mandatory in streaming section" << std::endl;
-                    ERR_EXIT("error conf file");
+                    ERR_EXIT("error commit rule is mandatory in streaming section");
                 }
                 // END PARSING COMMITTED
 
@@ -116,21 +124,23 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                     path = (capio_dir / path).lexically_normal();
                 }
                 std::size_t pos = path.native().find('*');
-                update_metadata_conf(path, pos, n_files, batch_size, std::string(commit_rule),
-                                     mode, std::string(app_name), false, n_close);
+                update_metadata_conf(path, pos, n_files, batch_size, std::string(commit_rule), mode,
+                                     std::string(app_name), false, n_close);
             }
 
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "completed parsing of streaming section for app: " << app_name
                       << std::endl;
+            LOG("completed parsing of streaming section for app: %s", app_name);
         } // END PARSING STREAMING FILES
 
     } // END OF APP MAIN LOOPS
-
+    LOG("Completed parsing of io_graph app main loops");
     long int batch_size = 0;
     if (entries["permanent"].get_array().get(permanent_files)) { // PARSING PERMANENT FILES
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                   << "No permanent section found for workflow: " << workflow_name << std::endl;
+        LOG("No permanent section found for workflow: %s", workflow_name);
     } else {
         for (auto file : permanent_files) {
             std::string_view name;
@@ -166,9 +176,11 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
         }
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Completed parsing of permanent files"
                   << std::endl;
+        LOG("Completed parsing of permanent files");
     } // END PARSING PERMANENT FILES
 
     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Completed parsing of io_graph" << std::endl;
+    LOG("Completed parsing of io_graph");
 }
 
 #endif // CAPIO_SERVER_UTILS_JSON_HPP

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -25,72 +25,88 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
         ERR_EXIT("Exception thrown while opening config file: %s", e.what());
     }
 
-    entries                              = parser.iterate(json);
-    const std::string_view workflow_name = entries["name"].get_string();
+    entries = parser.iterate(json);
+
+    std::string_view workflow_name;
+    error = entries["name"].get_string().get(workflow_name);
+    if (error) {
+        ERR_EXIT("Error: workflow name is mandatory");
+    }
 
     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
               << "Parsing configuration for workflow: " << workflow_name << std::endl;
-    LOG("Parsing configuration for workflow: %s", workflow_name);
+    LOG("Parsing configuration for workflow: %s", std::string(workflow_name).c_str());
 
     auto io_graph = entries["IO_Graph"];
 
     for (auto app : io_graph) {
-        std::string_view app_name = app["name"].get_string();
+        std::string_view app_name;
+        error = app["name"].get_string().get(app_name);
+        if (error) {
+            ERR_EXIT("Error: app name is mandatory");
+        }
 
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Parsing config for app " << app_name
                   << std::endl;
-        LOG("Parsing config for app %s", app_name);
+        LOG("Parsing config for app %s", std::string(app_name).c_str());
 
         if (app["input_stream"].get_array().get(input_stream)) {
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No input_stream section found for app " << app_name << std::endl;
-            LOG("No input_stream section found for app %s", app_name);
+            LOG("No input_stream section found for app %s", std::string(app_name).c_str());
         } else {
             // TODO: parse input_stream
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "Completed input_stream parsing for app: " << app_name << std::endl;
-            LOG("Completed input_stream parsing for app: %s", app_name);
+            LOG("Completed input_stream parsing for app: %s", std::string(app_name).c_str());
         }
 
         if (app["output_stream"].get_array().get(output_stream)) {
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No output_stream section found for app " << app_name << std::endl;
-            LOG("No output_stream section found for app %s", app_name);
+            LOG("No output_stream section found for app %s", std::string(app_name).c_str());
         } else {
             // TODO: parse output stream
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "Completed output_stream parsing for app: " << app_name << std::endl;
-            LOG("Completed output_stream parsing for app: %s", app_name);
+            LOG("Completed output_stream parsing for app: %s", std::string(app_name).c_str());
         }
 
         // PARSING STREAMING FILES
         if (app["streaming"].get_array().get(streaming)) {
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                       << "No streaming section found for app: " << app_name << std::endl;
-            LOG("No streaming section found for app: %s", app_name);
+            LOG("No streaming section found for app: %s", std::string(app_name).c_str());
         } else {
+            LOG("Began parsing streaming section for app %s", std::string(app_name).c_str());
             for (auto file : streaming) {
-                std::string_view name, committed;
-                std::string committed_str, commit_rule;
+                std::string_view name, committed, mode, commit_rule;
                 long int n_close = -1;
+                long n_files, batch_size;
 
                 error = file["name"].get_string().get(name);
+                if (error) {
+                    ERR_EXIT("error name for application is mandatory");
+                }
+                LOG("Stream name: %s", std::string(name).c_str());
 
                 // PARSING COMMITTED
-                if (!file["committed"].get_string().get(committed)) {
-
-                    committed_str = std::string(committed);
-                    int pos       = committed_str.find(':');
+                error = file["committed"].get_string().get(committed);
+                if (error) {
+                    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
+                              << "commit rule is mandatory in streaming section" << std::endl;
+                    ERR_EXIT("error commit rule is mandatory in streaming section");
+                } else {
+                    auto pos = committed.find(':');
                     if (pos != -1) {
-                        commit_rule = committed_str.substr(0, pos);
-                        if (commit_rule != CAPIO_FILE_MODE_ON_CLOSE) {
+                        commit_rule = committed.substr(0, pos);
+                        if (commit_rule != CAPIO_FILE_COMMITTED_ON_CLOSE) {
                             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "commit rule "
                                       << commit_rule << std::endl;
-                            ERR_EXIT("error commit rule: %s", commit_rule.c_str());
+                            ERR_EXIT("error commit rule: %s", std::string(commit_rule).c_str());
                         }
 
-                        std::string n_close_str =
-                            committed_str.substr(pos + 1, committed_str.length());
+                        std::string n_close_str(committed.substr(pos + 1, committed.length()));
 
                         if (!is_int(n_close_str)) {
                             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
@@ -99,52 +115,65 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                         }
                         n_close = std::stol(n_close_str);
                     } else {
-                        commit_rule = std::string(committed);
+                        commit_rule = committed;
                     }
-                } else {
-                    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
-                              << "commit rule is mandatory in streaming section" << std::endl;
-                    ERR_EXIT("error commit rule is mandatory in streaming section");
                 }
+                LOG("Committed: %s", std::string(committed).c_str());
                 // END PARSING COMMITTED
 
-                std::string mode = CAPIO_FILE_MODE_UPDATE;
+                error = file["mode"].get_string().get(mode);
+                if (error) {
+                    mode = CAPIO_FILE_MODE_UPDATE;
+                }
+                LOG("Mode: %s", std::string(mode).c_str());
 
-                long n_files;
-                if (file["n_files"].get_int64().get(n_files)) {
+                error = file["n_files"].get_int64().get(n_files);
+                if (error) {
                     n_files = -1;
                 }
-                long batch_size;
+                LOG("n_files: %d", n_files);
+
                 error = file["batch_size"].get_int64().get(batch_size);
                 if (error) {
                     batch_size = 0;
                 }
+                LOG("batch_size: %d", batch_size);
+
                 std::filesystem::path path(name);
                 if (path.is_relative()) {
                     path = (capio_dir / path).lexically_normal();
                 }
+                LOG("path: %s", path.c_str());
+
                 std::size_t pos = path.native().find('*');
-                update_metadata_conf(path, pos, n_files, batch_size, std::string(commit_rule), mode,
-                                     std::string(app_name), false, n_close);
+                update_metadata_conf(path, pos, n_files, batch_size, std::string(commit_rule),
+                                     std::string(mode), std::string(app_name), false, n_close);
             }
 
             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
                       << "completed parsing of streaming section for app: " << app_name
                       << std::endl;
-            LOG("completed parsing of streaming section for app: %s", app_name);
+            LOG("completed parsing of streaming section for app: %s",
+                std::string(app_name).c_str());
         } // END PARSING STREAMING FILES
 
     } // END OF APP MAIN LOOPS
     LOG("Completed parsing of io_graph app main loops");
+
     long int batch_size = 0;
     if (entries["permanent"].get_array().get(permanent_files)) { // PARSING PERMANENT FILES
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
                   << "No permanent section found for workflow: " << workflow_name << std::endl;
-        LOG("No permanent section found for workflow: %s", workflow_name);
+        LOG("No permanent section found for workflow: %s", std::string(workflow_name).c_str());
     } else {
         for (auto file : permanent_files) {
             std::string_view name;
             error = file.get_string().get(name);
+            if (error) {
+                ERR_EXIT("error name for permanent section is mandatory");
+            }
+            LOG("Permanent name: %s", std::string(name).c_str());
+
             std::filesystem::path path(name);
 
             if (path.is_relative()) {
@@ -157,8 +186,9 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
             if (pos == std::string::npos) {
                 auto it = metadata_conf.find(path);
                 if (it == metadata_conf.end()) {
-                    update_metadata_conf(path, pos, -1, batch_size, CAPIO_FILE_MODE_ON_TERMINATION,
-                                         "", "", true, -1);
+                    update_metadata_conf(path, pos, -1, batch_size,
+                                         CAPIO_FILE_COMMITTED_ON_TERMINATION,
+                                         CAPIO_FILE_MODE_UPDATE, "", true, -1);
                 } else {
                     std::get<4>(it->second) = true;
                 }
@@ -166,8 +196,8 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                 std::string prefix_str = path.native().substr(0, pos);
                 long int i             = match_globs(prefix_str);
                 if (i == -1) {
-                    update_metadata_conf(path, pos, -1, batch_size, CAPIO_FILE_MODE_ON_TERMINATION,
-                                         "", "", true, -1);
+                    update_metadata_conf(path, pos, -1, batch_size,
+                                         CAPIO_FILE_COMMITTED_ON_TERMINATION, "", "", true, -1);
                 } else {
                     auto &tuple        = metadata_conf_globs[i];
                     std::get<6>(tuple) = true;

--- a/src/server/utils/metadata.hpp
+++ b/src/server/utils/metadata.hpp
@@ -252,7 +252,7 @@ void update_metadata_conf(std::filesystem::path &path, size_t pos, long int n_fi
                           const std::string &app_name, bool permanent, long int n_close) {
     START_LOG(gettid(),
               "call(path=%s, pos=%ld, n_files=%ld, batch_size=%ld, committed=%s, "
-              "mode=%s, app_name=%s, permanent=&s, n_close=%ld)",
+              "mode=%s, app_name=%s, permanent=%s, n_close=%ld)",
               path.c_str(), pos, n_files, batch_size, committed.c_str(), mode.c_str(),
               app_name.c_str(), permanent ? "true" : "false", n_close);
 


### PR DESCRIPTION
This PR introduces the following changes aimed to fix the streaming functionality of capio:
- Added more logs on the json parsing code.
- Fixed json parsing code to be more in line with the design requirement
- Renamed default mode constants to a more understandable label
- Refactor of match_globs function to be more understandable


When a stat is requested on a capio file that has not been yet created, but will be (as the path is matched by a glob), the stat now lookg both on files_metadata to see whether the file has alreasy been created, and on match globs to see whether the file will be created in the future.  in the latter case, then capio will initialize the file in advance and wait for it to be streamable.