### PR TITLE
Refactor of server read handler

### DIFF
--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -12,9 +12,6 @@ constexpr size_t CAPIO_DEFAULT_DIR_INITIAL_SIZE   = 1024L * 1024 * 1024;
 constexpr off64_t CAPIO_DEFAULT_FILE_INITIAL_SIZE = 1024L * 1024 * 1024 * 4;
 constexpr std::array CAPIO_DIR_FORBIDDEN_PATHS    = {std::string_view{"/proc/"},
                                                      std::string_view{"/sys/"}};
-constexpr int CAPIO_THEORETICAL_SIZE_DIRENT64     = sizeof(ino64_t) + sizeof(off64_t) +
-                                                sizeof(unsigned short) + sizeof(unsigned char) +
-                                                sizeof(char) * NAME_MAX;
 
 // CAPIO default values for shared memory
 constexpr char CAPIO_DEFAULT_WORKFLOW_NAME[] = "CAPIO";

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -4,7 +4,7 @@
 #if defined(SYS_getdents) || defined(SYS_getdents64)
 
 #include "capio/data_structure.hpp"
-#include "utils/common.hpp"
+
 #include "utils/data.hpp"
 
 // TODO: too similar to capio_read, refactoring needed
@@ -32,7 +32,6 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
             bytes_read = count_off;
         }
 
-        bytes_read = dirent_round(bytes_read);
         read_data(tid, buffer, bytes_read);
         set_capio_fd_offset(fd, offset + bytes_read);
 

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -25,7 +25,7 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
         }
         auto count_off      = static_cast<off64_t>(count);
         off64_t offset      = get_capio_fd_offset(fd);
-        off64_t end_of_read = add_getdents_request(fd, count_off, is64bit, tid);
+        off64_t end_of_read = getdents_request(fd, count_off, is64bit, tid);
         off64_t bytes_read  = end_of_read - offset;
 
         if (bytes_read > count_off) {
@@ -47,9 +47,8 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
             };
             START_LOG(syscall_no_intercept(SYS_gettid), "call ()");
             struct linux_dirent *d;
-            LOG("READ from "
-                "queue:\n\tOFFSET:%ld,\n\tcount:%ld\n\nINODE\tTYPE\tRECORD_LENGTH\tOFFSET\tNAME\n",
-                offset, count);
+            LOG("READ from queue: offset:%ld, count:%ld", offset, count);
+            LOG("INODE\tTYPE\tRECORD_LENGTH\tOFFSET\tNAME");
             for (size_t bpos = 0, i = 0; bpos < count && i < 10; i++) {
                 d = (struct linux_dirent *) (result + bpos);
                 LOG("%8lu\t%-10s (%ld)\t%4d\t%10jd\t%s\n", d->d_ino,

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -43,15 +43,15 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
                 off64_t d_off;
                 unsigned short d_reclen;
                 unsigned char d_type;
-                char d_name[];
+                char d_name[PATH_MAX];
             };
             START_LOG(syscall_no_intercept(SYS_gettid), "call ()");
             struct linux_dirent *d;
             LOG("READ from queue: offset:%ld, count:%ld", offset, count);
-            LOG("INODE\tTYPE\tRECORD_LENGTH\tOFFSET\tNAME");
+            LOG("%19s %12s %13s %15s %s", "INODE", "TYPE", "RECORD_LENGTH", "OFFSET", "NAME");
             for (size_t bpos = 0, i = 0; bpos < count && i < 10; i++) {
                 d = (struct linux_dirent *) (result + bpos);
-                LOG("%8lu\t%-10s (%ld)\t%4d\t%10jd\t%s\n", d->d_ino,
+                LOG("%19lu %9s %13ld %15ld %s\n", d->d_ino,
                     (d->d_type == 8)    ? "regular"
                     : (d->d_type == 4)  ? "directory"
                     : (d->d_type == 1)  ? "FIFO"
@@ -60,7 +60,7 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
                     : (d->d_type == 6)  ? "block dev"
                     : (d->d_type == 2)  ? "char dev"
                                         : "???",
-                    d->d_type, d->d_reclen, (intmax_t) d->d_off, d->d_name);
+                    d->d_reclen, d->d_off, d->d_name);
                 bpos += d->d_reclen;
             }
         }((char *) buffer, bytes_read, offset));

--- a/src/posix/utils/common.hpp
+++ b/src/posix/utils/common.hpp
@@ -14,14 +14,4 @@ int posix_return_value(long res, long *result) {
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
-inline off64_t dirent_round(off64_t bytes) {
-    off64_t res     = 0;
-    off64_t ld_size = CAPIO_THEORETICAL_SIZE_DIRENT64;
-
-    while (res + ld_size <= bytes) {
-        res += ld_size;
-    }
-    return res;
-}
-
 #endif // CAPIO_FUNCTIONS_H

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -97,15 +97,13 @@ inline void exit_group_request(const long tid) {
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
 }
 
-inline off64_t add_getdents_request(const int fd, const off64_t count, bool is64bit,
-                                    const long tid) {
+inline off64_t getdents_request(const int fd, const off64_t count, bool is64bit, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", is64bit ? CAPIO_REQUEST_GETDENTS64 : CAPIO_REQUEST_GETDENTS,
             tid, fd, count);
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
-    DBG(tid, [](off64_t res) { printf("Result of getends: %ld\n", res); }(res));
     return res;
 }
 

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -80,7 +80,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     _request_handlers[CAPIO_REQUEST_EXIT_GROUP]          = exit_group_handler;
     _request_handlers[CAPIO_REQUEST_FSTAT]               = fstat_handler;
     _request_handlers[CAPIO_REQUEST_GETDENTS]            = getdents_handler;
-    _request_handlers[CAPIO_REQUEST_GETDENTS64]          = getdents64_handler;
+    _request_handlers[CAPIO_REQUEST_GETDENTS64]          = getdents_handler;
     _request_handlers[CAPIO_REQUEST_HANDSHAKE_NAMED]     = handshake_named_handler;
     _request_handlers[CAPIO_REQUEST_HANDSHAKE_ANONYMOUS] = handshake_anonymous_handler;
     _request_handlers[CAPIO_REQUEST_MKDIR]               = mkdir_handler;

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -22,6 +22,11 @@
 
 std::string workflow_name;
 
+#include "utils/types.hpp"
+
+// tid -> (client_to_server_data_buf, server_to_client_data_buf)
+CSDataBufferMap_t data_buffers;
+
 #include "capio/env.hpp"
 #include "capio/logger.hpp"
 #include "capio/semaphore.hpp"
@@ -48,9 +53,6 @@ CSAppsMap_t apps;
 
 // application name -> set of files already sent
 CSFilesSentMap_t files_sent;
-
-// tid -> (client_to_server_data_buf, server_to_client_data_buf)
-CSDataBufferMap_t data_buffers;
 
 /*
  * pid -> pathname -> bool

--- a/src/server/handlers.hpp
+++ b/src/server/handlers.hpp
@@ -10,6 +10,7 @@
 #include "handlers/common.hpp"
 #include "handlers/dup.hpp"
 #include "handlers/exig.hpp"
+#include "handlers/getdents.hpp"
 #include "handlers/handshake.hpp"
 #include "handlers/mkdir.hpp"
 #include "handlers/open.hpp"

--- a/src/server/handlers/common.hpp
+++ b/src/server/handlers/common.hpp
@@ -17,21 +17,6 @@ inline void init_process(int tid) {
     }
 }
 
-void send_data_to_client(int tid, char *buf, long int count) {
-    START_LOG(gettid(), "call(%d,%.10s, %ld)", tid, buf, count);
-    auto *data_buf  = data_buffers[tid].second;
-    size_t n_writes = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    size_t r        = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    size_t i        = 0;
-    while (i < n_writes) {
-        data_buf->write(buf + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
-        ++i;
-    }
-    if (r) {
-        data_buf->write(buf + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
-    }
-}
-
 /*
  * Unlink resources in shared memory of the thread with thread id = tid
  * To be called only when the client thread terminates

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -1,0 +1,133 @@
+#ifndef CAPIO_GETDENTS_HPP
+#define CAPIO_GETDENTS_HPP
+
+#include <thread>
+
+#include "remote/backend.hpp"
+#include "remote/requests.hpp"
+
+#include "utils/location.hpp"
+#include "utils/metadata.hpp"
+#include "utils/producer.hpp"
+
+inline void handle_getdents_impl(int tid, int fd, long int count) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld)", tid, fd, count);
+
+    const std::filesystem::path &path = get_capio_file_path(tid, fd);
+    CapioFile &c_file                 = get_capio_file(path);
+    off64_t process_offset            = get_capio_file_offset(tid, fd);
+    off64_t end_of_sector             = c_file.get_sector_end(process_offset);
+    off64_t end_of_read               = process_offset + count;
+    int pid                           = pids[tid];
+    bool writer                       = writers[pid][path];
+
+    if (end_of_sector > end_of_read) {
+        end_of_sector = end_of_read;
+    }
+    off64_t dir_size  = c_file.get_stored_size();
+    off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
+    char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
+    end_of_sector     = store_dirent(c_file.get_buffer(), p_getdents, dir_size);
+    write_response(tid, end_of_sector);
+    send_data_to_client(tid, p_getdents + process_offset, end_of_sector - process_offset);
+    free(p_getdents);
+}
+
+inline void request_remote_getdents(int tid, int fd, off64_t count) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld)", tid, fd, count);
+
+    const std::filesystem::path &path = get_capio_file_path(tid, fd);
+    CapioFile &c_file                 = get_capio_file(path);
+    off64_t offset                    = get_capio_file_offset(tid, fd);
+    off64_t end_of_read               = offset + count;
+    off64_t end_of_sector             = c_file.get_sector_end(offset);
+
+    if (c_file.is_complete() &&
+        (end_of_read <= end_of_sector ||
+         (end_of_sector == -1 ? 0 : end_of_sector) == c_file.real_file_size)) {
+        LOG("Handling local read");
+        handle_getdents_impl(tid, fd, count);
+    } else if (end_of_read <= end_of_sector) {
+        LOG("?");
+        c_file.create_buffer_if_needed(path, false);
+        write_response(tid, end_of_sector);
+        send_data_to_client(tid, c_file.get_buffer() + offset, count);
+    } else {
+        LOG("Delegating to backend remote read");
+        handle_remote_read_request(tid, fd, count, true);
+    }
+}
+
+inline void handle_getdents(int tid, int fd, long int count) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld)", tid, fd, count);
+
+    const std::filesystem::path &path      = get_capio_file_path(tid, fd);
+    const std::filesystem::path &capio_dir = get_capio_dir();
+    bool is_prod                           = is_producer(tid, path);
+    auto file_location_opt                 = get_file_location_opt(path);
+
+    if (!file_location_opt && !is_prod) {
+        std::thread t([tid, fd, count] {
+            START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld)", tid, fd, count);
+
+            const std::filesystem::path &path_to_check = get_capio_file_path(tid, fd);
+            loop_load_file_location(path_to_check);
+
+            if (strcmp(std::get<0>(get_file_location(path_to_check)), node_name) == 0) {
+                handle_getdents(tid, fd, count);
+            } else {
+                const CapioFile &c_file = get_capio_file(path_to_check);
+                auto remote_app         = apps.find(tid);
+                if (!c_file.is_complete() && remote_app != apps.end()) {
+                    long int pos = match_globs(path_to_check);
+                    if (pos != -1) {
+                        const std::string &remote_app_name = remote_app->second;
+                        std::string prefix                 = std::get<0>(metadata_conf_globs[pos]);
+                        off64_t batch_size                 = std::get<5>(metadata_conf_globs[pos]);
+                        if (batch_size > 0) {
+                            handle_remote_read_batch_request(tid, fd, count, remote_app_name,
+                                                             prefix, batch_size, true);
+                            return;
+                        }
+                    }
+                }
+                request_remote_getdents(tid, fd, count);
+            }
+        });
+        t.detach();
+    } else if (is_prod || strcmp(std::get<0>(file_location_opt->get()), node_name) == 0 ||
+               capio_dir == path) {
+        handle_getdents_impl(tid, fd, count);
+    } else {
+        LOG("File is remote");
+        CapioFile &c_file = get_capio_file(path);
+        auto it           = apps.find(tid);
+        if (!c_file.is_complete() && it != apps.end()) {
+            LOG("File not complete");
+            const std::string &app_name = it->second;
+            long int pos                = match_globs(path);
+            if (pos != -1) {
+                LOG("Glob matched");
+                std::string prefix = std::get<0>(metadata_conf_globs[pos]);
+                off64_t batch_size = std::get<5>(metadata_conf_globs[pos]);
+                if (batch_size > 0) {
+                    LOG("Handling batch file");
+                    handle_remote_read_batch_request(tid, fd, count, app_name, prefix, batch_size,
+                                                     true);
+                    return;
+                }
+            }
+        }
+        LOG("Delegating to backend remote read");
+        request_remote_getdents(tid, fd, count);
+    }
+}
+
+void getdents_handler(const char *const str) {
+    int tid, fd;
+    off64_t count;
+    sscanf(str, "%d %d %ld", &tid, &fd, &count);
+    handle_getdents(tid, fd, count);
+}
+
+#endif // CAPIO_GETDENTS_HPP

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -20,7 +20,6 @@ inline void handle_getdents_impl(int tid, int fd, long int count) {
     off64_t n_entries     = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
     char *p_getdents      = (char *) malloc(n_entries * sizeof(char) * dir_size);
     off64_t end_of_sector = store_dirent(c_file.get_buffer(), p_getdents, dir_size);
-
     write_response(tid, end_of_sector);
     send_data_to_client(tid, p_getdents + process_offset, end_of_sector - process_offset);
     free(p_getdents);

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -20,6 +20,7 @@ inline void handle_getdents_impl(int tid, int fd, long int count) {
     off64_t n_entries     = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
     char *p_getdents      = (char *) malloc(n_entries * sizeof(char) * dir_size);
     off64_t end_of_sector = store_dirent(c_file.get_buffer(), p_getdents, dir_size);
+
     write_response(tid, end_of_sector);
     send_data_to_client(tid, p_getdents + process_offset, end_of_sector - process_offset);
     free(p_getdents);

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -27,8 +27,7 @@ inline void request_remote_getdents(int tid, int fd, off64_t count) {
     } else if (end_of_read <= end_of_sector) {
         LOG("?");
         c_file.create_buffer_if_needed(path, false);
-        write_response(tid, end_of_sector);
-        send_data_to_client(tid, c_file.get_buffer() + offset, count);
+        send_data_to_client(tid, c_file.get_buffer(), offset, count);
     } else {
         LOG("Delegating to backend remote read");
         handle_remote_read_request(tid, fd, count, true);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -25,7 +25,7 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
     c_file.create_buffer_if_needed(path, false);
     char *p = c_file.get_buffer();
 
-    size_t bytes_read;
+    off64_t bytes_read;
     if (end_of_sector > end_of_read) {
         end_of_sector = end_of_read;
         bytes_read    = count;

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -13,10 +13,9 @@
 
 std::mutex local_read_mutex;
 
-inline void handle_pending_read(int tid, int fd, long int process_offset, long int count,
-                                bool is_getdents) {
-    START_LOG(gettid(), "call(tid=%d, fd=%d, process_offset=%ld, count=%ld, is_getdents=%s)", tid,
-              fd, process_offset, count, is_getdents ? "true" : "false");
+inline void handle_pending_read(int tid, int fd, long int process_offset, long int count) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d, process_offset=%ld, count=%ld)", tid, fd,
+              process_offset, count);
 
     const std::filesystem::path &path = get_capio_file_path(tid, fd);
     CapioFile &c_file                 = get_capio_file(path);
@@ -33,25 +32,15 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
     } else {
         bytes_read = end_of_sector - process_offset;
     }
-    if (is_getdents) {
-        off64_t dir_size  = c_file.get_stored_size();
-        off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
-        char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
-        end_of_sector     = store_dirent(p, p_getdents, dir_size);
-        write_response(tid, end_of_sector);
-        send_data_to_client(tid, p_getdents + process_offset, end_of_sector - process_offset);
-        free(p_getdents);
-    } else {
-        write_response(tid, end_of_sector);
-        send_data_to_client(tid, p + process_offset, bytes_read);
-    }
+
+    write_response(tid, end_of_sector);
+    send_data_to_client(tid, p + process_offset, bytes_read);
+
     // TODO: check if the file was moved to the disk
 }
 
-inline void handle_local_read(int tid, int fd, off64_t count, bool dir, bool is_getdents,
-                              bool is_prod) {
-    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld, dir=%s, is_getdents=%s, is_prod=%s)", tid,
-              fd, count, dir ? "true" : "false", is_getdents ? "true" : "false",
+inline void handle_local_read(int tid, int fd, off64_t count, bool is_prod) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld, is_prod=%s)", tid, fd, count,
               is_prod ? "true" : "false");
 
     const std::lock_guard<std::mutex> lg(local_read_mutex);
@@ -63,19 +52,19 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool dir, bool is_
     off64_t end_of_sector             = c_file.get_sector_end(process_offset);
     off64_t end_of_read               = process_offset + count;
     std::string_view mode             = c_file.get_mode();
-    if (mode == CAPIO_FILE_MODE_UPDATE && !c_file.is_complete() && !writer && !is_prod && !dir) {
+    if (mode == CAPIO_FILE_MODE_UPDATE && !c_file.is_complete() && !writer && !is_prod) {
         // wait for file to be completed and then do what is done inside handle pending read
-        std::thread t([&c_file, tid, fd, count, is_getdents, process_offset] {
+        std::thread t([&c_file, tid, fd, count, process_offset] {
             c_file.wait_for_completion();
-            handle_pending_read(tid, fd, process_offset, count, is_getdents);
+            handle_pending_read(tid, fd, process_offset, count);
         });
         t.detach();
     } else if (end_of_read > end_of_sector) {
-        if (!is_prod && !writer && !c_file.is_complete() && !dir) {
+        if (!is_prod && !writer && !c_file.is_complete()) {
             // here if mode is NO_UPDATE, wait for data and then send it
-            std::thread t([&c_file, tid, fd, count, is_getdents, process_offset] {
+            std::thread t([&c_file, tid, fd, count, process_offset] {
                 c_file.wait_for_data(process_offset + count);
-                handle_pending_read(tid, fd, process_offset, count, is_getdents);
+                handle_pending_read(tid, fd, process_offset, count);
             });
             t.detach();
 
@@ -85,42 +74,19 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool dir, bool is_
                 return;
             }
             c_file.create_buffer_if_needed(path, false);
-            char *p = c_file.get_buffer();
-            if (is_getdents || dir) {
-                off64_t dir_size  = c_file.get_stored_size();
-                off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
-                char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
-                end_of_sector     = store_dirent(p, p_getdents, dir_size);
-                write_response(tid, end_of_sector);
-                send_data_to_client(tid, p_getdents + process_offset,
-                                    end_of_sector - process_offset);
-                free(p_getdents);
-            } else {
-                write_response(tid, end_of_sector);
-                send_data_to_client(tid, p + process_offset, end_of_sector - process_offset);
-            }
+            write_response(tid, end_of_sector);
+            send_data_to_client(tid, c_file.get_buffer() + process_offset,
+                                end_of_sector - process_offset);
         }
     } else {
         c_file.create_buffer_if_needed(path, false);
-        char *p = c_file.get_buffer();
-        if (is_getdents) {
-            off64_t dir_size  = c_file.get_stored_size();
-            off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
-            char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
-            store_dirent(p, p_getdents, dir_size);
-            write_response(tid, end_of_read);
-            send_data_to_client(tid, p_getdents + process_offset, count);
-            free(p_getdents);
-        } else {
-            write_response(tid, end_of_read);
-            send_data_to_client(tid, p + process_offset, count);
-        }
+        write_response(tid, end_of_read);
+        send_data_to_client(tid, c_file.get_buffer() + process_offset, count);
     }
 }
 
-inline void request_remote_read(int tid, int fd, off64_t count, bool is_dir, bool is_getdents) {
-    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld, is_dir=%s, is_getdents=%s)", tid, fd, count,
-              is_dir ? "true" : "false", is_getdents ? "true" : "false");
+inline void request_remote_read(int tid, int fd, off64_t count) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld)", tid, fd, count);
 
     const std::filesystem::path &path = get_capio_file_path(tid, fd);
     CapioFile &c_file                 = get_capio_file(path);
@@ -132,7 +98,7 @@ inline void request_remote_read(int tid, int fd, off64_t count, bool is_dir, boo
         (end_of_read <= end_of_sector ||
          (end_of_sector == -1 ? 0 : end_of_sector) == c_file.real_file_size)) {
         LOG("Handling local read");
-        handle_local_read(tid, fd, count, is_dir, is_getdents, true);
+        handle_local_read(tid, fd, count, true);
     } else if (end_of_read <= end_of_sector) {
         LOG("Data is present locally and can be served to client");
         c_file.create_buffer_if_needed(path, false);
@@ -141,20 +107,18 @@ inline void request_remote_read(int tid, int fd, off64_t count, bool is_dir, boo
         send_data_to_client(tid, p + offset, count);
     } else {
         LOG("Delegating to backend remote read");
-        handle_remote_read_request(tid, fd, count, is_getdents);
+        handle_remote_read_request(tid, fd, count, false);
     }
 }
 
-void wait_for_file_creation(const std::filesystem::path &path, int tid, int fd, off64_t count,
-                            bool dir, bool is_getdents) {
-    START_LOG(gettid(), "call(tid=%d, parent_pid=%d,  fd=%d, count=%ld, dir=%s, is_getdents=%s)",
-              tid, getppid(), fd, count, dir ? "true" : "false", is_getdents ? "true" : "false");
+void wait_for_file(const std::filesystem::path &path, int tid, int fd, off64_t count) {
+    START_LOG(gettid(), "call(path=%s, tid=%d, fd=%d, count=%ld)", path.c_str(), tid, fd, count);
 
     loop_load_file_location(path);
 
     // check if the file is local or remote
     if (strcmp(std::get<0>(get_file_location(path)), node_name) == 0) {
-        handle_local_read(tid, fd, count, dir, is_getdents, false);
+        handle_local_read(tid, fd, count, false);
     } else {
         const CapioFile &c_file = get_capio_file(path);
         auto remote_app         = apps.find(tid);
@@ -166,18 +130,17 @@ void wait_for_file_creation(const std::filesystem::path &path, int tid, int fd, 
                 off64_t batch_size                 = std::get<5>(metadata_conf_globs[pos]);
                 if (batch_size > 0) {
                     handle_remote_read_batch_request(tid, fd, count, remote_app_name, prefix,
-                                                     batch_size, is_getdents);
+                                                     batch_size, false);
                     return;
                 }
             }
         }
-        request_remote_read(tid, fd, count, dir, is_getdents);
+        request_remote_read(tid, fd, count);
     }
 }
 
-inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getdents) {
-    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld, dir=%s, is_getdents=%s)", tid, fd, count,
-              dir ? "true" : "false", is_getdents ? "true" : "false");
+inline void handle_read(int tid, int fd, off64_t count) {
+    START_LOG(gettid(), "call(tid=%d, fd=%d, count=%ld)", tid, fd, count);
 
     const std::filesystem::path &path      = get_capio_file_path(tid, fd);
     const std::filesystem::path &capio_dir = get_capio_dir();
@@ -186,12 +149,12 @@ inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getden
     if (!file_location_opt && !is_prod) {
         LOG("Starting thread to wait for file creation");
         // launch a thread that checks when the file is created
-        std::thread t(wait_for_file_creation, path, tid, fd, count, dir, is_getdents);
+        std::thread t(wait_for_file, path, tid, fd, count);
         t.detach();
     } else if (is_prod || strcmp(std::get<0>(file_location_opt->get()), node_name) == 0 ||
                capio_dir == path) {
         LOG("File is local. handling local read");
-        handle_local_read(tid, fd, count, dir, is_getdents, is_prod);
+        handle_local_read(tid, fd, count, is_prod);
     } else {
         LOG("File is remote");
         CapioFile &c_file = get_capio_file(path);
@@ -207,35 +170,21 @@ inline void handle_read(int tid, int fd, off64_t count, bool dir, bool is_getden
                 if (batch_size > 0) {
                     LOG("Handling batch file");
                     handle_remote_read_batch_request(tid, fd, count, app_name, prefix, batch_size,
-                                                     is_getdents);
+                                                     false);
                     return;
                 }
             }
         }
         LOG("Delegating to backend remote read");
-        request_remote_read(tid, fd, count, dir, is_getdents);
+        request_remote_read(tid, fd, count);
     }
-}
-
-void getdents_handler(const char *const str) {
-    int tid, fd;
-    off64_t count;
-    sscanf(str, "%d %d %ld", &tid, &fd, &count);
-    handle_read(tid, fd, count, true, true);
-}
-
-void getdents64_handler(const char *const str) {
-    int tid, fd;
-    off64_t count;
-    sscanf(str, "%d %d %ld", &tid, &fd, &count);
-    handle_read(tid, fd, count, true, false);
 }
 
 void read_handler(const char *const str) {
     int tid, fd;
     off64_t count;
     sscanf(str, "%d %d %ld", &tid, &fd, &count);
-    handle_read(tid, fd, count, false, false);
+    handle_read(tid, fd, count);
 }
 
 #endif // CAPIO_SERVER_HANDLERS_READ_HPP

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -8,7 +8,7 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, base_offset=%ld, count=%ld)", tid, fd, base_offset,
               count);
     // check if another process is waiting for this data
-    off64_t data_size                 = base_offset + count;
+    off64_t end_of_read               = base_offset + count;
     const std::filesystem::path &path = get_capio_file_path(tid, fd);
     CapioFile &c_file                 = get_capio_file(path);
     size_t file_shm_size              = c_file.get_buf_size();
@@ -17,8 +17,8 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count) {
     off64_t r                         = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
 
     c_file.create_buffer_if_needed(path, true);
-    if (data_size > file_shm_size) {
-        c_file.expand_buffer(data_size);
+    if (end_of_read > file_shm_size) {
+        c_file.expand_buffer(end_of_read);
     }
     for (int i = 0; i < n_reads; i++) {
         c_file.read_from_queue(*data_buf, base_offset + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
@@ -29,7 +29,7 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count) {
     }
     int pid            = pids[tid];
     writers[pid][path] = true;
-    c_file.insert_sector(base_offset, data_size);
+    c_file.insert_sector(base_offset, end_of_read);
     if (c_file.first_write) {
         c_file.first_write = false;
         write_file_location(path);

--- a/src/server/remote/handlers/read.hpp
+++ b/src/server/remote/handlers/read.hpp
@@ -110,9 +110,7 @@ inline void handle_read_reply(int tid, int fd, long count, off64_t file_size, of
     if (is_getdents) {
         send_dirent_to_client(tid, c_file, offset, bytes_read);
     } else {
-        char *p = c_file.get_buffer();
-        write_response(tid, end_of_sector);
-        send_data_to_client(tid, p + offset, bytes_read);
+        send_data_to_client(tid, c_file.get_buffer(), offset, bytes_read);
     }
 }
 

--- a/src/server/remote/handlers/read.hpp
+++ b/src/server/remote/handlers/read.hpp
@@ -99,7 +99,6 @@ inline void handle_read_reply(int tid, int fd, long count, off64_t file_size, of
 
     off64_t end_of_sector = c_file.get_sector_end(offset);
     c_file.create_buffer_if_needed(path, false);
-    char *p = c_file.get_buffer();
     off64_t bytes_read;
     off64_t end_of_read = offset + count;
     if (end_of_sector > end_of_read) {
@@ -109,14 +108,9 @@ inline void handle_read_reply(int tid, int fd, long count, off64_t file_size, of
         bytes_read = end_of_sector - offset;
     }
     if (is_getdents) {
-        off64_t dir_size  = c_file.get_stored_size();
-        off64_t n_entries = dir_size / CAPIO_THEORETICAL_SIZE_DIRENT64;
-        char *p_getdents  = (char *) malloc(n_entries * sizeof(char) * dir_size);
-        end_of_sector     = store_dirent(p, p_getdents, dir_size);
-        write_response(tid, end_of_sector);
-        send_data_to_client(tid, p_getdents + offset, bytes_read);
-        free(p_getdents);
+        send_dirent_to_client(tid, c_file, offset, bytes_read);
     } else {
+        char *p = c_file.get_buffer();
         write_response(tid, end_of_sector);
         send_data_to_client(tid, p + offset, bytes_read);
     }

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -39,14 +39,13 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path,
 
     strcpy(ld.d_name, file_name.c_str());
     LOG("FILENAME LD: %s", ld.d_name);
-    long int ld_size = CAPIO_THEORETICAL_SIZE_DIRENT64;
-    ld.d_reclen      = ld_size;
+    ld.d_reclen = sizeof(linux_dirent64);
 
     CapioFile &c_file = get_capio_file(dir);
     c_file.create_buffer_if_needed(dir, true);
     void *file_shm       = c_file.get_buffer();
     off64_t file_size    = c_file.get_stored_size();
-    off64_t data_size    = file_size + ld_size; // TODO: check theoreitcal size and sizeof(ld) usage
+    off64_t data_size    = file_size + ld.d_reclen;
     size_t file_shm_size = c_file.get_buf_size();
     ld.d_off             = data_size;
 

--- a/src/server/utils/types.hpp
+++ b/src/server/utils/types.hpp
@@ -8,6 +8,8 @@
 
 #include "capio/queue.hpp"
 
+#include "utils/capio_file.hpp"
+
 typedef std::unordered_map<int, int> CSPidsMap_T;
 typedef std::unordered_map<int, std::string> CSAppsMap_t;
 typedef std::unordered_map<std::string, std::unordered_set<std::string>> CSFilesSentMap_t;

--- a/tests/unit/syscall/src/dirent.cpp
+++ b/tests/unit/syscall/src/dirent.cpp
@@ -72,23 +72,9 @@ TEST(SystemCallTest, TestDirentsOnCapioDir) {
 
         for (size_t bpos = 0, i = 0; bpos < nread && i < 10; i++) {
             auto d = (struct linux_dirent64 *) (buf + bpos);
-            //  printf("%8ld  ", d->d_ino);
-            // d_type           = d->d_type;
-            /* printf("%-10s(%d) ",
-                               (d_type == DT_REG)    ? "regular"
-                               : (d_type == DT_DIR)  ? "directory"
-                               : (d_type == DT_FIFO) ? "FIFO"
-                               : (d_type == DT_SOCK) ? "socket"
-                               : (d_type == DT_LNK)  ? "symlink"
-                               : (d_type == DT_BLK)  ? "block dev"
-                               : (d_type == DT_CHR)  ? "char dev"
-                                                     : "???",
-                               d_type); */
 
             EXPECT_NE(std::find(expectedNames.begin(), expectedNames.end(), d->d_name),
                       expectedNames.end());
-
-            // printf("%4d %10lld  %s\n", d->d_reclen, (long long) d->d_off, d->d_name);
             bpos += d->d_reclen;
         }
     }


### PR DESCRIPTION
This commit introduces the following changes:

- Split `read` code from `getdents` code into two different files.
- The `getdents` and `getdents64` handlers are now unified to reflect the implementation in glibc of `getdents` structure
- All the server `getdents` logic has been moved inside the `send_dirent_to_client` method, and the syscall handling has been optimised to reduce the amount of memory copies
- The `read` response sending logic has been moved inside the `send_data_to_client` method, reducing the amount of duplicate code