### PR TITLE
Phase 1 of location rewrite

### DIFF
--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,73 @@
+{
+   "$schema" : "https://clio.hpc4ai.it/schema/clio.json",
+   "version" : 2,
+   "name":"1000-genome-new",
+   "alias":{
+      "mutation_frequency_in" : ["sifted.SIFT.chr1.txt", "chr1n", "data/populations/ALL", "data/20130502/columns.txt"]
+   },
+   "io_graph" : {
+      "download" :{
+         "output" : {
+            "data*" : {
+               "committed" : "on_close",
+				   "mode" : "append"
+            }
+         }
+      },
+      "individuals":{
+         "input" : {
+            "data/20130502/ALL.chr1.250000.vcf" : {}
+         },
+         "output" : {
+            "chr1n-*" : {
+               "committed" : "on_close",
+				   "mode" : "append",
+				   "n_files" : 2504
+            }
+         }
+      },
+      "individuals_merge" :{
+         "input" : {
+            "chr1n-*" : {}
+         },
+         "output" : {
+            "chr1n" :{
+               "committed" : "on_close",
+				   "mode" : "append",
+				   "n_files" : 2504
+            }
+         }
+      },
+      "sifting" :{
+         "input" : {
+            "data/20130502/sifting/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5.20130502.sites.annotation.vcf" : {}
+         },
+         "output" : {
+            "sifted.SIFT.chr1.txt":{
+               "committed" : "on_close",
+				   "mode" : "append"
+            }
+         }
+      },
+      "mutations_overlap" :{
+         "input" :{
+            "mutation_frequency_in" : {}
+         },
+         "output" : {
+            "chr1-ALL.tar.gz" : {},
+            "output_no_sift/total_mutations_individual1_sNO-SIFT_ALL.txt" : {
+               "committed" : "on_close"
+            }
+         }
+      },
+      "frequency" : {
+         "input" : {
+            "mutation_frequency_in" : {}
+         },
+         "output":{
+            "chr1-ALL-freq.tar.gz" : {}
+         }
+      }
+   }
+}
+

--- a/sample.json
+++ b/sample.json
@@ -1,73 +1,83 @@
 {
-   "$schema" : "https://clio.hpc4ai.it/schema/clio.json",
-   "version" : 2,
-   "name":"1000-genome-new",
-   "alias":{
-      "mutation_frequency_in" : ["sifted.SIFT.chr1.txt", "chr1n", "data/populations/ALL", "data/20130502/columns.txt"]
-   },
-   "io_graph" : {
-      "download" :{
-         "output" : {
-            "data*" : {
-               "committed" : "on_close",
-				   "mode" : "append"
-            }
-         }
-      },
-      "individuals":{
-         "input" : {
-            "data/20130502/ALL.chr1.250000.vcf" : {}
-         },
-         "output" : {
-            "chr1n-*" : {
-               "committed" : "on_close",
-				   "mode" : "append",
-				   "n_files" : 2504
-            }
-         }
-      },
-      "individuals_merge" :{
-         "input" : {
-            "chr1n-*" : {}
-         },
-         "output" : {
-            "chr1n" :{
-               "committed" : "on_close",
-				   "mode" : "append",
-				   "n_files" : 2504
-            }
-         }
-      },
-      "sifting" :{
-         "input" : {
-            "data/20130502/sifting/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5.20130502.sites.annotation.vcf" : {}
-         },
-         "output" : {
-            "sifted.SIFT.chr1.txt":{
-               "committed" : "on_close",
-				   "mode" : "append"
-            }
-         }
-      },
-      "mutations_overlap" :{
-         "input" :{
-            "mutation_frequency_in" : {}
-         },
-         "output" : {
-            "chr1-ALL.tar.gz" : {},
-            "output_no_sift/total_mutations_individual1_sNO-SIFT_ALL.txt" : {
-               "committed" : "on_close"
-            }
-         }
-      },
-      "frequency" : {
-         "input" : {
-            "mutation_frequency_in" : {}
-         },
-         "output":{
-            "chr1-ALL-freq.tar.gz" : {}
-         }
+  "$schema": "https://clio.hpc4ai.it/schema/v1.1/clio.json",
+  "version": 1.1,
+  "name": "1000-genome-new",
+  "alias": {
+    "mutfreqin": [
+      "sifted.SIFT.chr1.txt",
+      "chr1n",
+      "data/populations/ALL",
+      "data/20130502/columns.txt"
+    ]
+  },
+  "io_graph": {
+    "download": {
+      "output": {
+        "data*": {
+          "committed": "on_close",
+          "mode": "append",
+          "permanent" : true,
+          "exclude" : false
+        }
       }
-   }
+    },
+    "individuals": {
+      "input": {
+        "data/20130502/ALL.chr1.250000.vcf": {}
+      },
+      "output": {
+        "chr1n-*": {
+          "committed": "on_close",
+          "mode": "append",
+          "n_files": 2504,
+          "permanent" : false,
+          "exclude" : true
+        }
+      }
+    },
+    "individuals_merge": {
+      "input": {
+        "chr1n-*": {}
+      },
+      "output": {
+        "chr1n": {
+          "committed": "on_close",
+          "mode": "append",
+          "permanent" : true,
+          "exclude" : false,
+          "n_files": 2504
+        }
+      }
+    },
+    "sifting": {
+      "input": {
+        "data/20130502/sifting/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5.20130502.sites.annotation.vcf": {}
+      },
+      "output": {
+        "sifted.SIFT.chr1.txt": {
+          "committed": "on_close",
+          "mode": "append"
+        }
+      }
+    },
+    "mutations_overlap": {
+      "input": {
+        "mutfreqin": {}
+      },
+      "output": {
+        "chr1-ALL.tar.gz": {},
+        "output_no_sift/total_mutations_individual1_sNO-SIFT_ALL.txt": {
+          "committed": "on_close"
+        }
+      }
+    },
+    "frequency": {
+      "input": {
+        "mutfreqin": {}
+      },
+      "output": {
+        "chr1-ALL-freq.tar.gz": {}
+      }
+    }
+  }
 }
-

--- a/sample.json
+++ b/sample.json
@@ -14,7 +14,7 @@
     "download": {
       "output": {
         "data*": {
-          "committed": "on_close",
+          "committed": "on_close:10",
           "mode": "append",
           "permanent" : true,
           "exclude" : false

--- a/src/common/capio/circular_buffer.hpp
+++ b/src/common/capio/circular_buffer.hpp
@@ -91,7 +91,8 @@ template <class T> class CircularBuffer {
         SEM_CREATE_CHECK(_sem_num_empty, _sem_num_empty_name.c_str());
     }
 
-    CircularBuffer(const CircularBuffer &)            = delete;
+    CircularBuffer(const CircularBuffer &) = delete;
+
     CircularBuffer &operator=(const CircularBuffer &) = delete;
 
     ~CircularBuffer() {

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -94,6 +94,7 @@ constexpr char CAPIO_LOG_SERVER_BANNER[] =
 constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_INFO[]    = "[ \033[1;32m SERVER \033[0m ] ";
 constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
 constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_JSON[]    = "[ \033[1;34m SERVER \033[0m ] ";
 constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING[] =
     "[ \033[1;33m SERVER \033[0m ] "
     "|==================================================================|\n"

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -19,7 +19,9 @@
 #endif
 
 #ifndef __CAPIO_POSIX
+
 #include <filesystem>
+
 thread_local std::ofstream logfile; // if building for server, self contained logfile
 std::string log_master_dir_name = CAPIO_DEFAULT_LOG_FOLDER;
 std::string logfile_prefix      = CAPIO_SERVER_DEFAULT_LOG_FILE_PREFIX;
@@ -31,7 +33,7 @@ thread_local char logfile_path[PATH_MAX]{'\0'};
 
 thread_local int current_log_level = 0;
 thread_local bool logging_syscall  = false; // this variable tells the logger that syscall logging
-                                            // has started and we are not in setup phase
+// has started and we are not in setup phase
 
 #ifndef CAPIO_MAX_LOG_LEVEL // capio max log level. defaults to -1, where everything is logged
 #define CAPIO_MAX_LOG_LEVEL -1
@@ -40,6 +42,7 @@ thread_local bool logging_syscall  = false; // this variable tells the logger th
 int CAPIO_LOG_LEVEL = CAPIO_MAX_LOG_LEVEL;
 
 #ifndef __CAPIO_POSIX
+
 inline auto open_server_logfile() {
     auto hostname = new char[HOST_NAME_MAX];
     gethostname(hostname, HOST_NAME_MAX);
@@ -57,6 +60,7 @@ inline auto open_server_logfile() {
 
     return logfile_name;
 }
+
 #else
 
 inline auto get_hostname() {
@@ -144,6 +148,7 @@ void log_write_to(char *buffer, size_t bufflen) {
 class SyscallLoggingSuspender {
   public:
     SyscallLoggingSuspender() { logging_syscall = false; }
+
     ~SyscallLoggingSuspender() { logging_syscall = true; }
 };
 
@@ -223,7 +228,8 @@ class Logger {
         current_log_level++;
     }
 
-    Logger(const Logger &)            = delete;
+    Logger(const Logger &) = delete;
+
     Logger &operator=(const Logger &) = delete;
 
     inline ~Logger() {

--- a/src/common/capio/spsc_queue.hpp
+++ b/src/common/capio/spsc_queue.hpp
@@ -84,7 +84,8 @@ template <class T> class SPSCQueue {
         }
     }
 
-    SPSCQueue(const SPSCQueue &)            = delete;
+    SPSCQueue(const SPSCQueue &) = delete;
+
     SPSCQueue &operator=(const SPSCQueue &) = delete;
 
     ~SPSCQueue() {

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -208,7 +208,6 @@ int parseCLI(int argc, char **argv) {
         const std::filesystem::path &capio_dir = get_capio_dir();
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "parsing config file: " << token
                   << std::endl;
-        load_configuration(token, capio_dir);
         parse_conf_file(token, capio_dir);
     } else if (noConfigFile) {
         workflow_name = std::string_view(get_capio_workflow_name());

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -26,13 +26,7 @@ std::string workflow_name;
 #include "capio/logger.hpp"
 #include "capio/semaphore.hpp"
 #include "utils/capio_file.hpp"
-#include "utils/common.hpp"
-#include "utils/env.hpp"
-#include "utils/json.hpp"
-#include "utils/metadata.hpp"
-#include "utils/requests.hpp"
-
-using namespace simdjson;
+#include "utils/types.hpp"
 
 int n_servers;
 // name of the node
@@ -61,6 +55,19 @@ CSWritersMap_t writers;
 CSClientsRemotePendingNFilesMap_t clients_remote_pending_nfiles;
 
 sem_t clients_remote_pending_nfiles_sem;
+
+using namespace simdjson;
+
+#include "capio/env.hpp"
+#include "capio/logger.hpp"
+#include "capio/semaphore.hpp"
+
+#include "utils/common.hpp"
+#include "utils/env.hpp"
+#include "utils/json.hpp"
+#include "utils/metadata.hpp"
+#include "utils/requests.hpp"
+
 
 #include "handlers.hpp"
 #include "utils/location.hpp"
@@ -201,6 +208,7 @@ int parseCLI(int argc, char **argv) {
         const std::filesystem::path &capio_dir = get_capio_dir();
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "parsing config file: " << token
                   << std::endl;
+        load_configuration(token, capio_dir);
         parse_conf_file(token, capio_dir);
     } else if (noConfigFile) {
         workflow_name = std::string_view(get_capio_workflow_name());
@@ -256,6 +264,7 @@ int main(int argc, char **argv) {
     std::cout << CAPIO_LOG_SERVER_BANNER;
 
     parseCLI(argc, argv);
+
 
     START_LOG(gettid(), "call()");
 

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -68,7 +68,6 @@ using namespace simdjson;
 #include "utils/metadata.hpp"
 #include "utils/requests.hpp"
 
-
 #include "handlers.hpp"
 #include "utils/location.hpp"
 #include "utils/signals.hpp"
@@ -263,7 +262,6 @@ int main(int argc, char **argv) {
     std::cout << CAPIO_LOG_SERVER_BANNER;
 
     parseCLI(argc, argv);
-
 
     START_LOG(gettid(), "call()");
 

--- a/src/server/remote/backend.hpp
+++ b/src/server/remote/backend.hpp
@@ -1,5 +1,6 @@
 #ifndef CAPIO_SERVER_REMOTE_BACKEND_HPP
 #define CAPIO_SERVER_REMOTE_BACKEND_HPP
+
 #include "capio/logger.hpp"
 #include <charconv>
 
@@ -25,13 +26,16 @@ class RemoteRequest {
         }
     };
 
-    RemoteRequest(const RemoteRequest &)            = delete;
+    RemoteRequest(const RemoteRequest &) = delete;
+
     RemoteRequest &operator=(const RemoteRequest &) = delete;
 
     ~RemoteRequest() { delete[] _buf_recv; }
 
     [[nodiscard]] auto get_source() const { return this->_source; }
+
     [[nodiscard]] auto get_content() const { return this->_buf_recv; }
+
     [[nodiscard]] auto get_code() const { return this->_code; }
 };
 

--- a/src/server/remote/backend/include.hpp
+++ b/src/server/remote/backend/include.hpp
@@ -5,4 +5,5 @@
  */
 
 #include "mpi.hpp"
+
 #endif // CAPIO_SERVER_REMOTE_BACKEND_INCLUDE_HPP

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -90,7 +90,8 @@ class CapioFile {
         : _buf_size(init_size), _committed(CAPIO_FILE_COMMITTED_ON_TERMINATION),
           _directory(directory), _n_close_expected(n_close_expected), _permanent(permanent) {}
 
-    CapioFile(const CapioFile &)            = delete;
+    CapioFile(const CapioFile &) = delete;
+
     CapioFile &operator=(const CapioFile &) = delete;
 
     ~CapioFile() {

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -14,7 +14,6 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
 
     std::unordered_map<std::string, std::vector<std::string_view>> alias_map;
 
-    std::string_view workflow_name;
     START_LOG(gettid(), "call(config_file='%s', capio_dir='%s')", conf_file.c_str(),
               capio_dir.c_str());
 
@@ -22,7 +21,7 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
     simdjson::ondemand::object objects = doc.get_object();
 
     try {
-        workflow_name = objects["name"].get_string();
+        workflow_name = std::string(objects["name"].get_string().value());
     } catch (simdjson::simdjson_error &e) {
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
                   << "Current configuration file does not provide required section name"
@@ -72,18 +71,18 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
         try {
             auto output = application.value()["output"].get_object();
             for (auto output_file : output) {
-                std::string file_name = std::string(output_file.unescaped_key().value());
-
-                bool isAlias = (alias_map.find(file_name) != alias_map.end());
+                std::string file_name     = std::string(output_file.unescaped_key().value());
+                std::string commit_number = "-1";
+                bool isAlias              = (alias_map.find(file_name) != alias_map.end());
 
                 file_locations.newFile(file_name);
 
-                if(isAlias){
-                    for(auto name : alias_map.at(file_name)){
+                if (isAlias) {
+                    for (auto name : alias_map.at(file_name)) {
                         std::string producer_name = std::string(name);
                         file_locations.addProducer(application_name, producer_name);
                     }
-                }else{
+                } else {
                     file_locations.addProducer(file_name, application_name);
                 }
 
@@ -91,15 +90,30 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
                     auto commit_rule =
                         output_file.value()["committed"].value().get_string().value();
 
-                    if(isAlias){
-                        for(auto name : alias_map.at(file_name)){
-                            std::string name_str = std::string(name);
-                            file_locations.setCommitRule(name_str, std::string(commit_rule));
-                        }
-                    }else{
-                        file_locations.setCommitRule(file_name, std::string(commit_rule));
+                    if (commit_rule.find(":") != std::string::npos) {
+                        commit_number = std::string(
+                            commit_rule.substr(commit_rule.find(":") + 1, commit_rule.length()));
+                        commit_rule = commit_rule.substr(0, commit_rule.find(":"));
+                        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "File is committed "
+                                  << commit_rule << " after " << commit_number << " times."
+                                  << std::endl;
                     }
 
+                    if (isAlias) {
+                        for (auto name : alias_map.at(file_name)) {
+                            std::string name_str = std::string(name);
+                            file_locations.setCommitRule(name_str, std::string(commit_rule));
+                            if (commit_number != "-1") {
+                                file_locations.setCommitedNumber(name_str,
+                                                                 std::stoi(commit_number));
+                            }
+                        }
+                    } else {
+                        file_locations.setCommitRule(file_name, std::string(commit_rule));
+                        if (commit_number != "-1") {
+                            file_locations.setCommitedNumber(file_name, std::stoi(commit_number));
+                        }
+                    }
 
                 } catch (simdjson::simdjson_error &e) {
                     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "No committed rule for file "
@@ -108,12 +122,12 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
                 try {
                     auto fire_rule = output_file.value()["mode"].value().get_string().value();
 
-                    if(isAlias){
-                        for(auto name : alias_map.at(file_name)){
+                    if (isAlias) {
+                        for (auto name : alias_map.at(file_name)) {
                             std::string name_str = std::string(name);
                             file_locations.setFireRule(name_str, std::string(fire_rule));
                         }
-                    }else{
+                    } else {
                         file_locations.setFireRule(file_name, std::string(fire_rule));
                     }
 
@@ -125,12 +139,12 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
                 try {
                     auto permanent = output_file.value()["permanent"].value().get_bool().value();
 
-                    if(isAlias){
-                        for(auto name : alias_map.at(file_name)){
+                    if (isAlias) {
+                        for (auto name : alias_map.at(file_name)) {
                             std::string name_str = std::string(name);
                             file_locations.setPermanent(name_str, permanent);
                         }
-                    }else{
+                    } else {
                         file_locations.setPermanent(file_name, permanent);
                     }
 
@@ -142,17 +156,62 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
                 try {
                     auto exclude = output_file.value()["exclude"].value().get_bool().value();
 
-                    if(isAlias){
-                        for(auto name : alias_map.at(file_name)){
+                    if (isAlias) {
+                        for (auto name : alias_map.at(file_name)) {
                             std::string name_str = std::string(name);
                             file_locations.setExclude(name_str, exclude);
                         }
-                    }else{
+                    } else {
                         file_locations.setExclude(file_name, exclude);
                     }
                 } catch (simdjson::simdjson_error &e) {
                     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "No exclude rule for file "
                               << file_name << std::endl;
+                }
+
+                try {
+                    auto exclude = output_file.value()["kind"].value().get_string().value();
+                    if (exclude == "d") {
+                        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "File " << file_name
+                                  << " is a directory" << std::endl;
+                        file_locations.setDirectory(file_name);
+                    } else {
+                        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "File " << file_name
+                                  << " is a file" << std::endl;
+                        file_locations.setFile(file_name);
+                    }
+                } catch (simdjson::simdjson_error &e) {
+                    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "Setting file " << file_name
+                              << " to be a file" << std::endl;
+                    file_locations.setFile(file_name);
+                }
+
+                try {
+                    auto policy_name = output_file.value()["policy"].value().get_string();
+                    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON
+                              << "Policy was specified but CAPIO does not support other policies "
+                                 "other than CREATE";
+                } catch (simdjson::simdjson_error &e) {
+                    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "No policy rule for file "
+                              << file_name << std::endl;
+                }
+
+                try {
+                    auto directory_file_count =
+                        output_file.value()["n_files"].value().get_int64().value();
+
+                    if (directory_file_count > 0) {
+                        if (isAlias) {
+                            for (auto name : alias_map.at(file_name)) {
+                                file_locations.setDirectoryFileCount(std::string(name),
+                                                                     directory_file_count);
+                            }
+                        } else {
+                            file_locations.setDirectoryFileCount(file_name, directory_file_count);
+                        }
+                    }
+
+                } catch (simdjson::simdjson_error &e) {
                 }
             }
         } catch (simdjson::simdjson_error &e) {
@@ -170,12 +229,12 @@ inline void load_configuration(const std::string &conf_file, const std::filesyst
 
                 bool isAlias = (alias_map.find(file_name) != alias_map.end());
 
-                if(isAlias){
-                    for(auto name : alias_map.at(file_name)){
+                if (isAlias) {
+                    for (auto name : alias_map.at(file_name)) {
                         std::string name_str = std::string(name);
                         file_locations.addConsumer(name_str, application_name);
                     }
-                }else{
+                } else {
                     file_locations.newFile(file_name);
                     file_locations.addConsumer(file_name, application_name);
                 }

--- a/src/server/utils/json.hpp
+++ b/src/server/utils/json.hpp
@@ -3,6 +3,7 @@
 
 #include <singleheader/simdjson.h>
 
+#include "utils/location.hpp"
 #include "utils/metadata.hpp"
 #include "utils/types.hpp"
 
@@ -210,6 +211,97 @@ void parse_conf_file(const std::string &conf_file, const std::filesystem::path &
 
     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Completed parsing of io_graph" << std::endl;
     LOG("Completed parsing of io_graph");
+}
+
+inline void load_configuration(const std::string &conf_file,
+                               const std::filesystem::path &capio_dir) {
+    CapioFileLocations file_locations;
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string json;
+
+    std::unordered_map<std::string, std::vector<std::string_view>> alias_map;
+
+    std::string_view workflow_name;
+    START_LOG(gettid(), "call(config_file='%s', capio_dir='%s')", conf_file.c_str(),
+              capio_dir.c_str());
+
+    try {
+        json = simdjson::padded_string::load(conf_file);
+    } catch (const simdjson::simdjson_error &e) {
+        std::cerr << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
+                  << "Exception thrown while opening config file: " << e.what() << std::endl;
+        LOG("Exception thrown while opening config file: %s", e.what());
+        ERR_EXIT("Exception thrown while opening config file: %s", e.what());
+    }
+
+    auto doc                           = parser.iterate(json);
+    simdjson::ondemand::object objects = doc.get_object();
+
+    try {
+        workflow_name = objects["name"].get_string();
+    } catch (simdjson::simdjson_error &e) {
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Current configuration file does not provide required section name" <<  std::endl;
+        ERR_EXIT("Current configuration file does not provide required section name");
+    }
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "Workflow name: " << workflow_name << std::endl;
+
+    auto aliases = objects["alias"].get_object();
+    for (auto alias : aliases) {
+        std::string_view alias_name = alias.unescaped_key();
+        std::vector<std::string_view> resolved_alias;
+        for (auto t : alias.value().get_array().value()) {
+            std::string_view tmp_str;
+            t.get(tmp_str);
+            resolved_alias.emplace_back(tmp_str);
+        }
+        alias_map.emplace(alias_name, resolved_alias);
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "Alias: " << alias_name << " = [";
+        for (auto str : resolved_alias) {
+            std::cout << " " << str;
+        }
+        std::cout << " ]" << std::endl;
+    }
+
+    simdjson::simdjson_result<simdjson::ondemand::object> io_graph;
+
+    try{
+        io_graph = objects["io_graph"].get_object();
+    } catch (simdjson::simdjson_error& e){
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Current configuration file does not provide required section io_graph" <<  std::endl;
+        ERR_EXIT("Current configuration file does not provide required section io_graph");
+    }
+
+    for (auto application : io_graph) {
+        auto application_name = std::string(application.unescaped_key().value());
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON
+                  << "Parsing configuration for: " << application_name << std::endl;
+
+        try {
+            auto output = application.value()["output"].get_object();
+            for (auto output_file : output) {
+                std::string file_name = std::string(output_file.unescaped_key().value());
+                file_locations.newFile(file_name);
+                file_locations.addProducer(file_name, application_name);
+            }
+        } catch (simdjson::simdjson_error &e) {
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "No output files for app "
+                      << application_name << std::endl;
+        }
+
+        try {
+            auto input = application.value()["input"].get_object();
+            for (auto input_file : input) {
+                std::string file_name = std::string(input_file.unescaped_key().value());
+                file_locations.newFile(file_name);
+                file_locations.addConsumer(file_name, application_name);
+            }
+        } catch (simdjson::simdjson_error &e) {
+            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON << "No input files for app "
+                      << application_name << std::endl;
+        }
+    }
+
+    file_locations.print();
 }
 
 #endif // CAPIO_SERVER_UTILS_JSON_HPP

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -10,32 +10,43 @@
 
 class CapioFileLocations {
   private:
-    // pathname => <vector of producers, vector of consumers, commit_rule, fire_rule, permanent,
-    // exclude>
-    std::unordered_map<std::string, std::tuple<
-                                        std::vector<std::string>,
-                                        std::vector<std::string>,
-                                        std::string,
-                                        std::string,
-                                        bool,
-                                        bool>>
+    std::unordered_map<std::string,                         // path name
+                       std::tuple<std::vector<std::string>, // Vector for producers
+                                  std::vector<std::string>, // Vector for consumers
+                                  std::string,              // commit rule
+                                  std::string,              // fire_rule
+                                  bool,                     // permanent
+                                  bool,                     // exclude
+                                  bool, // is_file (if true yes otherwise it is a directory)
+                                  int,  // commit on file number
+                                  long> // directory file count
+                       >
         _locations;
 
-    inline std::string truncate_last_n(const std::string &str, int n) {
+    static inline std::string truncate_last_n(const std::string &str, int n) {
         return str.length() > n ? "[..] " + str.substr(str.length() - n) : str;
     }
 
   public:
     void print() {
         std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_JSON
-                  << "Composition of expected CAPIO FS: " << std::endl<< std::endl
-                  << "|===================|===================|====================|====================|============|===========|=========|"<< std::endl
-                  << "| Filename          | Producer step     | Consumer step      |  Commit Rule       |  Fire Rule | Permanent | Exclude |"<< std::endl
-                  << "|===================|===================|====================|====================|============|===========|=========|"<< std::endl;
+                  << "Composition of expected CAPIO FS: " << std::endl
+                  << std::endl
+                  << "|======|===================|===================|====================|========"
+                     "============|============|===========|=========|"
+                  << std::endl
+                  << "| Kind | Filename          | Producer step     | Consumer step      |  "
+                     "Commit Rule       |  Fire Rule | Permanent | Exclude |"
+                  << std::endl
+                  << "|======|===================|===================|====================|========"
+                     "============|============|===========|=========|"
+                  << std::endl;
         for (auto itm : _locations) {
             std::string name_trunc = truncate_last_n(itm.first, 12);
+            auto kind              = std::get<5>(itm.second) ? "F" : "D";
 
-            std::cout << "| " << name_trunc << std::setfill(' ')
+            std::cout << "|   " << kind << "  "
+                      << "| " << name_trunc << std::setfill(' ')
                       << std::setw(20 - name_trunc.length()) << "| ";
 
             auto producers = std::get<0>(itm.second);
@@ -46,7 +57,7 @@ class CapioFileLocations {
             for (int i = 0; i <= rowCount; i++) {
                 std::string prod, cons;
                 if (i > 0) {
-                    std::cout << "|                   | ";
+                    std::cout << "|      |                   | ";
                 }
 
                 if (i < producers.size()) {
@@ -68,21 +79,21 @@ class CapioFileLocations {
                 if (i == 0) {
                     std::string commit_rule = std::get<2>(itm.second),
                                 fire_rule   = std::get<3>(itm.second);
-                    bool exclude = std::get<4>(itm.second),
-                        permanent = std::get<5>(itm.second);
+                    bool exclude = std::get<4>(itm.second), permanent = std::get<5>(itm.second);
 
                     std::cout << " " << commit_rule << std::setfill(' ')
                               << std::setw(20 - commit_rule.length()) << " | " << fire_rule
                               << std::setfill(' ') << std::setw(13 - fire_rule.length()) << " | "
-                              << "    " << (permanent ? "YES" : "NO " )<< "   |   " << (exclude ? "YES" : "NO " )
-                              << "   |" << std::endl;
+                              << "    " << (permanent ? "YES" : "NO ") << "   |   "
+                              << (exclude ? "YES" : "NO ") << "   |" << std::endl;
                 } else {
                     std::cout << std::setfill(' ') << std::setw(20) << "|" << std::setfill(' ')
                               << std::setw(13) << "|" << std::setfill(' ') << std::setw(12) << "|"
-                              <<std::setfill(' ') << std::setw(10) << "|" << std::endl;
+                              << std::setfill(' ') << std::setw(10) << "|" << std::endl;
                 }
             }
             std::cout << "*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                         "~~~~~~~"
                          "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*"
                       << std::endl;
         }
@@ -93,15 +104,15 @@ class CapioFileLocations {
                     std::vector<std::string> &consumers, const std::string &commit_rule,
                     const std::string &fire_rule, bool permanent, bool exclude) {
         _locations.emplace(path, std::make_tuple(producers, consumers, commit_rule, fire_rule,
-                                                 permanent, exclude));
+                                                 permanent, exclude, true, -1, -1));
     }
 
     inline void newFile(const std::string &path) {
         if (_locations.find(path) == _locations.end()) {
-            _locations.emplace(path, std::make_tuple(std::vector<std::string>(),
-                                                     std::vector<std::string>(),
-                                                     CAPIO_FILE_COMMITTED_ON_TERMINATION,
-                                                     CAPIO_FILE_MODE_UPDATE, false, false));
+            _locations.emplace(
+                path, std::make_tuple(std::vector<std::string>(), std::vector<std::string>(),
+                                      CAPIO_FILE_COMMITTED_ON_TERMINATION, CAPIO_FILE_MODE_UPDATE,
+                                      false, false, true, -1, -1));
         }
     }
 
@@ -123,19 +134,50 @@ class CapioFileLocations {
         std::get<3>(_locations.at(path)) = fire_rule;
     }
 
-    inline void setPermanent(const std::string& path, bool value){
+    inline void setPermanent(const std::string &path, bool value) {
         std::get<5>(_locations.at(path)) = value;
     }
 
-    inline void setExclude(const std::string& path, bool value){
+    inline void setExclude(const std::string &path, bool value) {
         std::get<4>(_locations.at(path)) = value;
+    }
+
+    inline void setDirectory(const std::string &path) { std::get<5>(_locations.at(path)) = false; }
+
+    inline bool isDirectory(const std::string &path) { return !std::get<5>(_locations.at(path)); }
+
+    inline void setFile(const std::string &path) { std::get<5>(_locations.at(path)) = true; }
+
+    inline bool isFile(const std::string &path) { return std::get<5>(_locations.at(path)); }
+
+    inline void setCommitedNumber(const std::string &path, int num) {
+        std::get<6>(_locations.at(path)) = num;
+    }
+
+    inline void setDirectoryFileCount(const std::string &path, long num) {
+        std::get<7>(_locations.at(path)) = num;
     }
 
     inline void remove(const std::string &path) { _locations.erase(path); }
 
+    // TODO: return vector
     inline auto producers(const std::string &path) { return std::get<0>(_locations.at(path)); }
 
+    // TODO: return vector
     inline auto consumers(const std::string &path) { return std::get<1>(_locations.at(path)); }
+
+    // TODO: as soon as we migrate locations to use this class, finalize method can be removed
+    inline void finalize() {
+        for (auto file : _locations) {
+            auto name                                    = std::filesystem::path(file.first);
+            auto [producers, consumers, commit_rule, fire_rule, permanent, exclude, is_file,
+                  commitNumber, expected_dir_file_count] = file.second;
+            update_metadata_conf(name, file.first.find("*"), expected_dir_file_count,
+                                 -1, // NOTE: can be ignored as it is a useless parameter when
+                                     // home_node_policies are implemented
+                                 commit_rule, fire_rule, producers[0], permanent, commitNumber);
+        }
+    }
 };
 
 constexpr char CAPIO_SERVER_FILES_LOCATION_NAME[]     = "files_location.txt";
@@ -168,7 +210,8 @@ class FlockGuard {
         }
     }
 
-    FlockGuard(const FlockGuard &)            = delete;
+    FlockGuard(const FlockGuard &) = delete;
+
     FlockGuard &operator=(const FlockGuard &) = delete;
 
     inline ~FlockGuard() {


### PR DESCRIPTION
This commit introduces the following changes:
- Introduction of a class `CapioFileLocations` which in future commits shall be responsible of resolving locations
- Introduction of a new parser for json that exploits the new class `CapioFileLocations`. the new parser is built around the experimental new version of CLIO.

This commit is retro compatible with the already implemented version of CLIO. To use the new parser, in the config file, the field `"version"` must be set to a value greater than 1.