### PR TITLE
Refactor synchronization protocol for stat

### DIFF
--- a/src/common/capio/requests.hpp
+++ b/src/common/capio/requests.hpp
@@ -23,12 +23,11 @@ constexpr const int CAPIO_REQUEST_SEEK_DATA           = 18;
 constexpr const int CAPIO_REQUEST_SEEK_END            = 19;
 constexpr const int CAPIO_REQUEST_SEEK_HOLE           = 20;
 constexpr const int CAPIO_REQUEST_STAT                = 21;
-constexpr const int CAPIO_REQUEST_STAT_REPLY          = 22;
-constexpr const int CAPIO_REQUEST_UNLINK              = 23;
-constexpr const int CAPIO_REQUEST_WRITE               = 24;
-constexpr const int CAPIO_REQUEST_RMDIR               = 25;
+constexpr const int CAPIO_REQUEST_UNLINK              = 22;
+constexpr const int CAPIO_REQUEST_WRITE               = 23;
+constexpr const int CAPIO_REQUEST_RMDIR               = 24;
 
-constexpr const int CAPIO_NR_REQUESTS = 26;
+constexpr const int CAPIO_NR_REQUESTS = 25;
 
 /*REQUESTS FOR SERVER TO SERVER COMMUNICATION*/
 

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -107,7 +107,6 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     _request_handlers[CAPIO_REQUEST_SEEK_END]            = seek_end_handler;
     _request_handlers[CAPIO_REQUEST_SEEK_HOLE]           = seek_hole_handler;
     _request_handlers[CAPIO_REQUEST_STAT]                = stat_handler;
-    _request_handlers[CAPIO_REQUEST_STAT_REPLY]          = stat_reply_handler;
     _request_handlers[CAPIO_REQUEST_UNLINK]              = unlink_handler;
     _request_handlers[CAPIO_REQUEST_WRITE]               = write_handler;
 
@@ -124,9 +123,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     setup_signal_handlers();
     backend->handshake_servers(rank);
     open_files_location(rank);
-    create_dir(getpid(), get_capio_dir(),
-               rank); // TODO: can be a problem if a process execute readdir
-    // on capio_dir
+    create_dir(getpid(), get_capio_dir(), rank);
 
     init_server();
 

--- a/src/server/handlers/close.hpp
+++ b/src/server/handlers/close.hpp
@@ -31,9 +31,6 @@ inline void handle_close(int tid, int fd, int rank) {
             }
             pending_reads.erase(it);
         }
-        if (c_file.is_dir()) {
-            wake_pending_remote_stats(path);
-        }
         // TODO: error if seek are done and also do this on exit
         handle_pending_remote_reads(path, c_file.get_sector_end(0), true);
         handle_pending_remote_nfiles(path);

--- a/src/server/handlers/exig.hpp
+++ b/src/server/handlers/exig.hpp
@@ -22,7 +22,6 @@ inline void handle_exit_group(int tid, int rank) {
                     LOG("file %s is dir", path.c_str());
                     long int n_committed = c_file.n_files_expected;
                     if (n_committed <= c_file.n_files) {
-                        wake_pending_remote_stats(path);
                         LOG("Setting file %s to complete", path.c_str());
                         c_file.set_complete();
                     }

--- a/src/server/remote/backend.hpp
+++ b/src/server/remote/backend.hpp
@@ -124,10 +124,9 @@ class Backend {
      * Handle a remote stat
      * @param path Pathname of stat to be carried on
      * @param dest Target to send the stats of @param path to
-     * @param c_file the capio file on which the stat is carried out
+     * @param source_tid The tid to which to reply to
      */
-    virtual void serve_remote_stat(const std::filesystem::path &path, int dest,
-                                   const CapioFile &c_file) = 0;
+    virtual void serve_remote_stat(const std::filesystem::path &path, int dest, int source_tid) = 0;
 
     /**
      * Handle a remote stat request

--- a/src/server/remote/handlers/stat.hpp
+++ b/src/server/remote/handlers/stat.hpp
@@ -3,67 +3,64 @@
 
 #include "remote/backend.hpp"
 
-void wait_for_completion(const std::filesystem::path &path, const CapioFile &c_file, int dest,
-                         sem_t *data_is_complete) {
+void wait_for_completion(const std::filesystem::path &path, int source_tid, int dest) {
     START_LOG(gettid(), "call(path=%s, dest=%d)", path.c_str(), dest);
 
-    SEM_WAIT_CHECK(data_is_complete, "data_is_complete");
+    const CapioFile &c_file = get_capio_file(path);
+    c_file.wait_for_completion();
     LOG("File %s has been completed. serving stats data", path.c_str());
-    backend->serve_remote_stat(path, dest, c_file);
-
-    delete data_is_complete;
+    backend->serve_remote_stat(path, dest, source_tid);
 }
 
-void wait_for_file_stat(const std::filesystem::path &path, int dest, CapioFile &c_file) {
-    START_LOG(gettid(), "call(path_c=%s, dest=%d, c_file=%ld)", path.c_str(), dest, &c_file);
-    auto sem = new sem_t;
-
-    if (sem_init(sem, 0, 0) == -1) {
-        ERR_EXIT("sem_init in remote_listener_stat_req");
-    }
-    clients_remote_pending_stat[path].emplace_back(sem);
-    std::thread t(wait_for_completion, path, std::cref(c_file), dest, sem);
-    t.detach();
-}
-
-inline void handle_remote_stat(const std::filesystem::path &path, int dest) {
-    START_LOG(gettid(), "call(path=%s, dest=%d)", path.c_str(), dest);
+inline void handle_remote_stat(int source_tid, const std::filesystem::path &path, int dest) {
+    START_LOG(gettid(), "call(source_tid=%d, path=%s, dest=%d)", source_tid, path.c_str(), dest);
 
     auto c_file = get_capio_file_opt(path);
     if (c_file) {
-        if (c_file->get().is_complete()) {
+        if (c_file->get().is_complete() || c_file->get().get_mode() == CAPIO_FILE_MODE_NO_UPDATE) {
             LOG("file is complete. serving file");
-            backend->serve_remote_stat(path, dest, c_file->get());
+            backend->serve_remote_stat(path, dest, source_tid);
         } else { // wait for completion
-            LOG("File is not complete. awaiting completion on different thread");
-            wait_for_file_stat(path, dest, c_file->get());
+            LOG("File is not _complete. awaiting completion on different thread");
+            std::thread t(wait_for_completion, path, source_tid, dest);
+            t.detach();
         }
     } else {
         LOG("CAPIO file is not in metadata. checking in globs for files to be created");
         if (match_globs(path) != -1) {
             LOG("File is in globs. creating capio_file and starting thread awaiting for future "
                 "creation of file");
-            CapioFile &file = create_capio_file(path, false, CAPIO_DEFAULT_FILE_INITIAL_SIZE);
-            wait_for_file_stat(path, dest, file);
+            create_capio_file(path, false, CAPIO_DEFAULT_FILE_INITIAL_SIZE);
+            std::thread t(wait_for_completion, path, source_tid, dest);
+            t.detach();
         } else {
             ERR_EXIT("Error capio file is not present, nor is going to be created in the future.");
         }
     }
 }
 
+inline void handle_remote_stat_reply(const std::filesystem::path &path, int source_tid,
+                                     off64_t size, bool dir) {
+    START_LOG(gettid(), "call(path=%s, source_tid=%d, size=%ld, dir=%s)", path.c_str(), source_tid,
+              size, dir ? "true" : "false");
+
+    write_response(source_tid, size);
+    write_response(source_tid, static_cast<off64_t>(dir));
+}
+
 void remote_stat_handler(const RemoteRequest &request) {
     char path[PATH_MAX];
-    int dest;
-    sscanf(request.get_content(), "%d %s", &dest, path);
-    handle_remote_stat(path, dest);
+    int dest, tid;
+    sscanf(request.get_content(), "%d %d %s", &tid, &dest, path);
+    handle_remote_stat(tid, path, dest);
 }
 
 void remote_stat_reply_handler(const RemoteRequest &request) {
     char path[PATH_MAX];
     off64_t size;
-    int dir;
-    sscanf(request.get_content(), "%s %ld %d", path, &size, &dir);
-    stat_reply_request(path, size, dir);
+    int dir, source_tid;
+    sscanf(request.get_content(), "%s %d %ld %d", path, &source_tid, &size, &dir);
+    handle_remote_stat_reply(path, source_tid, size, dir);
 }
 
 #endif // CAPIO_SERVER_REMOTE_HANDLERS_STAT_HPP

--- a/src/server/utils/requests.hpp
+++ b/src/server/utils/requests.hpp
@@ -103,10 +103,4 @@ inline void read_reply_request(const std::filesystem::path &path, off64_t size, 
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
 }
 
-inline void stat_reply_request(const std::filesystem::path &path, off64_t size, int dir) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
-    sprintf(req, "%04d %s %ld %d", CAPIO_REQUEST_STAT_REPLY, path.c_str(), size, dir);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
-}
-
 #endif // CAPIO_SERVER_REQUESTS_HPP

--- a/src/server/utils/types.hpp
+++ b/src/server/utils/types.hpp
@@ -34,10 +34,8 @@ typedef std::unordered_map<std::string, std::vector<std::tuple<int, int, off64_t
     CSPendingReadsMap_t;
 typedef std::unordered_map<std::string, std::list<std::tuple<int, int, off64_t, bool>>>
     CSMyRemotePendingReads_t;
-typedef std::unordered_map<std::string, std::list<int>> CSMyRemotePendingStats_t;
 typedef std::unordered_map<std::string, std::list<std::tuple<size_t, size_t, sem_t *>>>
     CSClientsRemotePendingReads_t;
-typedef std::unordered_map<std::string, std::list<sem_t *>> CSClientsRemotePendingStats_t;
 typedef std::unordered_map<std::string,
                            std::list<std::tuple<const std::filesystem::path, size_t, int,
                                                 std::vector<std::string> *, sem_t *>>>


### PR DESCRIPTION
This commit rewrites the synchronization protocol for the `stat` syscall. In particular, it replaces semaphores with `std::mutex` and `std::condition_variable` objects and removes explicit awake methods with the condition variable `wait` and `notify` mechanisms.