### PR TITLE
Refactor `load_file_location` protocol

### DIFF
--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -114,8 +114,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     MPI_Comm_size(MPI_COMM_WORLD, &n_servers);
     setup_signal_handlers();
     backend->handshake_servers(rank);
-    open_files_location(rank);
-    create_dir(getpid(), get_capio_dir(), rank);
+    create_dir(getpid(), get_capio_dir());
 
     init_server();
 
@@ -251,6 +250,7 @@ int main(int argc, char **argv) {
 
     START_LOG(gettid(), "call()");
 
+    open_files_location();
     backend->initialize(argc, argv, &rank, &provided);
 
     int res = sem_init(&internal_server_sem, 0, 0);

--- a/src/server/handlers/close.hpp
+++ b/src/server/handlers/close.hpp
@@ -5,8 +5,8 @@
 
 #include "utils/filesystem.hpp"
 
-inline void handle_close(int tid, int fd, int rank) {
-    START_LOG(gettid(), "call(tid=%d, fd=%d, rank=%d)", tid, fd, rank);
+inline void handle_close(int tid, int fd) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d)", tid, fd);
 
     const std::filesystem::path &path = get_capio_file_path(tid, fd);
     if (path.empty()) { // avoid to try to close a file that does not exists
@@ -26,7 +26,7 @@ inline void handle_close(int tid, int fd, int rank) {
 
     if (c_file.is_deletable()) {
         delete_capio_file(path);
-        delete_from_file_locations(path, rank);
+        delete_from_files_location(path);
     } else {
         LOG("Deleting capio file from tid=%d", tid);
         delete_capio_file_from_tid(tid, fd);
@@ -36,7 +36,7 @@ inline void handle_close(int tid, int fd, int rank) {
 void close_handler(const char *str, int rank) {
     int tid, fd;
     sscanf(str, "%d %d", &tid, &fd);
-    handle_close(tid, fd, rank);
+    handle_close(tid, fd);
 }
 
 #endif // CAPIO_SERVER_HANDLERS_CLOSE_HPP

--- a/src/server/handlers/exig.hpp
+++ b/src/server/handlers/exig.hpp
@@ -1,8 +1,8 @@
 #ifndef CAPIO_SERVER_HANDLERS_EXITG_HPP
 #define CAPIO_SERVER_HANDLERS_EXITG_HPP
 
-inline void handle_exit_group(int tid, int rank) {
-    START_LOG(gettid(), "call(tid=%d, rank=%d)", tid, rank);
+inline void handle_exit_group(int tid) {
+    START_LOG(gettid(), "call(tid=%d)", tid);
 
     LOG("retrieving pid for process with tid = %d", tid);
     int pid = pids[tid];
@@ -35,7 +35,7 @@ inline void handle_exit_group(int tid, int rank) {
     }
 
     for (auto &fd : get_capio_fds_for_tid(tid)) {
-        handle_close(tid, fd, rank);
+        handle_close(tid, fd);
     }
     free_resources(tid);
 }
@@ -43,7 +43,7 @@ inline void handle_exit_group(int tid, int rank) {
 void exit_group_handler(const char *const str, int rank) {
     int tid;
     sscanf(str, "%d", &tid);
-    handle_exit_group(tid, rank);
+    handle_exit_group(tid);
 }
 
 #endif // CAPIO_SERVER_HANDLERS_EXITG_HPP

--- a/src/server/handlers/mkdir.hpp
+++ b/src/server/handlers/mkdir.hpp
@@ -5,7 +5,7 @@ void mkdir_handler(const char *const str, int rank) {
     pid_t tid;
     char pathname[PATH_MAX];
     sscanf(str, "%d %s", &tid, pathname);
-    write_response(tid, create_dir(tid, pathname, rank));
+    write_response(tid, create_dir(tid, pathname));
 }
 
 #endif // CAPIO_SERVER_HANDLERS_MKDIR_HPP

--- a/src/server/handlers/open.hpp
+++ b/src/server/handlers/open.hpp
@@ -29,8 +29,8 @@ inline void update_file_metadata(const std::filesystem::path &path, int tid, int
     }
     if (c_file.first_write && is_creat) {
         c_file.first_write = false;
-        write_file_location(rank, path, tid);
-        update_dir(tid, path, rank);
+        write_file_location(path);
+        update_dir(tid, path);
     }
 }
 

--- a/src/server/handlers/rename.hpp
+++ b/src/server/handlers/rename.hpp
@@ -18,13 +18,13 @@ void handle_rename(int tid, const std::filesystem::path &oldpath,
             }
         }
     }
-    int res = delete_from_file_locations("files_location.txt", oldpath, rank);
+    int res = delete_from_files_location(oldpath);
     if (res != 1) {
         write_response(tid, 1);
         return;
     }
     rename_file_location(oldpath, newpath);
-    write_file_location(rank, newpath, tid);
+    write_file_location(newpath);
     write_response(tid, 0);
 }
 

--- a/src/server/handlers/rmdir.hpp
+++ b/src/server/handlers/rmdir.hpp
@@ -3,12 +3,10 @@
 
 #include "utils/location.hpp"
 
-inline void handle_rmdir(int tid, const std::filesystem::path &dir_to_remove, int rank) {
-    START_LOG(gettid(), "call(tid=%d, dir_to_remove=%s, rank=%d)", tid, dir_to_remove.c_str(),
-              rank);
+inline void handle_rmdir(int tid, const std::filesystem::path &dir_to_remove) {
+    START_LOG(gettid(), "call(tid=%d, dir_to_remove=%s)", tid, dir_to_remove.c_str());
 
-    long res = delete_from_file_locations("files_location.txt", dir_to_remove, rank);
-    erase_from_files_location(dir_to_remove);
+    int res = delete_from_files_location(dir_to_remove);
     write_response(tid, res);
 }
 
@@ -16,7 +14,7 @@ void rmdir_handler(const char *const str, int rank) {
     char dir_to_remove[PATH_MAX];
     int tid;
     sscanf(str, "%s %d", dir_to_remove, &tid);
-    handle_rmdir(tid, dir_to_remove, rank);
+    handle_rmdir(tid, dir_to_remove);
 }
 
 #endif // CAPIO_SERVER_HANDLERS_RMDIR_HPP

--- a/src/server/handlers/unlink.hpp
+++ b/src/server/handlers/unlink.hpp
@@ -1,8 +1,8 @@
 #ifndef CAPIO_SERVER_HANDLERS_UNLINK_HPP
 #define CAPIO_SERVER_HANDLERS_UNLINK_HPP
 
-inline void handle_unlink(int tid, const std::filesystem::path &path, int rank) {
-    START_LOG(gettid(), "call(tid=%d, path=%s, rank=%d)", tid, path.c_str(), rank);
+inline void handle_unlink(int tid, const std::filesystem::path &path) {
+    START_LOG(gettid(), "call(tid=%d, path=%s)", tid, path.c_str());
 
     auto c_file_opt = get_capio_file_opt(path);
     if (c_file_opt) { // TODO: it works only in the local case
@@ -10,7 +10,7 @@ inline void handle_unlink(int tid, const std::filesystem::path &path, int rank) 
         c_file.unlink();
         if (c_file.is_deletable()) {
             delete_capio_file(path);
-            delete_from_file_locations(path, rank);
+            delete_from_files_location(path);
         }
         write_response(tid, 0);
     } else {
@@ -22,7 +22,7 @@ void unlink_handler(const char *const str, int rank) {
     char path[PATH_MAX];
     int tid;
     sscanf(str, "%d %s", &tid, path);
-    handle_unlink(tid, path, rank);
+    handle_unlink(tid, path);
 }
 
 #endif // CAPIO_SERVER_HANDLERS_UNLINK_HPP

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -32,9 +32,9 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count, in
     c_file.insert_sector(base_offset, data_size);
     if (c_file.first_write) {
         c_file.first_write = false;
-        write_file_location(rank, path, tid);
+        write_file_location(path);
         // TODO: it works only if there is one prod per file
-        update_dir(tid, path, rank);
+        update_dir(tid, path);
     }
 }
 

--- a/src/server/remote/backend/mpi.hpp
+++ b/src/server/remote/backend/mpi.hpp
@@ -39,10 +39,6 @@ class MPIBackend : public Backend {
         START_LOG(gettid(), "call(%d)", rank);
 
         auto buf = new char[MPI_MAX_PROCESSOR_NAME];
-
-        if (rank == 0) {
-            clean_files_location();
-        }
         for (int i = 0; i < n_servers; i += 1) {
             if (i != rank) {
                 // TODO: possible deadlock

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -72,19 +72,19 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path,
     }
 }
 
-void update_dir(int tid, const std::filesystem::path &file_path, int rank) {
-    START_LOG(gettid(), "call(file_path=%s, rank=%d)", file_path.c_str(), rank);
+void update_dir(int tid, const std::filesystem::path &file_path) {
+    START_LOG(gettid(), "call(file_path=%s)", file_path.c_str());
     const std::filesystem::path dir = get_parent_dir_path(file_path);
     CapioFile &c_file               = get_capio_file(dir.c_str());
     if (c_file.first_write) {
         c_file.first_write = false;
-        write_file_location(rank, dir, tid);
+        write_file_location(dir);
     }
     write_entry_dir(tid, file_path, dir, 0);
 }
 
-off64_t create_dir(int tid, const std::filesystem::path &path, int rank) {
-    START_LOG(tid, "call(path=%s, rank=%d)", path.c_str(), rank);
+off64_t create_dir(int tid, const std::filesystem::path &path) {
+    START_LOG(tid, "call(path=%s)", path.c_str());
 
     if (!get_file_location_opt(path)) {
         CapioFile &c_file = create_capio_file(path, true, CAPIO_DEFAULT_DIR_INITIAL_SIZE);
@@ -94,8 +94,8 @@ off64_t create_dir(int tid, const std::filesystem::path &path, int rank) {
             if (is_capio_dir(path)) {
                 add_file_location(path, node_name, -1);
             } else {
-                write_file_location(rank, path, tid);
-                update_dir(tid, path, rank);
+                write_file_location(path);
+                update_dir(tid, path);
             }
             write_entry_dir(tid, path, path, 1);
             const std::filesystem::path parent_dir = get_parent_dir_path(path);

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -6,25 +6,23 @@
 
 #include "utils/types.hpp"
 
+constexpr char CAPIO_SERVER_FILES_LOCATION_NAME[]     = "files_location.txt";
 constexpr char CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR = '#';
 
 CSFilesLocationMap_t files_location;
 std::mutex files_location_mutex;
 
-int fd_files_location;
-CSFDFileLocationReadsVector_t fd_files_location_reads;
+int files_location_fd;
+FILE *files_location_fp;
 
 class FlockGuard {
   private:
     int _fd;
     struct flock _lock;
-    bool _close_file;
 
   public:
-    inline explicit FlockGuard(const int fd, const short l_type, bool close_file)
-        : _fd(fd), _lock(), _close_file(close_file) {
-        START_LOG(gettid(), "call(fd=%d, l_type=%d, close_file=%s)", _fd, l_type,
-                  close_file ? "true" : "false");
+    inline explicit FlockGuard(const int fd, const short l_type) : _fd(fd), _lock() {
+        START_LOG(gettid(), "call(fd=%d, l_type=%d)", _fd, l_type);
 
         _lock.l_type   = l_type;
         _lock.l_whence = SEEK_SET;
@@ -33,7 +31,8 @@ class FlockGuard {
         _lock.l_pid    = getpid();
         if (fcntl(_fd, F_SETLKW, &_lock) < 0) {
             close(_fd);
-            ERR_EXIT("CAPIO server failed to lock the file");
+            ERR_EXIT("CAPIO server failed to lock the file with error %d (%s)", errno,
+                     strerror(errno));
         }
     }
 
@@ -46,10 +45,8 @@ class FlockGuard {
         _lock.l_type = F_UNLCK;
         if (fcntl(_fd, F_SETLK, &_lock) < 0) {
             close(_fd);
-            ERR_EXIT("CAPIO server failed to unlock the file");
-        }
-        if (_close_file) {
-            close(_fd);
+            ERR_EXIT("CAPIO server failed to unlock the file with error %d (%s)", errno,
+                     strerror(errno));
         }
     }
 };
@@ -109,203 +106,126 @@ void rename_file_location(const std::filesystem::path &oldpath,
  */
 bool load_file_location(const std::filesystem::path &path_to_load) {
     START_LOG(gettid(), "call(path_to_load=%s)", path_to_load.c_str());
+
     auto line = reinterpret_cast<char *>(malloc((PATH_MAX + HOST_NAME_MAX + 10) * sizeof(char)));
-    for (int rank = 0; rank < n_servers; rank++) {
-        FILE *fp;
-        bool seek_needed;
-        size_t len = 0;
-        int fd;
-
-        if (rank < fd_files_location_reads.size()) {
-            fd          = std::get<0>(fd_files_location_reads[rank]);
-            fp          = std::get<1>(fd_files_location_reads[rank]);
-            seek_needed = std::get<2>(fd_files_location_reads[rank]);
-        } else {
-            if ((fp = fopen("files_location.txt", "r+")) == nullptr) {
-                LOG("Unable to open file_locations.txt from node with rank %d", rank);
-                continue;
-            }
-
-            if ((fd = fileno(fp)) == -1) {
-                ERR_EXIT(
-                    "Unable to get fileno from files_location.txt FILE ptr on node with rank %d",
-                    rank);
-            }
-            seek_needed = false;
-
-            fd_files_location_reads.emplace_back(fd, fp, seek_needed);
+    const FlockGuard fg(files_location_fd, F_RDLCK);
+    off64_t old_offset = lseek(files_location_fd, 0, SEEK_CUR);
+    if (old_offset == -1) {
+        ERR_EXIT("lseek 1 delete_from_files_location");
+    }
+    LOG("Current %s offset is %ld", CAPIO_SERVER_FILES_LOCATION_NAME, old_offset);
+    if (fseek(files_location_fp, 0, SEEK_SET) == -1) {
+        ERR_EXIT("fseek in load_file_location");
+    }
+    LOG("%s offset has been moved to the beginning of the file", CAPIO_SERVER_FILES_LOCATION_NAME);
+    size_t len = 0;
+    bool found = false;
+    while (getline(&line, &len, files_location_fp) != -1) {
+        if (line[0] == CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR) {
+            continue;
         }
+        std::string_view line_str(line);
+        auto separator = line_str.find_first_of(' ');
+        const std::filesystem::path path(line_str.substr(0, separator));
+        std::string node(line_str.substr(separator + 1, line_str.length())); // remove ' '
+        node.pop_back();                             // remove \n from node name
+        auto node_str = new char[node.length() + 1]; // do not call delete[] on this
+        strcpy(node_str, node.c_str());
+        if (path == path_to_load) {
+            LOG("path %s was found on node %s", path_to_load.c_str(), node_str);
+            off64_t offset = lseek(files_location_fd, 0, SEEK_CUR);
+            if (offset == -1) {
+                ERR_EXIT("ftell in load_file_location");
+            }
+            add_file_location(path, node_str, offset);
+            found = true;
+            break;
+        }
+    }
+    if (lseek(files_location_fd, old_offset, SEEK_SET) == -1) {
+        ERR_EXIT("lseek 3 delete_from_files_location");
+    }
+    LOG("%s offset has been restored to %ld", CAPIO_SERVER_FILES_LOCATION_NAME, old_offset);
+    free(line);
+    return found;
+}
 
-        const FlockGuard fg(fd, F_RDLCK, false);
+/*
+ * Returns 1 if the location of the file path_to_check is found
+ * Returns 2 otherwise
+ */
+int delete_from_files_location(const std::filesystem::path &path) {
+    START_LOG(gettid(), "call(%s)", path.c_str());
 
-        if (seek_needed && (fseek(fp, ftell(fp), SEEK_SET) == -1)) {
+    auto &[node, offset] = get_file_location(path);
+    erase_from_files_location(path);
+    for (auto &pair : writers) {
+        pair.second.erase(path);
+    }
+    if (offset == -1) {
+        const FlockGuard fg(files_location_fd, F_WRLCK);
+        long old_offset = lseek(files_location_fd, 0, SEEK_CUR);
+        if (old_offset == -1) {
+            ERR_EXIT("lseek 1 delete_from_files_location");
+        }
+        LOG("Current %s offset is %ld", CAPIO_SERVER_FILES_LOCATION_NAME, old_offset);
+        if (fseek(files_location_fp, 0, SEEK_SET) == -1) {
             ERR_EXIT("fseek in load_file_location");
         }
-
-        while (getline(&line, &len, fp) != -1) {
-
+        LOG("%s offset has been moved to the beginning of the file",
+            CAPIO_SERVER_FILES_LOCATION_NAME);
+        auto line =
+            reinterpret_cast<char *>(malloc((PATH_MAX + HOST_NAME_MAX + 10) * sizeof(char)));
+        size_t len = 0;
+        offset     = old_offset;
+        int result = 2;
+        while (getline(&line, &len, files_location_fp) != -1) {
             if (line[0] == CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR) {
                 continue;
             }
             std::string_view line_str(line);
             auto separator = line_str.find_first_of(' ');
-            const std::filesystem::path path(line_str.substr(0, separator));
-            std::string node(line_str.substr(separator + 1, line_str.length())); // remove ' '
-            node.pop_back(); // remove \n from node name
-
-            LOG("found [%s]@[%s]", path.c_str(), node.c_str());
-
-            auto node_str = new char[node.length() + 1]; // do not call delete[] on this
-            strcpy(node_str, node.c_str());
-            long offset = ftell(fp);
-            if (offset == -1) {
-                ERR_EXIT("ftell in load_file_location");
+            const std::filesystem::path current_path(line_str.substr(0, separator));
+            if (is_prefix(path, current_path)) {
+                result = 1;
+                LOG("Path %s should be deleted from %s", current_path.c_str(),
+                    CAPIO_SERVER_FILES_LOCATION_NAME);
+                if (lseek(files_location_fd, offset, SEEK_SET) == -1) {
+                    ERR_EXIT("fseek delete_from_file_location");
+                }
+                if (write(files_location_fd, &CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR,
+                          sizeof(char)) != 1) {
+                    ERR_EXIT("fwrite unable to invalidate file %s in %s", current_path.c_str(),
+                             CAPIO_SERVER_FILES_LOCATION_NAME);
+                }
+                LOG("Path %s has been deleted from %s", current_path.c_str(),
+                    CAPIO_SERVER_FILES_LOCATION_NAME);
             }
-            add_file_location(path, node_str, offset);
-            if (path == path_to_load) {
-                free(line);
-
-                LOG("path: %s, was found on node with rank %d", path_to_load.c_str(), rank);
-                return true;
-            }
+            offset = lseek(files_location_fd, 0, SEEK_CUR);
         }
-
-        std::get<2>(fd_files_location_reads[rank]) = true;
-    }
-    free(line);
-    LOG("path %s has not been found on remote nodes", path_to_load.c_str());
-    return false;
-}
-
-void clean_files_location() {
-    START_LOG(gettid(), "call()");
-
-    std::filesystem::remove("files_location.txt");
-}
-
-/*
- * Returns 0 if the file "file_name" does not exists
- * Returns 1 if the location of the file path_to_check is found
- * Returns 2 otherwise
- *
- */
-int delete_from_file_locations(const std::string &file_name,
-                               const std::filesystem::path &path_to_remove, int rank) {
-    START_LOG(gettid(), "call(%s, %s, %d)", file_name.c_str(), path_to_remove.c_str(), rank);
-
-    std::unique_ptr<char[]> line(new char[PATH_MAX]);
-
-    size_t len   = PATH_MAX;
-    ssize_t read = 0;
-    FILE *fp     = fopen(file_name.c_str(), "r+");
-    if (fp == nullptr) {
-        LOG("capio server %d failed to open the location file", rank);
-        return 0;
-    }
-    int fd = fileno(fp);
-    if (fd == -1) {
-        ERR_EXIT("fileno delete_from_file_location");
-    }
-    const FlockGuard fg(fd, F_WRLCK, true);
-    int found = 0;
-    long byte = 0;
-    while (read != -1 && !found) {
-        byte = ftell(fp);
-        if (byte == -1) {
-            ERR_EXIT("ftell delete_from_file_location");
+        if (lseek(files_location_fd, old_offset, SEEK_SET) == -1) {
+            ERR_EXIT("lseek 3 delete_from_files_location");
         }
-        char *line_addr = static_cast<char *>(line.get());
-        read            = getline(&line_addr, &len, fp);
-        if (read == -1) {
-            break;
+        LOG("%s offset has been restored to %ld", CAPIO_SERVER_FILES_LOCATION_NAME, old_offset);
+        free(line);
+        return result;
+    } else {
+        LOG("fast remove offset %ld", offset);
+        const FlockGuard fg(files_location_fd, F_WRLCK);
+        long old_offset = lseek(files_location_fd, 0, SEEK_CUR);
+        if (old_offset == -1) {
+            ERR_EXIT("lseek 1 delete_from_files_location");
         }
-        if (line[0] == CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR) {
-            continue;
+        if (lseek(files_location_fd, offset, SEEK_SET) == -1) {
+            ERR_EXIT("lseek 2 delete_from_files_location");
         }
-        char path[PATH_MAX];
-        int i = 0;
-        while (line[i] != ' ') {
-            path[i] = line[i];
-            ++i;
+        if (write(files_location_fd, &CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR, sizeof(char)) == -1) {
+            ERR_EXIT("write delete_from_files_location");
         }
-        path[i] = '\0';
-        if (strcmp(path, path_to_remove.c_str()) == 0) {
-            found++;
-
-            if (lseek(fd, byte, SEEK_SET) == -1) {
-                ERR_EXIT("fseek delete_from_file_location");
-            }
-            if (write(fd, &CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR, sizeof(char)) != 1) {
-                ERR_EXIT("fwrite unable to invalidate file %s in "
-                         "files_location_%d.txt",
-                         path_to_remove.c_str(), rank);
-            }
+        if (lseek(files_location_fd, old_offset, SEEK_SET) == -1) {
+            ERR_EXIT("lseek 3 delete_from_files_location");
         }
-    }
-
-    LOG("%d files have been invalidated!", found);
-
-    if (found > 0) {
         return 1;
-    } else {
-        return 2;
-    }
-}
-
-void delete_from_file_locations(long offset, std::size_t rank) {
-    START_LOG(gettid(), "call(%ld, %ld)", offset, rank);
-
-    int fd;
-    if (rank < fd_files_location_reads.size()) {
-        fd = std::get<0>(fd_files_location_reads[rank]);
-    } else {
-        std::string file_name = "files_location.txt";
-        FILE *fp              = fopen(file_name.c_str(), "r+");
-        if (fp == nullptr) {
-            ERR_EXIT("fopen %s delete_from_file_locations", file_name.c_str());
-        }
-        fd = fileno(fp);
-        if (fd == -1) {
-            ERR_EXIT("fileno delete_from_file_locations");
-        }
-        fd_files_location_reads.emplace_back(fd, fp, false);
-    }
-
-    FlockGuard fg(fd, F_WRLCK, false);
-    LOG("fast remove offset %ld", offset);
-    long old_offset = lseek(fd, 0, SEEK_CUR);
-    if (old_offset == -1) {
-        ERR_EXIT("lseek 1 delete_from_file_locations");
-    }
-    if (lseek(fd, offset, SEEK_SET) == -1) {
-        ERR_EXIT("lseek 2 delete_from_file_locations");
-    }
-    write(fd, &CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR, sizeof(char));
-    if (lseek(fd, old_offset, SEEK_SET) == -1) {
-        ERR_EXIT("lseek 3 delete_from_file_locations");
-    }
-}
-
-void delete_from_file_locations(const std::filesystem::path &path, int rank) {
-    START_LOG(gettid(), "call(%s, %d)", path.c_str(), rank);
-
-    bool found           = false;
-    int res              = -1;
-    auto &[node, offset] = get_file_location(path);
-    if (offset == -1) { // TODO: very inefficient
-        int r = 0;
-        while (!found && r < n_servers) {
-            res   = delete_from_file_locations("files_location.txt", path, rank);
-            found = res == 1;
-            ++r;
-        }
-    } else {
-        int r = (node == std::string(node_name)) ? rank : nodes_helper_rank[node];
-        delete_from_file_locations(offset, r);
-    }
-    erase_from_files_location(path);
-    for (auto &pair : writers) {
-        pair.second.erase(path);
     }
 }
 
@@ -317,27 +237,36 @@ void loop_load_file_location(const std::filesystem::path &path_to_load) {
     }
 }
 
-void open_files_location(int rank) {
-    START_LOG(gettid(), "call(%d)", rank);
+void open_files_location() {
+    START_LOG(gettid(), "call()");
 
-    int fd;
-    if ((fd = open("files_location.txt", O_WRONLY | O_APPEND | O_CREAT, 0664)) == -1) {
-        ERR_EXIT("writer error opening file");
+    if ((files_location_fp = fopen(CAPIO_SERVER_FILES_LOCATION_NAME, "w+")) == nullptr) {
+        ERR_EXIT("Error opening %s file: %d (%s)", CAPIO_SERVER_FILES_LOCATION_NAME, errno,
+                 strerror(errno));
     }
-    fd_files_location = fd;
+    if (chmod(CAPIO_SERVER_FILES_LOCATION_NAME, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) == -1) {
+        ERR_EXIT("Error changing permissions for %s file: %d (%s)",
+                 CAPIO_SERVER_FILES_LOCATION_NAME, errno, strerror(errno));
+    }
+    if ((files_location_fd = fileno(files_location_fp)) == -1) {
+        ERR_EXIT("Error obtaining file descriptor for %s file: %d (%s)",
+                 CAPIO_SERVER_FILES_LOCATION_NAME, errno, strerror(errno));
+    }
 }
 
-void write_file_location(int rank, const std::filesystem::path &path_to_write, int tid) {
-    START_LOG(gettid(), "call(rank=%d, path_to_write=%s)", rank, path_to_write.c_str());
+void write_file_location(const std::filesystem::path &path_to_write) {
+    START_LOG(gettid(), "call(path_to_write=%s)", path_to_write.c_str());
 
-    const FlockGuard fg(fd_files_location, F_WRLCK, false);
+    const FlockGuard fg(files_location_fd, F_WRLCK);
 
-    long offset = lseek(fd_files_location, 0, SEEK_CUR);
+    long offset = lseek(files_location_fd, 0, SEEK_CUR);
     if (offset == -1) {
         ERR_EXIT("lseek in write_file_location");
     }
     const std::string line = path_to_write.native() + " " + node_name + "\n";
-    write(fd_files_location, line.c_str(), line.length());
+    if (write(files_location_fd, line.c_str(), line.length()) == -1) {
+        ERR_EXIT("write in write_file_location");
+    }
     add_file_location(path_to_write, node_name, offset);
 }
 

--- a/src/server/utils/types.hpp
+++ b/src/server/utils/types.hpp
@@ -9,7 +9,6 @@
 #include "capio/circular_buffer.hpp"
 #include "capio/spsc_queue.hpp"
 
-typedef std::vector<std::tuple<int, FILE *, bool>> CSFDFileLocationReadsVector_t;
 typedef std::unordered_map<int, int> CSPidsMap_T;
 typedef std::unordered_map<int, std::string> CSAppsMap_t;
 typedef std::unordered_map<std::string, std::unordered_set<std::string>> CSFilesSentMap_t;
@@ -26,8 +25,7 @@ typedef std::vector<std::tuple<std::string, std::string, std::string, std::strin
                                long int, bool, long int>>
     CSMetadataConfGlobs_t;
 typedef std::unordered_map<int, std::unordered_map<std::string, bool>> CSWritersMap_t;
-typedef std::unordered_map<std::string, std::pair<const char *const, long int>>
-    CSFilesLocationMap_t;
+typedef std::unordered_map<std::string, std::pair<const char *const, off64_t>> CSFilesLocationMap_t;
 typedef std::unordered_map<std::string, int> CSNodesHelperRankMap_t;
 typedef std::unordered_map<int, std::string> CSRankToNodeMap_t;
 typedef std::unordered_map<std::string,


### PR DESCRIPTION
This commit simplifies the `load_file_location` function in many ways:
- It removes the unnecessary repeated reads (one per CAPIO node), as the `files_location.txt` is globally unique
- It merges all the `delete_from_files_location` logic in a single function and again removes unnecessary duplicated accesses to the file
- It removes the `close_file` logic from the `FlockGuard` file, as it is not needed anymore