### PR TITLE
Delete `CapioFile` copy constructors

### DIFF
--- a/src/common/capio/spsc_queue.hpp
+++ b/src/common/capio/spsc_queue.hpp
@@ -75,6 +75,9 @@ template <class T> class SPSCQueue {
         }
     }
 
+    SPSCQueue(const SPSCQueue &)            = delete;
+    SPSCQueue &operator=(const SPSCQueue &) = delete;
+
     ~SPSCQueue() {
         sem_close(_sem_num_elems);
         sem_close(_sem_num_empty);

--- a/src/server/handlers/common.hpp
+++ b/src/server/handlers/common.hpp
@@ -62,16 +62,16 @@ void handle_pending_remote_nfiles(const std::filesystem::path &path) {
         auto &app_pending_nfiles = p.second;
         auto it                  = app_pending_nfiles.begin();
         while (it != app_pending_nfiles.end()) {
-            auto &[prefix, n_files, dest, files_path, sem] = *it;
-            std::unordered_set<std::string> &files         = files_sent[app];
-            auto file_location_opt                         = get_file_location_opt(path);
-            auto next_it                                   = std::next(it);
+            auto &[prefix, batch_size, dest, files_path, sem] = *it;
+            std::unordered_set<std::string> &files            = files_sent[app];
+            auto file_location_opt                            = get_file_location_opt(path);
+            auto next_it                                      = std::next(it);
             if (files.find(path) == files.end() && file_location_opt &&
                 strcmp(std::get<0>(file_location_opt->get()), node_name) == 0 &&
                 path.native().compare(0, prefix.native().length(), prefix) == 0) {
                 files_path->push_back(path);
                 files.insert(path);
-                if (files_path->size() == n_files) {
+                if (files_path->size() == batch_size) {
                     app_pending_nfiles.erase(it);
                     if (sem_post(sem) == -1) {
                         ERR_EXIT("sem_post sem in "

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -74,7 +74,7 @@ inline void reply_stat(int tid, const std::filesystem::path &path, int rank) {
     } else {
         LOG("Delegating backend to reply to remote stats");
         // init a capio file that is remote so that buffer is going to be allocated
-        init_capio_file(path, false);
+        c_file.create_buffer_if_needed(path, false);
         backend->handle_remote_stat(tid, path, rank);
         const std::lock_guard<std::mutex> lg(pending_remote_stats_mutex);
         pending_remote_stats[path].emplace_back(tid);

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -10,13 +10,14 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count, in
     // check if another process is waiting for this data
     off64_t data_size                 = base_offset + count;
     const std::filesystem::path &path = get_capio_file_path(tid, fd);
-    CapioFile &c_file                 = init_capio_file(path, true);
+    CapioFile &c_file                 = get_capio_file(path);
     size_t file_shm_size              = c_file.get_buf_size();
     auto *data_buf                    = data_buffers[tid].first;
     size_t n_reads                    = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
     size_t r                          = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
     size_t i                          = 0;
     char *p;
+    c_file.create_buffer_if_needed(path, true);
     if (data_size > file_shm_size) {
         c_file.expand_buffer(data_size);
     }

--- a/src/server/remote/backend.hpp
+++ b/src/server/remote/backend.hpp
@@ -21,6 +21,10 @@ class RemoteRequest {
             this->_code = -1;
         }
     };
+
+    RemoteRequest(const RemoteRequest &)            = delete;
+    RemoteRequest &operator=(const RemoteRequest &) = delete;
+
     ~RemoteRequest() { delete[] _buf_recv; }
 
     [[nodiscard]] auto get_source() const { return this->_source; }

--- a/src/server/remote/backend/mpi.hpp
+++ b/src/server/remote/backend/mpi.hpp
@@ -124,7 +124,7 @@ class MPIBackend : public Backend {
         MPI_Send(msg.c_str(), msg.length() + 1, MPI_CHAR, dest, 0, MPI_COMM_WORLD);
 
         for (const std::string &path : *files_to_send) {
-            CapioFile c_file = get_capio_file(path.c_str());
+            CapioFile &c_file = get_capio_file(path.c_str());
             send_file(c_file.get_buffer(), c_file.get_stored_size(), dest);
         }
     }

--- a/src/server/remote/handlers/send.hpp
+++ b/src/server/remote/handlers/send.hpp
@@ -10,7 +10,8 @@ inline void handle_remote_send(const std::filesystem::path &path, off64_t offset
               path.c_str(), offset, nbytes, complete ? "true" : "false", file_size, dest);
 
     char *file_shm    = nullptr;
-    CapioFile &c_file = init_capio_file(path, file_shm);
+    CapioFile &c_file = get_capio_file(path);
+    c_file.create_buffer_if_needed(path, false);
     if (nbytes != 0) {
         auto file_shm_size  = c_file.get_buf_size();
         auto file_size_recv = offset + nbytes;
@@ -32,7 +33,8 @@ handle_remote_send_batch(const std::vector<std::pair<std::filesystem::path, off6
         void *p_shm;
         auto c_file_opt = get_capio_file_opt(path);
         if (c_file_opt) {
-            CapioFile &c_file    = init_capio_file(path, false);
+            CapioFile &c_file = get_capio_file(path);
+            c_file.create_buffer_if_needed(path, false);
             p_shm                = c_file.get_buffer();
             size_t file_shm_size = c_file.get_buf_size();
             if (nbytes > file_shm_size) {

--- a/src/server/remote/handlers/stat.hpp
+++ b/src/server/remote/handlers/stat.hpp
@@ -43,7 +43,7 @@ inline void handle_remote_stat(const std::filesystem::path &path, int dest) {
         if (match_globs(path) != -1) {
             LOG("File is in globs. creating capio_file and starting thread awaiting for future "
                 "creation of file");
-            auto file = create_capio_file(path, false, CAPIO_DEFAULT_FILE_INITIAL_SIZE);
+            CapioFile &file = create_capio_file(path, false, CAPIO_DEFAULT_FILE_INITIAL_SIZE);
             wait_for_file_stat(path, dest, file);
         } else {
             ERR_EXIT("Error capio file is not present, nor is going to be created in the future.");

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -92,7 +92,8 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path,
     long int ld_size = CAPIO_THEORETICAL_SIZE_DIRENT64;
     ld.d_reclen      = ld_size;
 
-    CapioFile &c_file    = init_capio_file(dir, true);
+    CapioFile &c_file = get_capio_file(dir);
+    c_file.create_buffer_if_needed(dir, true);
     void *file_shm       = c_file.get_buffer();
     off64_t file_size    = c_file.get_stored_size();
     off64_t data_size    = file_size + ld_size; // TODO: check theoreitcal size and sizeof(ld) usage

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -98,7 +98,7 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
                     ERR_EXIT("error commit rule is mandatory in streaming section");
                 } else {
                     auto pos = committed.find(':');
-                    if (pos != -1) {
+                    if (pos != std::string::npos) {
                         commit_rule = committed.substr(0, pos);
                         if (commit_rule != CAPIO_FILE_COMMITTED_ON_CLOSE) {
                             std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "commit rule "


### PR DESCRIPTION
This commit deletes the `CapioFile` copy constructors to prepare it for containing `std::mutex` objects. To do that, it converts the `init_capio_file` function to a method of the `CapioFile` class, in order to avoid spurious copy.

This commit introduces also other small fixes and refactors, like deleting further unwanted copy constructors.