### PR TITLE
Reverted files locations

### DIFF
--- a/src/posix/utils/data.hpp
+++ b/src/posix/utils/data.hpp
@@ -42,10 +42,12 @@ inline void read_data(long tid, const void *buffer, off64_t count) {
     size_t r       = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
     size_t i       = 0;
     while (i < n_reads) {
+        LOG("READING %ld bytes from queue", CAPIO_DATA_BUFFER_ELEMENT_SIZE);
         data_buf->read((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
         ++i;
     }
     if (r) {
+        LOG("READING %ld bytes from queue", r);
         data_buf->read((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
     }
 }

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
     parseCLI(argc, argv);
 
     START_LOG(gettid(), "call()");
-    
+
     open_files_location();
 
     shm_canary = new CapioShmCanary(workflow_name);

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -108,7 +108,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     MPI_Comm_size(MPI_COMM_WORLD, &n_servers);
     setup_signal_handlers();
     backend->handshake_servers();
-    load_created_files_locations();
+
     create_dir(getpid(), get_capio_dir());
 
     init_server();

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -108,6 +108,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     MPI_Comm_size(MPI_COMM_WORLD, &n_servers);
     setup_signal_handlers();
     backend->handshake_servers();
+    load_created_files_locations();
     create_dir(getpid(), get_capio_dir());
 
     init_server();
@@ -258,7 +259,7 @@ int main(int argc, char **argv) {
     parseCLI(argc, argv);
 
     START_LOG(gettid(), "call()");
-
+    
     open_files_location();
 
     shm_canary = new CapioShmCanary(workflow_name);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -134,10 +134,10 @@ inline void request_remote_read(int tid, int fd, off64_t count, bool is_dir, boo
         LOG("Handling local read");
         handle_local_read(tid, fd, count, is_dir, is_getdents, true);
     } else if (end_of_read <= end_of_sector) {
-        LOG("Data is present locally and can be served to clien");
+        LOG("Data is present locally and can be served to client");
         c_file.create_buffer_if_needed(path, false);
         char *p = c_file.get_buffer();
-        write_response(tid, end_of_sector);
+        write_response(tid, end_of_read);
         send_data_to_client(tid, p + offset, count);
     } else {
         LOG("Delegating to backend remote read");
@@ -146,8 +146,8 @@ inline void request_remote_read(int tid, int fd, off64_t count, bool is_dir, boo
 }
 
 void wait_for_file_creation(int tid, int fd, off64_t count, bool dir, bool is_getdents) {
-    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld, dir=%s, is_getdents=%s)", tid, fd, count,
-              dir ? "true" : "false", is_getdents ? "true" : "false");
+    START_LOG(gettid(), "call(tid=%d, parent_pid=%d,  fd=%d, count=%ld, dir=%s, is_getdents=%s)",
+              tid, getppid(), fd, count, dir ? "true" : "false", is_getdents ? "true" : "false");
 
     const std::filesystem::path &path_to_check = get_capio_file_path(tid, fd);
     loop_load_file_location(path_to_check);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -145,7 +145,8 @@ inline void request_remote_read(int tid, int fd, off64_t count, bool is_dir, boo
     }
 }
 
-void wait_for_file_creation(const std::filesystem::path &path, int tid, int fd, off64_t count, bool dir, bool is_getdents) {
+void wait_for_file_creation(const std::filesystem::path &path, int tid, int fd, off64_t count,
+                            bool dir, bool is_getdents) {
     START_LOG(gettid(), "call(tid=%d, parent_pid=%d,  fd=%d, count=%ld, dir=%s, is_getdents=%s)",
               tid, getppid(), fd, count, dir ? "true" : "false", is_getdents ? "true" : "false");
 

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -134,7 +134,7 @@ inline void request_remote_read(int tid, int fd, off64_t count, bool is_dir, boo
         LOG("Handling local read");
         handle_local_read(tid, fd, count, is_dir, is_getdents, true);
     } else if (end_of_read <= end_of_sector) {
-        LOG("?");
+        LOG("Data is present locally and can be served to clien");
         c_file.create_buffer_if_needed(path, false);
         char *p = c_file.get_buffer();
         write_response(tid, end_of_sector);

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -43,7 +43,8 @@ inline void reply_stat(int tid, const std::filesystem::path &path) {
             // if it is in configuration file then wait otherwise fail
             if ((metadata_conf.find(path) != metadata_conf.end() || match_globs(path) != -1) &&
                 !is_producer(tid, path)) {
-                LOG("File found but not ready yet. Starting a thread to wait for file %d", path.c_str());
+                LOG("File found but not ready yet. Starting a thread to wait for file %s",
+                    path.c_str());
                 std::thread t(wait_for_file_completion, tid, std::filesystem::path(path));
                 t.detach();
             } else {

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -43,7 +43,7 @@ inline void reply_stat(int tid, const std::filesystem::path &path) {
             // if it is in configuration file then wait otherwise fail
             if ((metadata_conf.find(path) != metadata_conf.end() || match_globs(path) != -1) &&
                 !is_producer(tid, path)) {
-                LOG("File not ready yet. Starting a thread to wait for file.");
+                LOG("File found but not ready yet. Starting a thread to wait for file %d", path.c_str());
                 std::thread t(wait_for_file_completion, tid, std::filesystem::path(path));
                 t.detach();
             } else {

--- a/src/server/remote/backend.hpp
+++ b/src/server/remote/backend.hpp
@@ -46,6 +46,12 @@ class Backend {
     virtual ~Backend() = default;
 
     /**
+     * Returns the node names of the CAPIO servers
+     * @return A set containing the node names of all CAPIO servers
+     */
+    virtual const std::set<std::string> get_nodes() = 0;
+
+    /**
      * Handshake the server applications
      */
     virtual void handshake_servers() = 0;

--- a/src/server/remote/handlers/read.hpp
+++ b/src/server/remote/handlers/read.hpp
@@ -193,7 +193,7 @@ handle_remote_read_batch_reply(const std::string &source, int tid, int fd, off64
     for (const auto &[path, nbytes] : files) {
         auto c_file_opt = get_capio_file_opt(path);
         if (c_file_opt) {
-            CapioFile &c_file = get_capio_file(path);
+            CapioFile &c_file = c_file_opt->get();
             c_file.create_buffer_if_needed(path, false);
             size_t file_shm_size = c_file.get_buf_size();
             if (nbytes > file_shm_size) {

--- a/src/server/remote/requests.hpp
+++ b/src/server/remote/requests.hpp
@@ -18,7 +18,7 @@ inline void serve_remote_read_request(int tid, int fd, int count, long int nbyte
                                       const off64_t file_size, bool complete, bool is_getdents,
                                       const std::string &dest) {
     START_LOG(gettid(), "call()");
-    const char *const format = "%04d %d %d %ld %ld %ld %d %d";
+    const char *const format = "%04d %d %d %d %ld %ld %d %d";
     const int size = snprintf(nullptr, 0, format, CAPIO_SERVER_REQUEST_READ_REPLY, tid, fd, count,
                               nbytes, file_size, complete, is_getdents);
     const std::unique_ptr<char[]> message(new char[size + 1]);
@@ -34,7 +34,7 @@ inline void send_files_batch_request(const std::string &prefix, int tid, int fd,
                                      bool is_getdents, const std::string &dest,
                                      const std::vector<std::string> *files_to_send) {
     START_LOG(gettid(), "call()");
-    const char *const format = "%04d %s %d %d %ld %d";
+    const char *const format = "%04d %s %d %d %d %d";
     const int size           = snprintf(nullptr, 0, format, CAPIO_SERVER_REQUEST_READ_BATCH_REPLY,
                                         prefix.c_str(), tid, fd, count, is_getdents);
     const std::unique_ptr<char[]> header(new char[size + 1]);

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -205,13 +205,13 @@ int delete_from_files_location(const std::filesystem::path &path) {
             if (fseek(descriptor, 0, SEEK_SET) == -1) {
                 ERR_EXIT("fseek in load_file_location");
             }
-            LOG("%s offset has been moved to the beginning of the file", file_location_name);
+            LOG("%s offset has been moved to the beginning of the file", name.c_str());
             auto line =
                 reinterpret_cast<char *>(malloc((PATH_MAX + HOST_NAME_MAX + 10) * sizeof(char)));
             size_t len = 0;
             offset     = old_offset;
             int result = 2;
-            while (getline(&line, &len, files_location_fp) != -1) {
+            while (getline(&line, &len, descriptor) != -1) {
                 if (line[0] == CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR) {
                     continue;
                 }


### PR DESCRIPTION
This commit restores the original architecture of the `files_location` database, which was using a different file for each of the involved compute nodes. This approach avoids race conditions on parallel file systems that do not support distributed `flock` synchronization. Plus, it reduces the read/write contention on each of the files, improving performance.