### PR TITLE
Support for multiple CAPIO server running at the same time on the same machine

### DIFF
--- a/src/common/capio/circular_buffer.hpp
+++ b/src/common/capio/circular_buffer.hpp
@@ -7,6 +7,7 @@
 
 #include "capio/logger.hpp"
 #include "capio/shm.hpp"
+#include "capio/env.hpp"
 
 /*
  * Multi-producer and multi-consumer circular buffer.
@@ -22,6 +23,7 @@ template <class T> class CircularBuffer {
     long int *_first_elem;
     long int *_last_elem;
     const std::string _shm_name;
+    const std::string _workflow_name;
     sem_t *_mutex;
     sem_t *_sem_num_elems;
     sem_t *_sem_num_empty;
@@ -47,8 +49,8 @@ template <class T> class CircularBuffer {
 
   public:
     CircularBuffer(const std::string &shm_name, const long int _max_num_elems,
-                   const long int elem_size, long int sem_timeout, int sem_retries)
-        : _max_num_elems(_max_num_elems), _elem_size(elem_size), _shm_name(shm_name) {
+                   const long int elem_size, long int sem_timeout, int sem_retries, std::string workflow_name = get_capio_workflow_name())
+        : _max_num_elems(_max_num_elems), _elem_size(elem_size), _shm_name(shm_name), _workflow_name(workflow_name) {
         START_LOG(capio_syscall(SYS_gettid),
                   "call(shm_name=%s, _max_num_elems=%ld, elem_size=%ld, "
                   "sem_timeout=%d, sem_retries=%d)",
@@ -58,28 +60,28 @@ template <class T> class CircularBuffer {
         sem_timeout_struct.tv_nsec = sem_timeout;
         sem_timeout_struct.tv_sec  = 1;
         _buff_size                 = _max_num_elems * _elem_size;
-        _first_elem = (long int *) create_shm("_first_elem" + shm_name, sizeof(long int));
-        _last_elem  = (long int *) create_shm("_last_elem" + shm_name, sizeof(long int));
+        _first_elem = (long int *) create_shm(_workflow_name + "_first_elem" + shm_name, sizeof(long int));
+        _last_elem  = (long int *) create_shm(_workflow_name + "_last_elem" + shm_name, sizeof(long int));
         _shm        = get_shm_if_exist(_shm_name);
         if (_shm == nullptr) {
             *_first_elem = 0;
             *_last_elem  = 0;
-            _shm         = create_shm(shm_name, _buff_size);
+            _shm         = create_shm(_workflow_name + shm_name, _buff_size);
         }
 
-        _mutex = sem_open(("_mutex" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
+        _mutex = sem_open((_workflow_name + "_mutex" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
                           1); // check the flags
         if (_mutex == SEM_FAILED) {
             ERR_EXIT("sem_open _mutex %s", _shm_name.c_str());
         }
         _sem_num_elems =
-            sem_open(("_sem_num_elems" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
+            sem_open((_workflow_name + "_sem_num_elems" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
                      0); // check the flags
         if (_sem_num_elems == SEM_FAILED) {
             ERR_EXIT("sem_open _sem_num_elems %s", _shm_name.c_str());
         }
         _sem_num_empty =
-            sem_open(("_sem_num_empty" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
+            sem_open((_workflow_name + "_sem_num_empty" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
                      _max_num_elems); // check the flags
         if (_sem_num_empty == SEM_FAILED) {
             ERR_EXIT("sem_open _sem_num_empty %s", _shm_name.c_str());
@@ -98,26 +100,26 @@ template <class T> class CircularBuffer {
     void free_shm() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
 
-        if (shm_unlink(_shm_name.c_str()) == -1) {
+        if (shm_unlink((_workflow_name+ _shm_name).c_str()) == -1) {
             ERR_EXIT("shm_unlink %s in circular_buffer free_shm", _shm_name.c_str());
         }
-        std::string resource = "_first_elem" + _shm_name;
+        std::string resource = _workflow_name + "_first_elem" + _shm_name;
         if (shm_unlink(resource.c_str()) == -1) {
             ERR_EXIT("shm_unlink %s in circular_buffer free_shm", resource.c_str());
         }
-        resource = "_last_elem" + _shm_name;
+        resource = _workflow_name + "_last_elem" + _shm_name;
         if (shm_unlink(resource.c_str()) == -1) {
             ERR_EXIT("shm_unlink %s in circular_buffer free_shm", resource.c_str());
         }
-        resource = "_mutex" + _shm_name;
+        resource = _workflow_name + "_mutex" + _shm_name;
         if (sem_unlink(resource.c_str()) == -1) {
             ERR_EXIT("sem_unlink %s in circular_buffer free_shm", resource.c_str());
         }
-        resource = "_sem_num_elems" + _shm_name;
+        resource = _workflow_name +  "_sem_num_elems" + _shm_name;
         if (sem_unlink(resource.c_str()) == -1) {
             ERR_EXIT("sem_unlink %s in circular_buffer free_shm", resource.c_str());
         }
-        resource = "_sem_num_empty" + _shm_name;
+        resource = _workflow_name +  "_sem_num_empty" + _shm_name;
         if (sem_unlink(resource.c_str()) == -1) {
             ERR_EXIT("sem_unlink %s in circular_buffer free_shm", resource.c_str());
         }

--- a/src/common/capio/circular_buffer.hpp
+++ b/src/common/capio/circular_buffer.hpp
@@ -60,8 +60,9 @@ template <class T> class CircularBuffer {
           _sem_num_empty_name(workflow_name + "_sem_num_empty_" + shm_name) {
         START_LOG(capio_syscall(SYS_gettid),
                   "call(shm_name=%s, _max_num_elems=%ld, elem_size=%ld, "
-                  "sem_timeout=%d, sem_retries=%d)",
-                  shm_name.c_str(), _max_num_elems, elem_size, sem_timeout, sem_retries);
+                  "sem_timeout=%d, sem_retries=%d, workflow_name=%s)",
+                  _shm_name.data(), _max_num_elems, elem_size, sem_timeout, sem_retries,
+                  workflow_name.data());
         _sem_retries               = sem_retries;
         sem_timeout_struct.tv_nsec = sem_timeout;
         sem_timeout_struct.tv_sec  = 1;

--- a/src/common/capio/circular_buffer.hpp
+++ b/src/common/capio/circular_buffer.hpp
@@ -5,9 +5,9 @@
 
 #include <semaphore.h>
 
+#include "capio/env.hpp"
 #include "capio/logger.hpp"
 #include "capio/shm.hpp"
-#include "capio/env.hpp"
 
 /*
  * Multi-producer and multi-consumer circular buffer.
@@ -22,8 +22,8 @@ template <class T> class CircularBuffer {
     long int _buff_size;       // buffer size in bytes
     long int *_first_elem;
     long int *_last_elem;
-    const std::string _shm_name;
-    const std::string _workflow_name;
+    const std::string _shm_name, _mutex_name, _first_elem_name, _last_elem_name,
+        _sem_num_elem_names, _sem_num_empty_name;
     sem_t *_mutex;
     sem_t *_sem_num_elems;
     sem_t *_sem_num_empty;
@@ -48,44 +48,46 @@ template <class T> class CircularBuffer {
     }
 
   public:
-    CircularBuffer(const std::string &shm_name, const long int _max_num_elems,
-                   const long int elem_size, long int sem_timeout, int sem_retries, std::string workflow_name = get_capio_workflow_name())
-        : _max_num_elems(_max_num_elems), _elem_size(elem_size), _shm_name(shm_name), _workflow_name(workflow_name) {
+    CircularBuffer(const std::string &shm_name, const long int max_num_elems,
+                   const long int elem_size, long int sem_timeout, int sem_retries,
+                   const std::string &workflow_name = get_capio_workflow_name())
+        : _max_num_elems(max_num_elems), _elem_size(elem_size),
+          _shm_name(workflow_name + "_" + shm_name),
+          _first_elem_name(workflow_name + "_first_elem_" + shm_name),
+          _last_elem_name(workflow_name + "_last_elem_" + shm_name),
+          _mutex_name(workflow_name + "_mutex_" + shm_name),
+          _sem_num_elem_names(workflow_name + "_sem_num_elems_" + shm_name),
+          _sem_num_empty_name(workflow_name + "_sem_num_empty_" + shm_name) {
         START_LOG(capio_syscall(SYS_gettid),
                   "call(shm_name=%s, _max_num_elems=%ld, elem_size=%ld, "
                   "sem_timeout=%d, sem_retries=%d)",
                   shm_name.c_str(), _max_num_elems, elem_size, sem_timeout, sem_retries);
-
         _sem_retries               = sem_retries;
         sem_timeout_struct.tv_nsec = sem_timeout;
         sem_timeout_struct.tv_sec  = 1;
         _buff_size                 = _max_num_elems * _elem_size;
-        _first_elem = (long int *) create_shm(_workflow_name + "_first_elem" + shm_name, sizeof(long int));
-        _last_elem  = (long int *) create_shm(_workflow_name + "_last_elem" + shm_name, sizeof(long int));
-        _shm        = get_shm_if_exist(_shm_name);
+        _first_elem                = (long int *) create_shm(_first_elem_name, sizeof(long int));
+        _last_elem                 = (long int *) create_shm(_last_elem_name, sizeof(long int));
+        _shm                       = get_shm_if_exist(_shm_name);
         if (_shm == nullptr) {
             *_first_elem = 0;
             *_last_elem  = 0;
-            _shm         = create_shm(_workflow_name + shm_name, _buff_size);
+            _shm         = create_shm(_shm_name, _buff_size);
         }
 
-        _mutex = sem_open((_workflow_name + "_mutex" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
-                          1); // check the flags
-        if (_mutex == SEM_FAILED) {
-            ERR_EXIT("sem_open _mutex %s", _shm_name.c_str());
-        }
+        // check the flags
+        _mutex = sem_open(_mutex_name.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, 1);
+        SEM_CREATE_CHECK(_mutex, _shm_name.c_str());
+
+        // check the flags
         _sem_num_elems =
-            sem_open((_workflow_name + "_sem_num_elems" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
-                     0); // check the flags
-        if (_sem_num_elems == SEM_FAILED) {
-            ERR_EXIT("sem_open _sem_num_elems %s", _shm_name.c_str());
-        }
-        _sem_num_empty =
-            sem_open((_workflow_name + "_sem_num_empty" + _shm_name).c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
-                     _max_num_elems); // check the flags
-        if (_sem_num_empty == SEM_FAILED) {
-            ERR_EXIT("sem_open _sem_num_empty %s", _shm_name.c_str());
-        }
+            sem_open(_sem_num_elem_names.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, 0);
+        SEM_CREATE_CHECK(_sem_num_elems, _shm_name.c_str());
+
+        // check the flags
+        _sem_num_empty = sem_open(_sem_num_empty_name.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR,
+                                  _max_num_elems);
+        SEM_CREATE_CHECK(_sem_num_empty, _sem_num_empty_name.c_str());
     }
 
     CircularBuffer(const CircularBuffer &)            = delete;
@@ -100,28 +102,28 @@ template <class T> class CircularBuffer {
     void free_shm() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
 
-        if (shm_unlink((_workflow_name+ _shm_name).c_str()) == -1) {
+        if (shm_unlink(_shm_name.c_str()) == -1) {
             ERR_EXIT("shm_unlink %s in circular_buffer free_shm", _shm_name.c_str());
         }
-        std::string resource = _workflow_name + "_first_elem" + _shm_name;
-        if (shm_unlink(resource.c_str()) == -1) {
-            ERR_EXIT("shm_unlink %s in circular_buffer free_shm", resource.c_str());
+
+        if (shm_unlink(_first_elem_name.c_str()) == -1) {
+            ERR_EXIT("shm_unlink %s in circular_buffer free_shm", _first_elem_name.c_str());
         }
-        resource = _workflow_name + "_last_elem" + _shm_name;
-        if (shm_unlink(resource.c_str()) == -1) {
-            ERR_EXIT("shm_unlink %s in circular_buffer free_shm", resource.c_str());
+
+        if (shm_unlink(_last_elem_name.c_str()) == -1) {
+            ERR_EXIT("shm_unlink %s in circular_buffer free_shm", _last_elem_name.c_str());
         }
-        resource = _workflow_name + "_mutex" + _shm_name;
-        if (sem_unlink(resource.c_str()) == -1) {
-            ERR_EXIT("sem_unlink %s in circular_buffer free_shm", resource.c_str());
+
+        if (sem_unlink(_mutex_name.c_str()) == -1) {
+            ERR_EXIT("sem_unlink %s in circular_buffer free_shm", _mutex_name.c_str());
         }
-        resource = _workflow_name +  "_sem_num_elems" + _shm_name;
-        if (sem_unlink(resource.c_str()) == -1) {
-            ERR_EXIT("sem_unlink %s in circular_buffer free_shm", resource.c_str());
+
+        if (sem_unlink(_sem_num_elem_names.c_str()) == -1) {
+            ERR_EXIT("sem_unlink %s in circular_buffer free_shm", _sem_num_elem_names.c_str());
         }
-        resource = _workflow_name +  "_sem_num_empty" + _shm_name;
-        if (sem_unlink(resource.c_str()) == -1) {
-            ERR_EXIT("sem_unlink %s in circular_buffer free_shm", resource.c_str());
+
+        if (sem_unlink(_sem_num_empty_name.c_str()) == -1) {
+            ERR_EXIT("sem_unlink %s in circular_buffer free_shm", _sem_num_empty_name.c_str());
         }
     }
 

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -59,6 +59,11 @@ constexpr int CAPIO_POSIX_SYSCALL_SUCCESS      = 0;
 constexpr char CAPIO_LOG_PRE_MSG[]        = "at[%s]: ";
 constexpr char CAPIO_DEFAULT_LOG_FOLDER[] = "capio_logs\0";
 
+// CAPIO logger - shm errors
+constexpr char CAPIO_SHM_OPEN_ERROR[] =
+    "Unable to open shared memory segment. can it be that another instance of capio server is "
+    "running with the same WORKFLOW_NAME?";
+
 // CAPIO logger - POSIX
 constexpr char CAPIO_LOG_POSIX_DEFAULT_LOG_FILE_PREFIX[] = "posix_thread_\0";
 constexpr char CAPIO_LOG_POSIX_SYSCALL_START[]           = "\n+++++++++ SYSCALL %s (%d) +++++++++";

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -20,6 +20,9 @@ constexpr int CAPIO_THEORETICAL_SIZE_DIRENT64     = sizeof(ino64_t) + sizeof(off
 constexpr int CAPIO_SEM_MAX_RETRIES          = 100;
 constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC = 10e5;
 
+// CAPIO default values for shared memory
+constexpr char CAPIO_DEFAULT_WORKFLOW_NAME[] = "CAPIO";
+
 // CAPIO communication constants
 constexpr int CAPIO_DATA_BUFFER_LENGTH               = 10;
 constexpr int CAPIO_DATA_BUFFER_ELEMENT_SIZE         = 256 * 1024;

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -22,6 +22,12 @@ constexpr long int CAPIO_SEM_TIMEOUT_NANOSEC = 10e5;
 
 // CAPIO default values for shared memory
 constexpr char CAPIO_DEFAULT_WORKFLOW_NAME[] = "CAPIO";
+constexpr char CAPIO_SHM_CANARY_ERROR[] =
+    "FATAL ERROR:  Shared memories for workflow %s already "
+    "exists. One of two (or both) reasons are to blame: \n             "
+    "Either a previous run of CAPIO terminated without "
+    "cleaning up memory, or another instance of CAPIO\n             "
+    "is already running . Clean shared memory and then retry";
 
 // CAPIO communication constants
 constexpr int CAPIO_DATA_BUFFER_LENGTH               = 10;

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -25,9 +25,9 @@ constexpr char CAPIO_DEFAULT_WORKFLOW_NAME[] = "CAPIO";
 constexpr char CAPIO_SHM_CANARY_ERROR[] =
     "FATAL ERROR:  Shared memories for workflow %s already "
     "exists. One of two (or both) reasons are to blame: \n             "
-    "Either a previous run of CAPIO terminated without "
+    "either a previous run of CAPIO terminated without "
     "cleaning up memory, or another instance of CAPIO\n             "
-    "is already running . Clean shared memory and then retry";
+    "is already running. Clean shared memory and then retry";
 
 // CAPIO communication constants
 constexpr int CAPIO_DATA_BUFFER_LENGTH               = 10;
@@ -67,7 +67,7 @@ constexpr char CAPIO_DEFAULT_LOG_FOLDER[] = "capio_logs\0";
 
 // CAPIO logger - shm errors
 constexpr char CAPIO_SHM_OPEN_ERROR[] =
-    "Unable to open shared memory segment. can it be that another instance of capio server is "
+    "Unable to open shared memory segment. Could it be that another instance of capio server is "
     "running with the same WORKFLOW_NAME?";
 
 // CAPIO logger - POSIX

--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -71,14 +71,14 @@ inline int get_capio_log_level() {
     return level;
 }
 
-inline char* get_capio_workflow_name(){
-    static char* name = nullptr;
-    if(name == nullptr){
-        name = std::getenv("CAPIO_WORKFLOW_NAME");
-
-        if(name == nullptr){
-            name = new char[strlen(CAPIO_DEFAULT_WORKFLOW_NAME)];
-            strcpy(name, CAPIO_DEFAULT_WORKFLOW_NAME);
+inline std::string get_capio_workflow_name() {
+    static std::string name;
+    if (name.empty()) {
+        auto tmp = std::getenv("CAPIO_WORKFLOW_NAME");
+        if (tmp != nullptr) {
+            name = tmp;
+        } else {
+            name = CAPIO_DEFAULT_WORKFLOW_NAME;
         }
     }
     return name;

--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -71,4 +71,17 @@ inline int get_capio_log_level() {
     return level;
 }
 
+inline char* get_capio_workflow_name(){
+    static char* name = nullptr;
+    if(name == nullptr){
+        name = std::getenv("CAPIO_WORKFLOW_NAME");
+
+        if(name == nullptr){
+            name = new char[strlen(CAPIO_DEFAULT_WORKFLOW_NAME)];
+            strcpy(name, CAPIO_DEFAULT_WORKFLOW_NAME);
+        }
+    }
+    return name;
+}
+
 #endif // CAPIO_COMMON_ENV_HPP

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -275,6 +275,14 @@ class Logger {
     }
 };
 
+// Checks for trailing share memories from other capio server executions
+#ifndef __CAPIO_POSIX
+#define __SHM_CHECK_CLI_MSG                                                                        \
+    std::cout << CAPIO_SERVER_CLI_LOG_SERVER_ERROR << CAPIO_SHM_OPEN_ERROR << std::endl
+#else
+#define __SHM_CHECK_CLI_MSG
+#endif
+
 #ifdef CAPIOLOG
 #define ERR_EXIT(message, ...) (log.log(message, ##__VA_ARGS__), exit(EXIT_FAILURE))
 #define LOG(message, ...) log.log(message, ##__VA_ARGS__)
@@ -282,11 +290,24 @@ class Logger {
     Logger log(__func__, __FILE__, __LINE__, tid, message, ##__VA_ARGS__)
 #define START_SYSCALL_LOGGING() logging_syscall = true
 #define SUSPEND_SYSCALL_LOGGING() SyscallLoggingSuspender sls{};
+#define SEM_CREATE_CHECK(sem, source)                                                              \
+    if (sem == SEM_FAILED) {                                                                       \
+        LOG(CAPIO_SHM_OPEN_ERROR);                                                                 \
+        LOG("error while opening %s", _shm_name.c_str());                                          \
+        __SHM_CHECK_CLI_MSG;                                                                       \
+    }
 #else
+
 #define ERR_EXIT(message, ...) exit(EXIT_FAILURE)
 #define LOG(message, ...)
 #define START_LOG(tid, message, ...)
 #define START_SYSCALL_LOGGING()
 #define SUSPEND_SYSCALL_LOGGING()
+#define SEM_CREATE_CHECK(sem, source)                                                              \
+    if (sem == SEM_FAILED) {                                                                       \
+        __SHM_CHECK_CLI_MSG;                                                                       \
+    }
+
 #endif
+
 #endif // CAPIO_COMMON_LOGGER_HPP

--- a/src/common/capio/shm.hpp
+++ b/src/common/capio/shm.hpp
@@ -2,6 +2,7 @@
 #define CAPIO_COMMON_SHM_HPP
 
 #include <string>
+#include <utility>
 
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -9,6 +10,53 @@
 #include <unistd.h>
 
 #include "capio/logger.hpp"
+
+class CapioSHmCanary {
+    int _shm_id;
+    std::string _canary_name;
+
+  public:
+    explicit CapioSHmCanary(std::string capio_workflow_name = get_capio_workflow_name())
+        : _canary_name(capio_workflow_name) {
+        START_LOG(capio_syscall(SYS_gettid), "call(capio_workflow_name: %s)", _canary_name.data());
+        if (_canary_name.empty()) {
+            _canary_name = get_capio_workflow_name();
+            if (_canary_name.empty()) {
+                _canary_name = CAPIO_DEFAULT_WORKFLOW_NAME;
+            }
+        }
+        _shm_id = shm_open(_canary_name.data(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+        if (_shm_id == -1) {
+            LOG(CAPIO_SHM_CANARY_ERROR, _canary_name.data());
+#ifndef __CAPIO_POSIX
+            auto message = new char[strlen(CAPIO_SHM_CANARY_ERROR)];
+            sprintf(message, CAPIO_SHM_CANARY_ERROR, _canary_name.data());
+            std::cout << CAPIO_SERVER_CLI_LOG_SERVER_ERROR << message << std::endl;
+            delete[] message;
+#endif
+            ERR_EXIT("ERR: shm canary flag already exists");
+        }
+    };
+
+    ~CapioSHmCanary() {
+        START_LOG(capio_syscall(SYS_gettid), "call()");
+#ifndef __CAPIO_POSIx
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "Removing shared memory canary flag"
+                  << std::endl;
+#endif
+        close(_shm_id);
+        int success = shm_unlink(_canary_name.data());
+        LOG("Removed shm canary? %s (errno: %s)", success == 0 ? "yes" : "no", strerror(errno));
+#ifndef __CAPIO_POSIx
+        if (success != 0) {
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Unable to remove shm canary "
+                      << _canary_name.data() << " due to: " << strerror(errno) << std::endl;
+        }
+#endif
+    }
+};
+
+CapioSHmCanary *shm_canary;
 
 void *create_shm(const std::string &shm_name, const long int size) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s, size=%ld)", shm_name.c_str(), size);

--- a/src/common/capio/shm.hpp
+++ b/src/common/capio/shm.hpp
@@ -8,6 +8,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "capio/logger.hpp"
+
 void *create_shm(const std::string &shm_name, const long int size) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s, size=%ld)", shm_name.c_str(), size);
 
@@ -15,16 +17,20 @@ void *create_shm(const std::string &shm_name, const long int size) {
     int fd = shm_open(shm_name.c_str(), O_CREAT | O_RDWR,
                       S_IRUSR | S_IWUSR); // to be closed
     if (fd == -1) {
+        __SHM_CHECK_CLI_MSG;
         ERR_EXIT("create_shm shm_open %s", shm_name.c_str());
     }
     if (ftruncate(fd, size) == -1) {
+        __SHM_CHECK_CLI_MSG;
         ERR_EXIT("ftruncate create_shm %s", shm_name.c_str());
     }
     void *p = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (p == MAP_FAILED) {
+        __SHM_CHECK_CLI_MSG;
         ERR_EXIT("mmap create_shm %s", shm_name.c_str());
     }
     if (close(fd) == -1) {
+        __SHM_CHECK_CLI_MSG;
         ERR_EXIT("close");
     }
     return p;

--- a/src/common/capio/shm.hpp
+++ b/src/common/capio/shm.hpp
@@ -11,19 +11,15 @@
 
 #include "capio/logger.hpp"
 
-class CapioSHmCanary {
+class CapioShmCanary {
     int _shm_id;
     std::string _canary_name;
 
   public:
-    explicit CapioSHmCanary(std::string capio_workflow_name = get_capio_workflow_name())
-        : _canary_name(capio_workflow_name) {
+    explicit CapioShmCanary(std::string capio_workflow_name) : _canary_name(capio_workflow_name) {
         START_LOG(capio_syscall(SYS_gettid), "call(capio_workflow_name: %s)", _canary_name.data());
         if (_canary_name.empty()) {
             _canary_name = get_capio_workflow_name();
-            if (_canary_name.empty()) {
-                _canary_name = CAPIO_DEFAULT_WORKFLOW_NAME;
-            }
         }
         _shm_id = shm_open(_canary_name.data(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
         if (_shm_id == -1) {
@@ -38,7 +34,7 @@ class CapioSHmCanary {
         }
     };
 
-    ~CapioSHmCanary() {
+    ~CapioShmCanary() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
 #ifndef __CAPIO_POSIx
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "Removing shared memory canary flag"
@@ -56,7 +52,7 @@ class CapioSHmCanary {
     }
 };
 
-CapioSHmCanary *shm_canary;
+CapioShmCanary *shm_canary;
 
 void *create_shm(const std::string &shm_name, const long int size) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s, size=%ld)", shm_name.c_str(), size);

--- a/src/posix/utils/data.hpp
+++ b/src/posix/utils/data.hpp
@@ -19,10 +19,12 @@ inline void init_data_plane() { threads_data_bufs = new CPThreadDataBufs_t; }
 inline void register_data_listener(long tid) {
     auto *write_queue = new SPSCQueue<char>(
         "capio_write_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
-        CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+        CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES,
+        get_capio_workflow_name());
     auto *read_queue = new SPSCQueue<char>("capio_read_data_buffer_tid_" + std::to_string(tid),
                                            CAPIO_DATA_BUFFER_LENGTH, CAPIO_DATA_BUFFER_ELEMENT_SIZE,
-                                           CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+                                           CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES,
+                                           get_capio_workflow_name());
     threads_data_bufs->insert({static_cast<int>(tid), {write_queue, read_queue}});
 }
 

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -20,6 +20,8 @@
 #include <unordered_set>
 #include <vector>
 
+std::string workflow_name;
+
 #include "capio/env.hpp"
 #include "capio/logger.hpp"
 #include "capio/semaphore.hpp"
@@ -57,8 +59,6 @@ CSDataBufferMap_t data_buffers;
 CSWritersMap_t writers;
 
 CSClientsRemotePendingNFilesMap_t clients_remote_pending_nfiles;
-
-sem_t internal_server_sem;
 
 sem_t clients_remote_pending_nfiles_sem;
 
@@ -99,7 +99,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     return _request_handlers;
 }
 
-[[noreturn]] void capio_server() {
+[[noreturn]] void capio_server(sem_t *internal_server_sem) {
     static const std::array<CSHandler_t, CAPIO_NR_REQUESTS> request_handlers =
         build_request_handlers_table();
 
@@ -112,7 +112,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
 
     init_server();
 
-    if (sem_post(&internal_server_sem) == -1) {
+    if (sem_post(internal_server_sem) == -1) {
         ERR_EXIT("sem_post internal_server_sem in capio_server");
     }
 
@@ -205,17 +205,10 @@ int parseCLI(int argc, char **argv) {
     } else if (noConfigFile) {
         workflow_name = std::string_view(get_capio_workflow_name());
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "skipping config file parsing."
-                  << std::endl;
-        if (workflow_name.empty()) {
-            workflow_name = CAPIO_DEFAULT_WORKFLOW_NAME;
-            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
-                      << "Using default workflow name: " << workflow_name << std::endl;
-
-        } else {
-            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
-                      << "Obtained from environment variable current workflow name: "
-                      << workflow_name.data() << std::endl;
-        }
+                  << std::endl
+                  << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
+                  << "Obtained from environment variable current workflow name: "
+                  << workflow_name.data() << std::endl;
 
     } else {
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
@@ -258,6 +251,8 @@ int parseCLI(int argc, char **argv) {
 
 int main(int argc, char **argv) {
 
+    sem_t internal_server_sem;
+
     std::cout << CAPIO_LOG_SERVER_BANNER;
 
     parseCLI(argc, argv);
@@ -266,7 +261,7 @@ int main(int argc, char **argv) {
 
     open_files_location();
 
-    shm_canary = new CapioSHmCanary(workflow_name.data());
+    shm_canary = new CapioShmCanary(workflow_name);
 
     int res = sem_init(&internal_server_sem, 0, 0);
     if (res != 0) {
@@ -275,9 +270,9 @@ int main(int argc, char **argv) {
     if (sem_init(&clients_remote_pending_nfiles_sem, 0, 1) == -1) {
         ERR_EXIT("sem_init clients_remote_pending_nfiles_sem in main");
     }
-    std::thread server_thread(capio_server);
+    std::thread server_thread(capio_server, &internal_server_sem);
     LOG("capio_server thread started");
-    std::thread remote_listener_thread(capio_remote_listener);
+    std::thread remote_listener_thread(capio_remote_listener, &internal_server_sem);
     LOG("capio_remote_listener thread started.");
     server_thread.join();
     remote_listener_thread.join();

--- a/src/server/handlers/common.hpp
+++ b/src/server/handlers/common.hpp
@@ -9,10 +9,12 @@ inline void init_process(int tid) {
 
         auto *write_data_cb = new SPSCQueue<char>(
             "capio_write_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
-            CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+            CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES,
+            workflow_name.data());
         auto *read_data_cb = new SPSCQueue<char>(
             "capio_read_data_buffer_tid_" + std::to_string(tid), CAPIO_DATA_BUFFER_LENGTH,
-            CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+            CAPIO_DATA_BUFFER_ELEMENT_SIZE, CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES,
+            workflow_name.data());
         data_buffers.insert({tid, {write_data_cb, read_data_cb}});
     }
 }

--- a/src/server/remote/listener.hpp
+++ b/src/server/remote/listener.hpp
@@ -27,15 +27,24 @@ build_server_request_handlers_table() {
 
 inline Backend *select_backend(const std::string &backend_name, int argc, char *argv[]) {
     START_LOG(gettid(), "call(backend_name=%s)", backend_name.c_str());
+
+    if (backend_name.empty()) {
+        LOG("backend selected: none");
+        std::cout << CAPIO_SERVER_CLI_LOG_SERVER
+                  << "Starting CAPIO with default backend (MPI) as no preferred backend was chosen"
+                  << std::endl;
+        return new MPIBackend(argc, argv);
+    }
+
     if (backend_name == "mpi") {
         LOG("backend selected: mpi");
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << " Starting CAPIO with MPI backend" << std::endl;
+        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "Starting CAPIO with MPI backend" << std::endl;
         return new MPIBackend(argc, argv);
     }
 
     if (backend_name == "mpisync") {
         LOG("backend selected: mpisync");
-        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << " Starting CAPIO with MPI (SYNC) backend"
+        std::cout << CAPIO_SERVER_CLI_LOG_SERVER << "Starting CAPIO with MPI (SYNC) backend"
                   << std::endl;
         return new MPISYNCBackend(argc, argv);
     }

--- a/src/server/remote/listener.hpp
+++ b/src/server/remote/listener.hpp
@@ -55,13 +55,13 @@ inline Backend *select_backend(const std::string &backend_name, int argc, char *
     return new MPIBackend(argc, argv);
 }
 
-[[noreturn]] void capio_remote_listener() {
+[[noreturn]] void capio_remote_listener(sem_t *internal_server_sem) {
     static const std::array<CComsHandler_t, CAPIO_SERVER_NR_REQUEST> server_request_handlers =
         build_server_request_handlers_table();
 
     START_LOG(gettid(), "call()");
 
-    sem_wait(&internal_server_sem);
+    sem_wait(internal_server_sem);
     while (true) {
         auto request = backend->read_next_request();
 

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -6,6 +6,8 @@
 #include "utils/metadata.hpp"
 #include "utils/types.hpp"
 
+std::string workflow_name;
+
 void parse_conf_file(const std::string &conf_file, const std::filesystem::path &capio_dir) {
     START_LOG(gettid(), "call(config_file='%s', capio_dir='%s')", conf_file.c_str(),
               capio_dir.c_str());
@@ -26,13 +28,12 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
     }
 
     entries = parser.iterate(json);
-
-    std::string_view workflow_name;
-    error = entries["name"].get_string().get(workflow_name);
+    std::string_view wf_name;
+    error = entries["name"].get_string().get(wf_name);
     if (error) {
         ERR_EXIT("Error: workflow name is mandatory");
     }
-
+    workflow_name = std::string(wf_name);
     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
               << "Parsing configuration for workflow: " << workflow_name << std::endl;
     LOG("Parsing configuration for workflow: %s", std::string(workflow_name).c_str());

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -6,8 +6,6 @@
 #include "utils/metadata.hpp"
 #include "utils/types.hpp"
 
-std::string workflow_name;
-
 void parse_conf_file(const std::string &conf_file, const std::filesystem::path &capio_dir) {
     START_LOG(gettid(), "call(config_file='%s', capio_dir='%s')", conf_file.c_str(),
               capio_dir.c_str());

--- a/src/server/utils/requests.hpp
+++ b/src/server/utils/requests.hpp
@@ -47,7 +47,7 @@ inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
     auto *p_buf_response = new CircularBuffer<off_t>(
         "buf_response_" + std::to_string(tid), 8 * 1024 * 1024, sizeof(off_t),
-        CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES, std::string(workflow_name));
+        CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES, workflow_name);
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 

--- a/src/server/utils/requests.hpp
+++ b/src/server/utils/requests.hpp
@@ -15,8 +15,9 @@ CSBufResponse_t *bufs_response;
  */
 inline void init_server() {
     // TODO: replace number with constexpr
-    buf_requests  = new CSBufRequest_t("circular_buffer", 1024 * 1024, CAPIO_REQUEST_MAX_SIZE,
-                                       CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+    buf_requests =
+        new CSBufRequest_t("circular_buffer", 1024 * 1024, CAPIO_REQUEST_MAX_SIZE,
+                           CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES, workflow_name);
     bufs_response = new CSBufResponse_t();
 }
 
@@ -44,9 +45,9 @@ inline void destroy_server() {
  */
 inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
-    auto *p_buf_response =
-        new CircularBuffer<off_t>("buf_response_" + std::to_string(tid), 8 * 1024 * 1024,
-                                  sizeof(off_t), CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES);
+    auto *p_buf_response = new CircularBuffer<off_t>(
+        "buf_response_" + std::to_string(tid), 8 * 1024 * 1024, sizeof(off_t),
+        CAPIO_SEM_TIMEOUT_NANOSEC, CAPIO_SEM_MAX_RETRIES, std::string(workflow_name));
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 

--- a/src/server/utils/signals.hpp
+++ b/src/server/utils/signals.hpp
@@ -33,8 +33,11 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
               << std::endl;
 
     destroy_server();
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "shutdown completed" << std::endl;
+
     delete backend;
+    delete shm_canary;
+
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "shutdown completed" << std::endl;
     exit(EXIT_SUCCESS);
 }
 

--- a/tests/server/src/capio_file.cpp
+++ b/tests/server/src/capio_file.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 
+#include "capio/env.hpp"
 #include "utils/capio_file.hpp"
 
 TEST_CASE("Test inserting a single sector", "[server]") {


### PR DESCRIPTION
This commit adds the support to run multiple instances of `capio_server` on the same node. This is achieved by adding the workflow name to the shared memory segments, so that different workflows do not share the same shared memory names

This commit also adds a canary shared memory segment. This is used to know whether another CAPIO instance is running with the same workflow name scope or if the previous CAPIO run terminated without properly cleaning up the shared memory segments.

The workflow name can be given trough the configuration file under the 'name' parameter, and for both posix and server application can be given trough the 'CAPIO_WORKFLOW_NAME' environment variable. Server always prioritises configuration file workflow name over the env variable option.