### PR TITLE
Refactor class names and constructors

### DIFF
--- a/src/common/capio/circular_buffer.hpp
+++ b/src/common/capio/circular_buffer.hpp
@@ -13,7 +13,7 @@
  * Each element of the circular buffer has the same size.
  */
 
-template <class T> class Circular_buffer {
+template <class T> class CircularBuffer {
   private:
     void *_shm;
     const long int _max_num_elems;
@@ -46,8 +46,8 @@ template <class T> class Circular_buffer {
     }
 
   public:
-    Circular_buffer(const std::string &shm_name, const long int _max_num_elems,
-                    const long int elem_size, long int sem_timeout, int sem_retries)
+    CircularBuffer(const std::string &shm_name, const long int _max_num_elems,
+                   const long int elem_size, long int sem_timeout, int sem_retries)
         : _max_num_elems(_max_num_elems), _elem_size(elem_size), _shm_name(shm_name) {
         START_LOG(capio_syscall(SYS_gettid),
                   "call(shm_name=%s, _max_num_elems=%ld, elem_size=%ld, "
@@ -86,7 +86,10 @@ template <class T> class Circular_buffer {
         }
     }
 
-    ~Circular_buffer() {
+    CircularBuffer(const CircularBuffer &)            = delete;
+    CircularBuffer &operator=(const CircularBuffer &) = delete;
+
+    ~CircularBuffer() {
         sem_close(_mutex);
         sem_close(_sem_num_elems);
         sem_close(_sem_num_empty);

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -223,6 +223,24 @@ class Logger {
         current_log_level++;
     }
 
+    Logger(const Logger &)            = delete;
+    Logger &operator=(const Logger &) = delete;
+
+    inline ~Logger() {
+        current_log_level--;
+        sprintf(format, CAPIO_LOG_PRE_MSG, this->invoker);
+        size_t pre_msg_len = strlen(format);
+        strcpy(format + pre_msg_len, "returned");
+
+        log_write_to(format, strlen(format));
+#ifdef __CAPIO_POSIX
+        if (current_log_level == 0 && logging_syscall) {
+            log_write_to(const_cast<char *>(CAPIO_LOG_POSIX_SYSCALL_END),
+                         strlen(CAPIO_LOG_POSIX_SYSCALL_END));
+        }
+#endif
+    }
+
     inline void log(const char *message, ...) {
         va_list argp, argpc;
 
@@ -254,21 +272,6 @@ class Logger {
         va_end(argp);
         va_end(argpc);
         capio_syscall(SYS_munmap, buf, size);
-    }
-
-    inline ~Logger() {
-        current_log_level--;
-        sprintf(format, CAPIO_LOG_PRE_MSG, this->invoker);
-        size_t pre_msg_len = strlen(format);
-        strcpy(format + pre_msg_len, "returned");
-
-        log_write_to(format, strlen(format));
-#ifdef __CAPIO_POSIX
-        if (current_log_level == 0 && logging_syscall) {
-            log_write_to(const_cast<char *>(CAPIO_LOG_POSIX_SYSCALL_END),
-                         strlen(CAPIO_LOG_POSIX_SYSCALL_END));
-        }
-#endif
     }
 };
 

--- a/src/common/capio/spsc_queue.hpp
+++ b/src/common/capio/spsc_queue.hpp
@@ -10,7 +10,7 @@
  * Each element of the circular buffer has the same size.
  */
 
-template <class T> class SPSC_queue {
+template <class T> class SPSCQueue {
   private:
     void *_shm;
     const long int _max_num_elems;
@@ -41,8 +41,8 @@ template <class T> class SPSC_queue {
     }
 
   public:
-    SPSC_queue(const std::string &shm_name, const long int _max_num_elems, const long int elem_size,
-               long int sem_timeout, int sem_retries)
+    SPSCQueue(const std::string &shm_name, const long int _max_num_elems, const long int elem_size,
+              long int sem_timeout, int sem_retries)
         : _max_num_elems(_max_num_elems), _elem_size(elem_size), _shm_name(shm_name) {
         START_LOG(capio_syscall(SYS_gettid),
                   "call(shm_name=%s, _max_num_elems=%ld, elem_size=%ld, "
@@ -75,7 +75,7 @@ template <class T> class SPSC_queue {
         }
     }
 
-    ~SPSC_queue() {
+    ~SPSCQueue() {
         sem_close(_sem_num_elems);
         sem_close(_sem_num_empty);
     }

--- a/src/posix/utils/data.hpp
+++ b/src/posix/utils/data.hpp
@@ -17,12 +17,12 @@ inline void init_data_plane() { threads_data_bufs = new CPThreadDataBufs_t; }
  * @return
  */
 inline void register_data_listener(long tid) {
-    auto *write_queue = new SPSC_queue<char>(
+    auto *write_queue = new SPSCQueue<char>(
         "capio_write_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
         CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
-    auto *read_queue = new SPSC_queue<char>(
-        "capio_read_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
-        CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+    auto *read_queue = new SPSCQueue<char>("capio_read_data_buffer_tid_" + std::to_string(tid),
+                                           CAPIO_DATA_BUFFER_LENGTH, CAPIO_DATA_BUFFER_ELEMENT_SIZE,
+                                           CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     threads_data_bufs->insert({static_cast<int>(tid), {write_queue, read_queue}});
 }
 

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -31,8 +31,8 @@ inline void init_client() {
 inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
     auto *p_buf_response =
-        new Circular_buffer<off_t>("buf_response_" + std::to_string(tid), 8 * 1024 * 1024,
-                                   sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+        new CircularBuffer<off_t>("buf_response_" + std::to_string(tid), 8 * 1024 * 1024,
+                                  sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 

--- a/src/posix/utils/types.hpp
+++ b/src/posix/utils/types.hpp
@@ -9,12 +9,11 @@
 
 typedef std::unordered_map<int, std::tuple<off64_t *, off64_t, int, bool>> CPFiles_t;
 typedef std::pair<off64_t, off64_t> CPStatResponse_t;
-typedef Circular_buffer<char> CPBufRequest_t;
-typedef std::unordered_map<long, Circular_buffer<off_t> *> CPBufResponse_t;
+typedef CircularBuffer<char> CPBufRequest_t;
+typedef std::unordered_map<long, CircularBuffer<off_t> *> CPBufResponse_t;
 typedef std::unordered_map<int, std::string> CPFileDescriptors_t;
 typedef std::unordered_map<std::string, std::unordered_set<int>> CPFilesPaths_t;
-typedef std::unordered_map<int, std::pair<SPSC_queue<char> *, SPSC_queue<char> *>>
-    CPThreadDataBufs_t;
+typedef std::unordered_map<int, std::pair<SPSCQueue<char> *, SPSCQueue<char> *>> CPThreadDataBufs_t;
 
 typedef int (*CPHandler_t)(long, long, long, long, long, long, long *);
 

--- a/src/server/handlers/common.hpp
+++ b/src/server/handlers/common.hpp
@@ -7,10 +7,10 @@ inline void init_process(int tid) {
     if (data_buffers.find(tid) == data_buffers.end()) {
         register_listener(tid);
 
-        auto *write_data_cb = new SPSC_queue<char>(
+        auto *write_data_cb = new SPSCQueue<char>(
             "capio_write_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
             CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
-        auto *read_data_cb = new SPSC_queue<char>(
+        auto *read_data_cb = new SPSCQueue<char>(
             "capio_read_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
             CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
         data_buffers.insert({tid, {write_data_cb, read_data_cb}});

--- a/src/server/utils/requests.hpp
+++ b/src/server/utils/requests.hpp
@@ -45,8 +45,8 @@ inline void destroy_server() {
 inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
     auto *p_buf_response =
-        new Circular_buffer<off_t>("buf_response_" + std::to_string(tid), 8 * 1024 * 1024,
-                                   sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+        new CircularBuffer<off_t>("buf_response_" + std::to_string(tid), 8 * 1024 * 1024,
+                                  sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 

--- a/src/server/utils/types.hpp
+++ b/src/server/utils/types.hpp
@@ -17,8 +17,7 @@ typedef std::unordered_map<int, std::unordered_map<int, std::pair<CapioFile *, o
     CSProcessFileMap_t;
 typedef std::unordered_map<int, std::unordered_map<int, std::filesystem::path>>
     CSProcessFileMetadataMap_t;
-typedef std::unordered_map<int, std::pair<SPSC_queue<char> *, SPSC_queue<char> *>>
-    CSDataBufferMap_t;
+typedef std::unordered_map<int, std::pair<SPSCQueue<char> *, SPSCQueue<char> *>> CSDataBufferMap_t;
 typedef std::unordered_map<std::string, CapioFile *> CSFilesMetadata_t;
 typedef std::unordered_map<
     std::string, std::tuple<std::string, std::string, std::string, long int, bool, long int>>
@@ -43,8 +42,8 @@ typedef std::unordered_map<std::string,
                            std::list<std::tuple<const std::filesystem::path, size_t, int,
                                                 std::vector<std::string> *, sem_t *>>>
     CSClientsRemotePendingNFilesMap_t;
-typedef std::unordered_map<int, Circular_buffer<off_t> *> CSBufResponse_t;
-typedef Circular_buffer<char> CSBufRequest_t;
+typedef std::unordered_map<int, CircularBuffer<off_t> *> CSBufResponse_t;
+typedef CircularBuffer<char> CSBufRequest_t;
 
 typedef void (*CSHandler_t)(const char *const, int);
 


### PR DESCRIPTION
This commit adjusts existing classes in two ways:

- It uniforms all class names to CamelCase
- It deletes unwanted copy constructors, whenever a class implements a custom destructor