### PR TITLE
Migrate test suite to `GoogleTest`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -124,22 +124,28 @@ jobs:
                 -S ${GITHUB_WORKSPACE}
           cmake --build build -j $(nproc)
           sudo cmake --install build --prefix /usr/local
-      - name: "Run CAPIO server"
-        env:
-          CAPIO_DIR: ${{ github.workspace }}
-          CAPIO_LOG_LEVEL: -1
-        run: mpirun -n 1 capio_server --no-config &
       - name: "Run tests"
         id: run-tests
         timeout-minutes: 2
         env:
           CAPIO_DIR: ${{ github.workspace }}
+          CAPIO_LOG_LEVEL: -1
         run: |
-          ctest \
-            --build-config ${{ matrix.build_type }} \
-            --output-on-failure \
-            --stop-on-failure \
-            --test-dir build/tests
+          export LD_LIBRARY_PATH="build/src/posix:${LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="build/src/posix/syscall_intercept/lib:${LD_LIBRARY_PATH}"
+          
+          build/tests/posix/capio_posix_tests \
+            --gtest_break_on_failure \
+            --gtest_print_time=1
+          
+          build/tests/server/capio_server_tests \
+            --gtest_break_on_failure \
+            --gtest_print_time=1
+          
+          LD_PRELOAD=libcapio_posix.so \
+          build/tests/syscall/capio_syscall_tests \
+            --gtest_break_on_failure \
+            --gtest_print_time=1
       - name: "Show client logs on failure"
         if: ${{ always() && steps.run-tests.outcome == 'failure' && matrix.build_type == 'Debug' }}
         run: tail -v -n +1 capio_logs/posix/$(hostname)/posix_thread_*.log

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,17 +2,17 @@
 # External projects
 #####################################
 FetchContent_Declare(
-        Catch2
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.4.0
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
 )
-FetchContent_MakeAvailable(Catch2)
+FetchContent_MakeAvailable(GoogleTest)
 
 #####################################
 # CMake module imports
 #####################################
 include(CTest)
-include(Catch)
+include(GoogleTest)
 
 #####################################
 # Targets

--- a/tests/posix/CMakeLists.txt
+++ b/tests/posix/CMakeLists.txt
@@ -34,6 +34,7 @@ file(GLOB_RECURSE SYSCALL_INTERCEPT_HEADERS "${SYSCALL_INTERCEPT_INCLUDE_FOLDER}
 target_sources(${TARGET_NAME} PRIVATE
         "${CAPIO_COMMON_HEADERS}"
         "${CAPIO_POSIX_HEADERS}"
+        "${GTEST_CONFIG_HEADERS}"
         "${SYSCALL_INTERCEPT_HEADERS}"
 )
 target_include_directories(${TARGET_NAME} PRIVATE
@@ -45,12 +46,11 @@ target_include_directories(${TARGET_NAME} PRIVATE
 # Link libraries
 #####################################
 target_link_directories(${TARGET_NAME} PRIVATE ${SYSCALL_INTERCEPT_LIB_FOLDER})
-target_link_libraries(${TARGET_NAME} PRIVATE rt syscall_intercept Catch2::Catch2WithMain)
+target_link_libraries(${TARGET_NAME} PRIVATE rt syscall_intercept GTest::gtest_main)
 
 #####################################
 # Configure tests
 #####################################
-catch_discover_tests(${TARGET_NAME}
-        PROPERTIES
+gtest_discover_tests(${TARGET_NAME}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )

--- a/tests/posix/src/realpath.cpp
+++ b/tests/posix/src/realpath.cpp
@@ -1,6 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/reporters/catch_reporter_event_listener.hpp>
-#include <catch2/reporters/catch_reporter_registrars.hpp>
+#include <gtest/gtest.h>
 
 #include <filesystem>
 
@@ -8,63 +6,59 @@
 
 #include "utils/filesystem.hpp"
 
-class FileSystemRegistrar : public Catch::EventListenerBase {
-  public:
-    using Catch::EventListenerBase::EventListenerBase;
+class RealpathPosixTest : public testing::Test {
+  protected:
+    static void SetUpTestSuite() { init_filesystem(); }
 
-    void testCaseStarting(Catch::TestCaseInfo const &testCaseInfo) override { init_filesystem(); }
-
-    void testCaseEnded(Catch::TestCaseStats const &testCaseStats) override { destroy_filesystem(); }
+    static void TearDownTestSuite() { destroy_filesystem(); }
 };
 
-CATCH_REGISTER_LISTENER(FileSystemRegistrar);
-
-TEST_CASE("Test absolute paths inside the CAPIO_DIR when path exists", "[posix]") {
+TEST_F(RealpathPosixTest, TestAbsolutePathsInCapioDirWhenPathExists) {
     const std::filesystem::path PATHNAME = get_capio_dir() / "test";
-    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
-    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
-    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+    EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
+    EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
+    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
+    EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
+    EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
 
-TEST_CASE("Test absolute paths inside the CAPIO_DIR when path does not exist", "[posix]") {
+TEST_F(RealpathPosixTest, TestAbsoluePathsInCapioDirWhenPathDoesNotExist) {
     const std::filesystem::path PATHNAME = get_capio_dir() / "test";
-    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
 }
 
-TEST_CASE("Test absolute paths outside the CAPIO_DIR when path exists", "[posix]") {
+TEST_F(RealpathPosixTest, TestAbsolutePathsOutsideCapioDirWhenPathExists) {
     const std::filesystem::path PATHNAME = "/tmp/test";
-    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
-    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
-    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+    EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
+    EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
+    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
+    EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
+    EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
 
-TEST_CASE("Test absolute paths outside the CAPIO_DIR when path does not exist", "[posix]") {
+TEST_F(RealpathPosixTest, TestAbsoluePathOutsideCapioDirWhenPathDoesNotExist) {
     const std::filesystem::path PATHNAME = "/tmp/test";
-    REQUIRE(capio_posix_realpath(PATHNAME) == PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
 }
 
-TEST_CASE("Test relative paths inside the CAPIO_DIR when cwd is the CAPIO_DIR") {
+TEST_F(RealpathPosixTest, TestRelativePathsInCapioDirWhenCwdIsCapioDir) {
     const std::filesystem::path &capio_dir = get_capio_dir();
     const std::filesystem::path PATHNAME   = capio_dir / "test";
     set_current_dir(capio_dir);
-    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
-    REQUIRE(capio_posix_realpath("test") == PATHNAME);
-    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+    EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
+    EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
+    EXPECT_EQ(capio_posix_realpath("test"), PATHNAME);
+    EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
+    EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
 
-TEST_CASE("Test relative paths inside the CAPIO_DIR when cwd is a parent of the CAPIO_DIR") {
+TEST_F(RealpathPosixTest, TestRelativePathsInCapioDirWhenCwdIsParentOfCapioDir) {
     const std::filesystem::path &capio_dir = get_capio_dir();
     const std::filesystem::path PATHNAME   = capio_dir / "test";
     set_current_dir(capio_dir.parent_path());
-    REQUIRE(mkdir(PATHNAME.c_str(), S_IRWXU) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) == 0);
-    REQUIRE(capio_posix_realpath(capio_dir.filename() / "test") == PATHNAME);
-    REQUIRE(rmdir(PATHNAME.c_str()) != -1);
-    REQUIRE(access(PATHNAME.c_str(), F_OK) != 0);
+    EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
+    EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
+    EXPECT_EQ(capio_posix_realpath(capio_dir.filename() / "test"), PATHNAME);
+    EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
+    EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -25,12 +25,11 @@ target_include_directories(${TARGET_NAME} PRIVATE ${TARGET_INCLUDE_FOLDER})
 #####################################
 # Link libraries
 #####################################
-target_link_libraries(${TARGET_NAME} PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(${TARGET_NAME} PRIVATE GTest::gtest_main)
 
 #####################################
 # Configure tests
 #####################################
-catch_discover_tests(${TARGET_NAME}
-        PROPERTIES
+gtest_discover_tests(${TARGET_NAME}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )

--- a/tests/server/src/capio_file.cpp
+++ b/tests/server/src/capio_file.cpp
@@ -1,38 +1,45 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <iostream>
 
 #include "capio/env.hpp"
 #include "utils/capio_file.hpp"
 
-TEST_CASE("Test inserting a single sector", "[server]") {
+TEST(ServerTest, TestInsertSingleSector) {
     CapioFile c_file;
     c_file.insert_sector(1, 3);
     c_file.print(std::cout);
 }
 
-TEST_CASE("Test inserting two non-overlapping sectors", "[server]") {
+TEST(ServerTest, TestInsertTwoNonOverlappingSectors) {
     CapioFile c_file;
     c_file.insert_sector(5, 7);
     c_file.insert_sector(1, 3);
     c_file.print(std::cout);
 }
 
-TEST_CASE("Test inserting two overlapping sectors starting at the same offset", "[server]") {
+TEST(ServerTest, TestInsertTwoOverlappingSectors) {
+    CapioFile c_file;
+    c_file.insert_sector(2, 4);
+    c_file.insert_sector(1, 3);
+    c_file.print(std::cout);
+}
+
+TEST(ServerTest, TestInsertTwoOverlappingSectorsSameStart) {
     CapioFile c_file;
     c_file.insert_sector(1, 4);
     c_file.insert_sector(1, 3);
     c_file.print(std::cout);
 }
 
-TEST_CASE("Test inserting two overlapping sectors ending at the same offset", "[server]") {
+TEST(ServerTest, TestInsertTwoOverlappingSectorsSameEnd) {
     CapioFile c_file;
     c_file.insert_sector(1, 4);
     c_file.insert_sector(2, 4);
     c_file.print(std::cout);
 }
 
-TEST_CASE("Test inserting two overlapping sectors with one nested in the other", "[server]") {
+TEST(ServerTest, TestInsertTwoOverlappingSectorsNested) {
     CapioFile c_file;
     c_file.insert_sector(1, 4);
     c_file.insert_sector(2, 3);

--- a/tests/syscall/CMakeLists.txt
+++ b/tests/syscall/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TARGET_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/dirent.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/dup.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/file.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/rename.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/stat.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/statx.cpp
@@ -22,13 +23,12 @@ add_executable(${TARGET_NAME} ${TARGET_SOURCES})
 #####################################
 # Link libraries
 #####################################
-target_link_libraries(${TARGET_NAME} PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(${TARGET_NAME} PRIVATE GTest::gtest)
 
 #####################################
 # Configure tests
 #####################################
-catch_discover_tests(${TARGET_NAME}
-        PROPERTIES
-        ENVIRONMENT LD_PRELOAD=${PROJECT_BINARY_DIR}/src/posix/libcapio_posix.so
+gtest_discover_tests(${TARGET_NAME}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        PROPERTIES ENVIRONMENT LD_PRELOAD=${PROJECT_BINARY_DIR}/src/posix/libcapio_posix.so
 )

--- a/tests/syscall/src/clone.cpp
+++ b/tests/syscall/src/clone.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <thread>
 
@@ -11,7 +11,7 @@ constexpr int ARRAY_SIZE = 100;
 sem_t *sem;
 
 int func(const int *num) {
-    REQUIRE(*num == 12345);
+    EXPECT_EQ(*num, 12345);
     return 0;
 }
 
@@ -20,21 +20,20 @@ void write_file(int fd) {
     for (int i = 0; i < ARRAY_SIZE; i++) {
         array[i] = i;
     }
-    REQUIRE(write(fd, array, ARRAY_SIZE * sizeof(int)) == ARRAY_SIZE * sizeof(int));
+    EXPECT_EQ(write(fd, array, ARRAY_SIZE * sizeof(int)), ARRAY_SIZE * sizeof(int));
 }
 
 int write_file_stat_clone(FILE *fp) {
-    constexpr int ARRAY_SIZE = 100;
     int array[ARRAY_SIZE];
     for (int i = 0; i < ARRAY_SIZE; i++) {
         array[i] = i;
     }
-    REQUIRE(fwrite(array, sizeof(int), ARRAY_SIZE, fp) == ARRAY_SIZE);
-    REQUIRE(sem_post(sem) == 0);
+    EXPECT_EQ(fwrite(array, sizeof(int), ARRAY_SIZE, fp), ARRAY_SIZE);
+    EXPECT_EQ(sem_post(sem), 0);
     return 0;
 }
 
-TEST_CASE("Test thread clone", "[syscall]") {
+TEST(SystemCallTest, TestThreadClone) {
     int *num = static_cast<int *>(malloc(sizeof(int)));
     *num     = 12345;
     std::thread t(func, num);
@@ -42,38 +41,38 @@ TEST_CASE("Test thread clone", "[syscall]") {
     free(num);
 }
 
-TEST_CASE("Test thread clone producer/consumer", "[syscall]") {
+TEST(SystemCallTest, TestThreadCloneProducerConsumer) {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_RDWR | O_TRUNC;
     int fd                         = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
+    EXPECT_NE(fd, -1);
     std::thread t(write_file, fd);
     t.join();
-    REQUIRE(lseek(fd, 0, SEEK_SET) == 0);
+    EXPECT_EQ(lseek(fd, 0, SEEK_SET), 0);
     int num;
     for (int i = 0; i < ARRAY_SIZE; i++) {
-        REQUIRE(read(fd, &num, sizeof(int)) == sizeof(int));
-        REQUIRE(num == i);
+        EXPECT_EQ(read(fd, &num, sizeof(int)), sizeof(int));
+        EXPECT_EQ(num, i);
     }
-    REQUIRE(read(fd, &num, sizeof(int)) == 0);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
+    EXPECT_EQ(read(fd, &num, sizeof(int)), 0);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
 }
 
-TEST_CASE("Test thread clone producer/consumer with stat", "[syscall]") {
+TEST(SystemCallTest, TestThreadCloneProducerConsumerWithStat) {
     constexpr const char *PATHNAME = "test_file.txt";
     sem                            = static_cast<sem_t *>(malloc(sizeof(sem_t)));
-    REQUIRE(sem_init(sem, 0, 0) == 0);
+    EXPECT_EQ(sem_init(sem, 0, 0), 0);
     FILE *fp = fopen(PATHNAME, "w+");
-    REQUIRE(fp != nullptr);
+    EXPECT_NE(fp, nullptr);
     std::thread t1(write_file_stat_clone, fp);
-    REQUIRE(sem_wait(sem) == 0);
-    REQUIRE(fseek(fp, 0, SEEK_SET) != -1);
+    EXPECT_EQ(sem_wait(sem), 0);
+    EXPECT_NE(fseek(fp, 0, SEEK_SET), -1);
     int num;
     while (fread(&num, sizeof(int), 1, fp) != 0)
         ;
-    REQUIRE(feof(fp) != 0);
-    REQUIRE(fclose(fp) != EOF);
-    REQUIRE(unlink(PATHNAME) != -1);
+    EXPECT_NE(feof(fp), 0);
+    EXPECT_NE(fclose(fp), EOF);
+    EXPECT_NE(unlink(PATHNAME), -1);
     t1.join();
 }

--- a/tests/syscall/src/directory.cpp
+++ b/tests/syscall/src/directory.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <cerrno>
 #include <climits>
@@ -8,98 +8,92 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-TEST_CASE("Test directory creation, reopening and close", "[syscall]") {
+TEST(SystemCallTest, TestDirectoryCreateReopenClose) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(mkdir(PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     int flags = O_RDONLY | O_DIRECTORY;
     int fd    = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
     fd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(rmdir(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(rmdir(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test directory creation, reopening, and close using mkdirat with AT_FDCWD",
-          "[syscall]") {
+TEST(SystemCallTest, TestDirectoryCreateReopenCloseWithMkdiratAtFdcwd) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
     int flags = O_RDONLY | O_DIRECTORY;
     int fd    = openat(AT_FDCWD, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
     fd = openat(AT_FDCWD, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test that mkdir fails if directory already exists", "[syscall]") {
+TEST(SystemCallTest, TestMkdirFailsIfDirectoryAlreadyExists) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(mkdir(PATHNAME, S_IRWXU) == -1);
-    REQUIRE(errno == EEXIST);
-    REQUIRE(rmdir(PATHNAME) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(mkdir(PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(mkdir(PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(errno, EEXIST);
+    EXPECT_NE(rmdir(PATHNAME), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test directory creation, reopening, and close in a different directory using openat "
-          "with absolute path",
-          "[syscall]") {
+TEST(SystemCallTest, TestDirectoryCreateReopenCloseInDifferentDirectoryWithOpenatAbsolutePath) {
     const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
     const char *PATHNAME = path_fs.c_str();
-    REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(0, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(0, PATHNAME, F_OK, 0), 0);
     int flags = O_RDONLY | O_DIRECTORY;
     int fd    = openat(0, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
     fd = openat(0, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlinkat(0, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlinkat(0, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(0, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test directory creation, reopening, and close in a different directory using mkdirat "
-          "with dirfd",
-          "[syscall]") {
+TEST(SystemCallTest, TestDirectoryCreateReopenCloseInDifferentDirectoryWithMkdiratDirfd) {
     constexpr const char *PATHNAME = "test";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;
     int dirfd                      = open(DIRPATH, flags);
-    REQUIRE(dirfd != -1);
-    REQUIRE(mkdirat(dirfd, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(dirfd, -1);
+    EXPECT_NE(mkdirat(dirfd, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
     int fd = openat(dirfd, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
     fd = openat(dirfd, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
-    REQUIRE(close(dirfd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
+    EXPECT_NE(close(dirfd), -1);
 }
 
-TEST_CASE("Test obtaining the current directory with getcwd system call", "[syscall]") {
+TEST(SystemCallTest, TestGetcwd) {
     auto expected_path = std::string(std::getenv("PWD"));
     char obtained_path[PATH_MAX];
-    char *result = getcwd(obtained_path, PATH_MAX);
-    REQUIRE(expected_path == std::string(obtained_path));
-    REQUIRE(result != nullptr);
+    EXPECT_NE(getcwd(obtained_path, PATH_MAX), nullptr);
+    EXPECT_EQ(expected_path, std::string(obtained_path));
 }
 
-TEST_CASE("Test getcwd system call when path is longer than size", "[syscall]") {
+TEST(SystemCallTest, TestGetcwdWithPathLongerThanSize) {
     auto expected_path = std::string(std::getenv("PWD"));
-    REQUIRE(expected_path.size() > 1);
+    EXPECT_GT(expected_path.size(), 1);
     char obtained_path[1];
-    REQUIRE(getcwd(obtained_path, 1) == nullptr);
-    REQUIRE(errno == ERANGE);
+    EXPECT_EQ(getcwd(obtained_path, 1), nullptr);
+    EXPECT_EQ(errno, ERANGE);
 }

--- a/tests/syscall/src/dup.cpp
+++ b/tests/syscall/src/dup.cpp
@@ -1,145 +1,145 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <fcntl.h>
 #include <unistd.h>
 
-TEST_CASE("Test dup system call", "[syscall]") {
+TEST(SystemCallTest, TestDup) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(oldfd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     int newfd = dup(oldfd);
-    REQUIRE(newfd > oldfd);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(lseek(oldfd, 0, SEEK_SET) == 0);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(close(newfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_GT(newfd, oldfd);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_SET), 0);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(close(newfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test dup2 system call", "[syscall]") {
+TEST(SystemCallTest, TestDup2) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(oldfd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     int newfd = oldfd + 10;
-    REQUIRE(dup2(oldfd, newfd) == newfd);
-    REQUIRE(newfd > oldfd);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(lseek(oldfd, 0, SEEK_SET) == 0);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(close(newfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(dup2(oldfd, newfd), newfd);
+    EXPECT_GT(newfd, oldfd);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_SET), 0);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(close(newfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test dup2 system call when newfd points to an open file", "[syscall]") {
+TEST(SystemCallTest, TestDup2WithNewfdPointingToOpenFile) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(oldfd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     int newfd = open("/dev/null", O_WRONLY);
-    REQUIRE(dup2(oldfd, newfd) == newfd);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(close(newfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(dup2(oldfd, newfd), newfd);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(close(newfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test dup2 system call when the two arguments are equal", "[syscall]") {
+TEST(SystemCallTest, TestDup2WithTwoEqualArguments) {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd                      = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     int newfd = oldfd;
-    REQUIRE(dup2(oldfd, newfd) == newfd);
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(dup2(oldfd, newfd), newfd);
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test dup3 system call", "[syscall]") {
+TEST(SystemCallTest, TestDup3) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(oldfd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     int newfd = oldfd + 10;
-    REQUIRE(dup3(oldfd, newfd, 0) == newfd);
-    REQUIRE(newfd > oldfd);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(lseek(oldfd, 0, SEEK_SET) == 0);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(close(newfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(dup3(oldfd, newfd, 0), newfd);
+    EXPECT_GT(newfd, oldfd);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_SET), 0);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(close(newfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test dup3 system call when newfd points to an open file", "[syscall]") {
+TEST(SystemCallTest, TestDup3WithNewfdPointingToOpenFile) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(oldfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(oldfd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     int newfd = open("/dev/null", O_WRONLY);
-    REQUIRE(dup3(oldfd, newfd, 0) == newfd);
-    REQUIRE(lseek(oldfd, 0, SEEK_CUR) == lseek(newfd, 0, SEEK_CUR));
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(close(newfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(dup3(oldfd, newfd, 0), newfd);
+    EXPECT_EQ(lseek(oldfd, 0, SEEK_CUR), lseek(newfd, 0, SEEK_CUR));
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(close(newfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test dup3 system call when the two arguments are equal", "[syscall]") {
+TEST(SystemCallTest, TestDup3WithTwoEqualArguments) {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd                      = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     int newfd = oldfd;
-    REQUIRE(dup3(oldfd, newfd, 0) == -1);
-    REQUIRE(errno == EINVAL);
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(dup3(oldfd, newfd, 0), -1);
+    EXPECT_EQ(errno, EINVAL);
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test dup3 system call with the O_CLOEXEC flag", "[syscall]") {
+TEST(SystemCallTest, TestDup3WithOCloexec) {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
     int oldfd                      = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(oldfd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(oldfd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     int newfd = oldfd + 10;
-    REQUIRE(dup3(oldfd, newfd, O_CLOEXEC) == newfd);
-    REQUIRE((fcntl(oldfd, F_GETFD) & FD_CLOEXEC) != FD_CLOEXEC);
-    REQUIRE((fcntl(newfd, F_GETFD) & FD_CLOEXEC) == FD_CLOEXEC);
-    REQUIRE(close(oldfd) != -1);
-    REQUIRE(close(newfd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(dup3(oldfd, newfd, O_CLOEXEC), newfd);
+    EXPECT_NE((fcntl(oldfd, F_GETFD) & FD_CLOEXEC), FD_CLOEXEC);
+    EXPECT_EQ((fcntl(newfd, F_GETFD) & FD_CLOEXEC), FD_CLOEXEC);
+    EXPECT_NE(close(oldfd), -1);
+    EXPECT_NE(close(newfd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }

--- a/tests/syscall/src/file.cpp
+++ b/tests/syscall/src/file.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <cerrno>
 #include <filesystem>
@@ -7,92 +7,89 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-TEST_CASE("Test file creation, reopening, and close", "[syscall]") {
+TEST(SystemCallTest, TestFileCreateReopenClose) {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
     int fd                         = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     fd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test file creation using creat system call", "[syscall]") {
+TEST(SystemCallTest, TestCreat) {
     constexpr const char *PATHNAME = "test_file.txt";
     int fd                         = creat(PATHNAME, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test file creation, reopening, and close using openat with AT_FDCWD", "[syscall]") {
+TEST(SystemCallTest, TestFileCreateReopenCloseWithOpenatAtFdcwd) {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC;
     int fd                         = openat(AT_FDCWD, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
     fd = openat(AT_FDCWD, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test that open O_EXCL fails if file already exists", "[syscall]") {
+TEST(SystemCallTest, TestOpenFailsWithOExclIfFileAlreadyExists) {
     constexpr const char *PATHNAME = "test_file.txt";
     int flags                      = O_CREAT | O_WRONLY | O_TRUNC | O_EXCL;
     int fd                         = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     fd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd == -1);
-    REQUIRE(errno == EEXIST);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(fd, -1);
+    EXPECT_EQ(errno, EEXIST);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE(
-    "Test file creation, reopen and close in a different directory using openat with absolute path",
-    "[syscall]") {
+TEST(SystemCallTest, TestFileCreateReopenCloseInDifferentDirectoryWithOpenatAbsolutePath) {
     const auto path_fs =
         std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
     const char *PATHNAME = path_fs.c_str();
     int flags            = O_CREAT | O_WRONLY | O_TRUNC;
     int fd               = openat(0, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(faccessat(0, PATHNAME, F_OK, 0), 0);
     fd = openat(0, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlinkat(0, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlinkat(0, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(0, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test file creation, reopen and close in a different directory using openat with dirfd",
-          "[syscall]") {
+TEST(SystemCallTest, TestFileCreateReopenCloseInDifferentDirectoryWithOpenatDirfd) {
     constexpr const char *PATHNAME = "test_file.txt";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;
     int dirfd                      = open(DIRPATH, flags);
-    REQUIRE(dirfd != -1);
+    EXPECT_NE(dirfd, -1);
     flags  = O_CREAT | O_WRONLY | O_TRUNC;
     int fd = openat(dirfd, PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
     fd = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlinkat(dirfd, PATHNAME, 0) != -1);
-    REQUIRE(close(dirfd) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlinkat(dirfd, PATHNAME, 0), -1);
+    EXPECT_NE(close(dirfd), -1);
+    EXPECT_NE(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
 }

--- a/tests/syscall/src/main.cpp
+++ b/tests/syscall/src/main.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+char **build_args() {
+    char **args = (char **) malloc(3 * sizeof(uintptr_t));
+
+    char const *command = std::getenv("CAPIO_SERVER_PATH");
+    if (command == nullptr) {
+        command = "capio_server";
+    }
+
+    args[0] = strdup(command);
+    args[1] = strdup("--no-config");
+    args[2] = (char *) nullptr;
+
+    return args;
+}
+
+char **build_env(char **envp) {
+    std::vector<int> vars;
+    for (int i = 0; envp[i] != nullptr; i++) {
+        const std::string_view var(envp[i]);
+        const std::string_view key = var.substr(0, var.find('='));
+        if (key != "LD_PRELOAD") {
+            vars.emplace_back(i);
+        }
+    }
+
+    char **cleaned_env = (char **) malloc((vars.size() + 2) * sizeof(uintptr_t));
+    for (int i = 0; i < vars.size(); i++) {
+        cleaned_env[i] = strdup(envp[i]);
+    }
+    cleaned_env[vars.size()]     = strdup("LD_PRELOAD=");
+    cleaned_env[vars.size() + 1] = (char *) nullptr;
+
+    return cleaned_env;
+}
+
+class CapioServerEnvironment : public testing::Environment {
+  private:
+    char **args;
+    char **envp;
+    int server_pid;
+
+  public:
+    explicit CapioServerEnvironment(char **envp)
+        : args(build_args()), envp(build_env(envp)), server_pid(-1){};
+
+    ~CapioServerEnvironment() override {
+        for (int i = 0; args[i] != nullptr; i++) {
+            free(args[i]);
+        }
+        free(args);
+        for (int i = 0; envp[i] != nullptr; i++) {
+            free(envp[i]);
+        }
+        free(envp);
+    };
+
+    void SetUp() override {
+        if (server_pid < 0) {
+            ASSERT_NE(std::getenv("CAPIO_DIR"), nullptr);
+            ASSERT_GE(server_pid = fork(), 0);
+            if (server_pid == 0) {
+                execvpe(args[0], args, envp);
+                _exit(127);
+            } else {
+                sleep(5);
+            }
+        }
+    }
+
+    void TearDown() override {
+        if (server_pid > 0) {
+            kill(server_pid, SIGTERM);
+            waitpid(server_pid, nullptr, 0);
+            server_pid = -1;
+        }
+    }
+};
+
+int main(int argc, char **argv, char **envp) {
+    testing::InitGoogleTest(&argc, argv);
+    testing::AddGlobalTestEnvironment(new CapioServerEnvironment(envp));
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/syscall/src/rename.cpp
+++ b/tests/syscall/src/rename.cpp
@@ -1,64 +1,64 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-TEST_CASE("Test file rename when the new path does not exist", "[syscall]") {
+TEST(SystemCallTest, TestFileRenameWhenNewPathDoesNotExist) {
     constexpr const char *OLDNAME = "test_file.txt";
     constexpr const char *NEWNAME = "test_file2.txt";
     int flags                     = O_CREAT | O_WRONLY | O_TRUNC;
     int fd                        = open(OLDNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(access(OLDNAME, F_OK) == 0);
-    REQUIRE(access(NEWNAME, F_OK) != 0);
-    REQUIRE(rename(OLDNAME, NEWNAME) == 0);
-    REQUIRE(access(OLDNAME, F_OK) != 0);
-    REQUIRE(access(NEWNAME, F_OK) == 0);
-    REQUIRE(unlink(NEWNAME) != -1);
-    REQUIRE(access(NEWNAME, F_OK) != 0);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(access(OLDNAME, F_OK), 0);
+    EXPECT_NE(access(NEWNAME, F_OK), 0);
+    EXPECT_EQ(rename(OLDNAME, NEWNAME), 0);
+    EXPECT_NE(access(OLDNAME, F_OK), 0);
+    EXPECT_EQ(access(NEWNAME, F_OK), 0);
+    EXPECT_NE(unlink(NEWNAME), -1);
+    EXPECT_NE(access(NEWNAME, F_OK), 0);
 }
 
-TEST_CASE("Test file rename when the new path already exists", "[syscall]") {
+TEST(SystemCallTest, TestFileRenameWithNewPathAlreadyExists) {
     constexpr const char *OLDNAME = "test_file.txt";
     constexpr const char *NEWNAME = "test_file2.txt";
     int flags                     = O_CREAT | O_WRONLY | O_TRUNC;
     int fd                        = open(OLDNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(close(fd), -1);
     fd = open(NEWNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(access(OLDNAME, F_OK) == 0);
-    REQUIRE(access(NEWNAME, F_OK) == 0);
-    REQUIRE(rename(OLDNAME, NEWNAME) == 0);
-    REQUIRE(access(OLDNAME, F_OK) != 0);
-    REQUIRE(access(NEWNAME, F_OK) == 0);
-    REQUIRE(unlink(NEWNAME) != -1);
-    REQUIRE(access(NEWNAME, F_OK) != 0);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_EQ(access(OLDNAME, F_OK), 0);
+    EXPECT_EQ(access(NEWNAME, F_OK), 0);
+    EXPECT_EQ(rename(OLDNAME, NEWNAME), 0);
+    EXPECT_NE(access(OLDNAME, F_OK), 0);
+    EXPECT_EQ(access(NEWNAME, F_OK), 0);
+    EXPECT_NE(unlink(NEWNAME), -1);
+    EXPECT_NE(access(NEWNAME, F_OK), 0);
 }
 
-TEST_CASE("Test directory rename when the new path does not exist", "[syscall]") {
+TEST(SystemCallTest, TestDirectoryRenameWhenNewPathDoesNotExist) {
     constexpr const char *OLDNAME = "test";
     constexpr const char *NEWNAME = "test2";
-    REQUIRE(mkdir(OLDNAME, S_IRWXU) != -1);
-    REQUIRE(access(OLDNAME, F_OK) == 0);
-    REQUIRE(access(NEWNAME, F_OK) != 0);
-    REQUIRE(rename(OLDNAME, NEWNAME) == 0);
-    REQUIRE(access(OLDNAME, F_OK) != 0);
-    REQUIRE(access(NEWNAME, F_OK) == 0);
-    REQUIRE(rmdir(NEWNAME) != -1);
-    REQUIRE(access(NEWNAME, F_OK) != 0);
+    EXPECT_NE(mkdir(OLDNAME, S_IRWXU), -1);
+    EXPECT_EQ(access(OLDNAME, F_OK), 0);
+    EXPECT_NE(access(NEWNAME, F_OK), 0);
+    EXPECT_EQ(rename(OLDNAME, NEWNAME), 0);
+    EXPECT_NE(access(OLDNAME, F_OK), 0);
+    EXPECT_EQ(access(NEWNAME, F_OK), 0);
+    EXPECT_NE(rmdir(NEWNAME), -1);
+    EXPECT_NE(access(NEWNAME, F_OK), 0);
 }
 
-TEST_CASE("Test directory rename when the new path already exists", "[syscall]") {
+TEST(SystemCallTest, TestDirectoryRenameWhenNewPathAlreadyExists) {
     constexpr const char *OLDNAME = "test";
     constexpr const char *NEWNAME = "test2";
-    REQUIRE(mkdir(OLDNAME, S_IRWXU) != -1);
-    REQUIRE(mkdir(NEWNAME, S_IRWXU) != -1);
-    REQUIRE(access(OLDNAME, F_OK) == 0);
-    REQUIRE(access(NEWNAME, F_OK) == 0);
-    REQUIRE(rename(OLDNAME, NEWNAME) == 0);
-    REQUIRE(access(OLDNAME, F_OK) != 0);
-    REQUIRE(access(NEWNAME, F_OK) == 0);
-    REQUIRE(rmdir(NEWNAME) != -1);
-    REQUIRE(access(NEWNAME, F_OK) != 0);
+    EXPECT_NE(mkdir(OLDNAME, S_IRWXU), -1);
+    EXPECT_NE(mkdir(NEWNAME, S_IRWXU), -1);
+    EXPECT_EQ(access(OLDNAME, F_OK), 0);
+    EXPECT_EQ(access(NEWNAME, F_OK), 0);
+    EXPECT_EQ(rename(OLDNAME, NEWNAME), 0);
+    EXPECT_NE(access(OLDNAME, F_OK), 0);
+    EXPECT_EQ(access(NEWNAME, F_OK), 0);
+    EXPECT_NE(rmdir(NEWNAME), -1);
+    EXPECT_NE(access(NEWNAME, F_OK), 0);
 }

--- a/tests/syscall/src/stat.cpp
+++ b/tests/syscall/src/stat.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <filesystem>
 #include <thread>
@@ -8,230 +8,228 @@
 #include <unistd.h>
 
 void check_statbuf(struct stat &buf, unsigned long st_size) {
-    REQUIRE(buf.st_blocks == 8);
-    REQUIRE(buf.st_gid == getgid());
-    REQUIRE(buf.st_size == static_cast<off_t>(st_size));
-    REQUIRE(buf.st_uid == getuid());
+    EXPECT_EQ(buf.st_blocks, 8);
+    EXPECT_EQ(buf.st_gid, getgid());
+    EXPECT_EQ(buf.st_size, static_cast<off_t>(st_size));
+    EXPECT_EQ(buf.st_uid, getuid());
 }
 
-TEST_CASE("Test stat syscall on file", "[syscall]") {
+TEST(SystemCallTest, TestStatOnFile) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = open(PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     struct stat statbuf {};
-    REQUIRE(stat(PATHNAME, &statbuf) == 0);
+    EXPECT_EQ(stat(PATHNAME, &statbuf), 0);
     check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test stat syscall on folder", "[syscall]") {
+TEST(SystemCallTest, TestStatOnDirectory) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(mkdir(PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     struct stat statbuf {};
-    REQUIRE(stat(PATHNAME, &statbuf) == 0);
+    EXPECT_EQ(stat(PATHNAME, &statbuf), 0);
     check_statbuf(statbuf, 4096);
-    REQUIRE(rmdir(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(rmdir(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test stat syscall on nonexistent file", "[syscall]") {
+TEST(SystemCallTest, TestStatOnNonexistentFile) {
     struct stat statbuf {};
-    REQUIRE(stat("test", &statbuf) == -1);
-    REQUIRE(errno == ENOENT);
+    EXPECT_EQ(stat("test", &statbuf), -1);
+    EXPECT_EQ(errno, ENOENT);
 }
 
-TEST_CASE("Test fstat syscall on file", "[syscall]") {
+TEST(SystemCallTest, TestFstatOnFile) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = open(PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     struct stat statbuf {};
-    REQUIRE(fstat(fd, &statbuf) == 0);
+    EXPECT_EQ(fstat(fd, &statbuf), 0);
     check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test fstat syscall on folder", "[syscall]") {
+TEST(SystemCallTest, TestFstatOnDirectory) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
+    EXPECT_NE(mkdir(PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
     int flags = O_RDONLY | O_DIRECTORY;
     int fd    = open(PATHNAME, flags, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
+    EXPECT_NE(fd, -1);
     struct stat statbuf {};
-    REQUIRE(fstat(fd, &statbuf) == 0);
+    EXPECT_EQ(fstat(fd, &statbuf), 0);
     check_statbuf(statbuf, 4096);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(rmdir(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(rmdir(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test fstat syscall on invalid fd", "[syscall]") {
+TEST(SystemCallTest, TestFstatOnInvalidFd) {
     struct stat statbuf {};
-    REQUIRE(fstat(-1, &statbuf) == -1);
-    REQUIRE(errno == EBADF);
+    EXPECT_EQ(fstat(-1, &statbuf), -1);
+    EXPECT_EQ(errno, EBADF);
 }
 
-TEST_CASE("Test fstatat syscall on file with AT_FDCWD", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnFileWithAtFdcwd) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = openat(AT_FDCWD, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     struct stat statbuf {};
-    REQUIRE(fstatat(AT_FDCWD, PATHNAME, &statbuf, 0) == 0);
+    EXPECT_EQ(fstatat(AT_FDCWD, PATHNAME, &statbuf, 0), 0);
     check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test fstatat syscall on folder with AT_FDCWD", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnDirectoryWithAtFdcwd) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
     struct stat statbuf {};
-    REQUIRE(fstatat(AT_FDCWD, PATHNAME, &statbuf, 0) == 0);
+    EXPECT_EQ(fstatat(AT_FDCWD, PATHNAME, &statbuf, 0), 0);
     check_statbuf(statbuf, 4096);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test fstatat syscall on file in a different directory using absolute path",
-          "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnFileInDifferentDirectoryWithAbsolutePath) {
     const auto path_fs =
         std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
     const char *PATHNAME = path_fs.c_str();
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = openat(0, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(faccessat(0, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     struct stat statbuf {};
-    REQUIRE(fstatat(0, PATHNAME, &statbuf, 0) == 0);
+    EXPECT_EQ(fstatat(0, PATHNAME, &statbuf, 0), 0);
     check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(unlinkat(0, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(0, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(0, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test fstatat syscall on folder in a different directory using absolute path",
-          "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnDirectoryInDifferentDirectoryWithAbsolutePath) {
     const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
     const char *PATHNAME = path_fs.c_str();
-    REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(0, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(0, PATHNAME, F_OK, 0), 0);
     struct stat statbuf {};
-    REQUIRE(fstatat(0, PATHNAME, &statbuf, 0) == 0);
+    EXPECT_EQ(fstatat(0, PATHNAME, &statbuf, 0), 0);
     check_statbuf(statbuf, 4096);
-    REQUIRE(unlinkat(0, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(0, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(0, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test fstatat syscall on file in a different directory using dirfd", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnFileInDifferentDirectoryWithDirfd) {
     constexpr const char *PATHNAME = "test_file.txt";
     const char *DIRPATH            = std::getenv("PWD");
     int dirfd                      = open(DIRPATH, O_RDONLY | O_DIRECTORY);
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = openat(dirfd, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     struct stat statbuf {};
-    REQUIRE(fstatat(dirfd, PATHNAME, &statbuf, 0) == 0);
+    EXPECT_EQ(fstatat(dirfd, PATHNAME, &statbuf, 0), 0);
     check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(unlinkat(dirfd, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(dirfd, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test fstatat syscall on folder in a different directory using dirfd", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnDirectoryInDifferentDirectoryWithDirfd) {
     constexpr const char *PATHNAME = "test";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;
     int dirfd                      = open(DIRPATH, flags);
-    REQUIRE(dirfd != -1);
-    REQUIRE(mkdirat(dirfd, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(dirfd, -1);
+    EXPECT_NE(mkdirat(dirfd, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
     struct stat statbuf {};
-    REQUIRE(fstatat(dirfd, PATHNAME, &statbuf, 0) == 0);
+    EXPECT_EQ(fstatat(dirfd, PATHNAME, &statbuf, 0), 0);
     check_statbuf(statbuf, 4096);
-    REQUIRE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
-    REQUIRE(close(dirfd) != -1);
+    EXPECT_NE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
+    EXPECT_NE(close(dirfd), -1);
 }
 
-TEST_CASE("Test fstatat syscall using AT_EMPTY_PATH and AT_FDCWD", "[syscall]") {
+TEST(SystemCallTest, TwstFstatatWithAtEmptyPathAndAtFdcwd) {
     struct stat statbuf {};
-    REQUIRE(fstatat(AT_FDCWD, "", &statbuf, AT_EMPTY_PATH) == 0);
+    EXPECT_EQ(fstatat(AT_FDCWD, "", &statbuf, AT_EMPTY_PATH), 0);
     check_statbuf(statbuf, 4096);
 }
 
-TEST_CASE("Test fstatat syscall on file using AT_EMPTY_PATH and dirfd", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnFileWithAtEmptyPathAndDirfd) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int dirfd = openat(AT_FDCWD, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(dirfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(dirfd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     struct stat statbuf {};
-    REQUIRE(fstatat(dirfd, "", &statbuf, AT_EMPTY_PATH) == 0);
+    EXPECT_EQ(fstatat(dirfd, "", &statbuf, AT_EMPTY_PATH), 0);
     check_statbuf(statbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(close(dirfd) != -1);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(close(dirfd), -1);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test fstatat syscall on folder using AT_EMPTY_PATH and dirfd", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnDirectoryWIthAtEmptyPathAndDirfd) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
     int dirfd = openat(AT_FDCWD, PATHNAME, O_RDONLY | O_DIRECTORY);
-    REQUIRE(dirfd != -1);
+    EXPECT_NE(dirfd, -1);
     struct stat statbuf {};
-    REQUIRE(fstatat(dirfd, "", &statbuf, AT_EMPTY_PATH) == 0);
+    EXPECT_EQ(fstatat(dirfd, "", &statbuf, AT_EMPTY_PATH), 0);
     check_statbuf(statbuf, 4096);
-    REQUIRE(close(dirfd) != -1);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(close(dirfd), -1);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test fstatat syscall on nonexistent file", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnNonexistentFile) {
     struct stat statbuf {};
-    REQUIRE(fstatat(AT_FDCWD, "test", &statbuf, 0) == -1);
-    REQUIRE(errno == ENOENT);
+    EXPECT_EQ(fstatat(AT_FDCWD, "test", &statbuf, 0), -1);
+    EXPECT_EQ(errno, ENOENT);
 }
 
-TEST_CASE("Test fstatat syscall on relative path with invalid dirfd", "[syscall]") {
+TEST(SystemCallTest, TestFstatatOnRelativePathWithInvalidDirfd) {
     constexpr const char *PATHNAME = "test";
     struct stat statbuf {};
-    REQUIRE(fstatat(-1, PATHNAME, &statbuf, 0) == -1);
-    REQUIRE(errno == EBADF);
+    EXPECT_EQ(fstatat(-1, PATHNAME, &statbuf, 0), -1);
+    EXPECT_EQ(errno, EBADF);
 }
 
-TEST_CASE("Test fstatat syscall with empty path and no AT_EMPTY_PATH flag", "[syscall]") {
+TEST(SystemCallTest, TestFstatatWithEmptyPathAndNoAtEmptyPath) {
     struct stat statbuf {};
-    REQUIRE(fstatat(AT_FDCWD, "", &statbuf, 0) == -1);
-    REQUIRE(errno == ENOENT);
+    EXPECT_EQ(fstatat(AT_FDCWD, "", &statbuf, 0), -1);
+    EXPECT_EQ(errno, ENOENT);
 }
 
-TEST_CASE("Test file creation, write and close using stat", "[syscall]") {
+TEST(SystemCallTest, TestFileCreateWriteCloseWithStat) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr int ARRAY_SIZE       = 100;
     int array[ARRAY_SIZE];
@@ -239,32 +237,32 @@ TEST_CASE("Test file creation, write and close using stat", "[syscall]") {
         array[i] = i;
     }
     FILE *fp = fopen(PATHNAME, "w+");
-    REQUIRE(fp != nullptr);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(fwrite(array, sizeof(int), ARRAY_SIZE, fp) == ARRAY_SIZE);
-    REQUIRE(fseek(fp, 0, SEEK_SET) != -1);
+    EXPECT_NE(fp, nullptr);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(fwrite(array, sizeof(int), ARRAY_SIZE, fp), ARRAY_SIZE);
+    EXPECT_NE(fseek(fp, 0, SEEK_SET), -1);
     int num;
     for (int i = 0; i < ARRAY_SIZE; i++) {
-        REQUIRE(fread(&num, sizeof(int), 1, fp) == 1);
-        REQUIRE(num == i);
+        EXPECT_EQ(fread(&num, sizeof(int), 1, fp), 1);
+        EXPECT_EQ(num, i);
     }
-    REQUIRE(fread(&num, sizeof(int), 1, fp) == 0);
-    REQUIRE(feof(fp) != 0);
-    REQUIRE(fclose(fp) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(fread(&num, sizeof(int), 1, fp), 0);
+    EXPECT_NE(feof(fp), 0);
+    EXPECT_NE(fclose(fp), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test directory creation, reopening and close with stat", "[syscall]") {
+TEST(SystemCallTest, TestDirectoryCreateReopenCloseWithStat) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdir(PATHNAME, S_IRWXU) != -1);
+    EXPECT_NE(mkdir(PATHNAME, S_IRWXU), -1);
     FILE *fp = fopen(PATHNAME, "r");
-    REQUIRE(fp != nullptr);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(fclose(fp) != -1);
+    EXPECT_NE(fp, nullptr);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_NE(fclose(fp), -1);
     fp = fopen(PATHNAME, "r");
-    REQUIRE(fp != nullptr);
-    REQUIRE(fclose(fp) != -1);
-    REQUIRE(rmdir(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(fp, nullptr);
+    EXPECT_NE(fclose(fp), -1);
+    EXPECT_NE(rmdir(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }

--- a/tests/syscall/src/statx.cpp
+++ b/tests/syscall/src/statx.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <filesystem>
 
@@ -7,161 +7,160 @@
 #include <unistd.h>
 
 void check_statxbuf(struct statx &buf, unsigned long st_size) {
-    REQUIRE(buf.stx_blocks == 8);
-    REQUIRE(buf.stx_gid == getgid());
-    REQUIRE(buf.stx_size == st_size);
-    REQUIRE(buf.stx_uid == getuid());
+    EXPECT_EQ(buf.stx_blocks, 8);
+    EXPECT_EQ(buf.stx_gid, getgid());
+    EXPECT_EQ(buf.stx_size, st_size);
+    EXPECT_EQ(buf.stx_uid, getuid());
 }
 
-TEST_CASE("Test statx syscall on file with AT_FDCWD", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnFileWithAtFdcwd) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = openat(AT_FDCWD, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test statx syscall on folder with AT_FDCWD", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnDirectoryWithAtFdcwd) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, 4096);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test statx syscall on file in a different directory using absolute path", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnFileInDifferentDirectoryWithAbsolutePath) {
     const auto path_fs =
         std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test_file.txt");
     const char *PATHNAME = path_fs.c_str();
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = openat(0, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(faccessat(0, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(unlinkat(0, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(0, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(0, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test statx syscall on folder in a different directory using absolute path",
-          "[syscall]") {
+TEST(SystemCallTest, TestStatxOnDirectoryInDifferentDirectoryWithAbsoluePath) {
     const auto path_fs = std::filesystem::path(std::getenv("PWD")) / std::filesystem::path("test");
     const char *PATHNAME = path_fs.c_str();
-    REQUIRE(mkdirat(0, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(0, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(0, PATHNAME, F_OK, 0), 0);
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(AT_FDCWD, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, 4096);
-    REQUIRE(unlinkat(0, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(0, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(0, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(0, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test statx syscall on file in a different directory using dirfd", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnFileInDifferentDirectoryWithDirfd) {
     constexpr const char *PATHNAME = "test_file.txt";
     const char *DIRPATH            = std::getenv("PWD");
     int dirfd                      = open(DIRPATH, O_RDONLY | O_DIRECTORY);
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = openat(dirfd, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     struct statx statxbuf {};
-    REQUIRE(statx(dirfd, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(dirfd, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(unlinkat(dirfd, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(unlinkat(dirfd, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test statx syscall on folder in a different directory using dirfd", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnDirectoryInDifferentDirectoryWithDirfd) {
     constexpr const char *PATHNAME = "test";
     const char *DIRPATH            = std::getenv("PWD");
     int flags                      = O_RDONLY | O_DIRECTORY;
     int dirfd                      = open(DIRPATH, flags);
-    REQUIRE(dirfd != -1);
-    REQUIRE(mkdirat(dirfd, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(dirfd, -1);
+    EXPECT_NE(mkdirat(dirfd, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
     struct statx statxbuf {};
-    REQUIRE(statx(dirfd, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(dirfd, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, 4096);
-    REQUIRE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(dirfd, PATHNAME, F_OK, 0) != 0);
-    REQUIRE(close(dirfd) != -1);
+    EXPECT_NE(unlinkat(dirfd, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(dirfd, PATHNAME, F_OK, 0), 0);
+    EXPECT_NE(close(dirfd), -1);
 }
 
-TEST_CASE("Test statx syscall using AT_EMPTY_PATH and AT_FDCWD", "[syscall]") {
+TEST(SystemCallTest, TestStatxWithAtEmptyPathAndAtFdcwd) {
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(AT_FDCWD, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, 4096);
 }
 
-TEST_CASE("Test statx syscall on file using AT_EMPTY_PATH and dirfd", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnFileWithAtEmptyPathAndDirfd) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int dirfd = openat(AT_FDCWD, PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
-    REQUIRE(write(dirfd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
+    EXPECT_EQ(write(dirfd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
     struct statx statxbuf {};
-    REQUIRE(statx(dirfd, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(dirfd, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, strlen(BUFFER) * sizeof(char));
-    REQUIRE(close(dirfd) != -1);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, 0) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(close(dirfd), -1);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, 0), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test statx syscall on folder using AT_EMPTY_PATH and dirfd", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnDirectoryWithAtEmptyPathAndDirfd) {
     constexpr const char *PATHNAME = "test";
-    REQUIRE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) == 0);
+    EXPECT_NE(mkdirat(AT_FDCWD, PATHNAME, S_IRWXU), -1);
+    EXPECT_EQ(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
     int dirfd = openat(AT_FDCWD, PATHNAME, O_RDONLY | O_DIRECTORY);
-    REQUIRE(dirfd != -1);
+    EXPECT_NE(dirfd, -1);
     struct statx statxbuf {};
-    REQUIRE(statx(dirfd, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == 0);
+    EXPECT_EQ(statx(dirfd, "", AT_EMPTY_PATH, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), 0);
     check_statxbuf(statxbuf, 4096);
-    REQUIRE(close(dirfd) != -1);
-    REQUIRE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR) != -1);
-    REQUIRE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0) != 0);
+    EXPECT_NE(close(dirfd), -1);
+    EXPECT_NE(unlinkat(AT_FDCWD, PATHNAME, AT_REMOVEDIR), -1);
+    EXPECT_NE(faccessat(AT_FDCWD, PATHNAME, F_OK, 0), 0);
 }
 
-TEST_CASE("Test statx syscall on nonexistent file", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnNonexistentFile) {
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, "test", 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == -1);
-    REQUIRE(errno == ENOENT);
+    EXPECT_EQ(statx(AT_FDCWD, "test", 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), -1);
+    EXPECT_EQ(errno, ENOENT);
 }
 
-TEST_CASE("Test statx syscall on relative path with invalid dirfd", "[syscall]") {
+TEST(SystemCallTest, TestStatxOnRelativePathWithInvalidDirfd) {
     constexpr const char *PATHNAME = "test";
     struct statx statxbuf {};
-    REQUIRE(statx(-1, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == -1);
-    REQUIRE(errno == EBADF);
+    EXPECT_EQ(statx(-1, PATHNAME, 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), -1);
+    EXPECT_EQ(errno, EBADF);
 }
 
-TEST_CASE("Test statx syscall with STATX__RESERVED set", "[syscall]") {
+TEST(SystemCallTest, TestStatxWithStatxReservedSet) {
     constexpr const char *PATHNAME = "test";
     struct statx statxbuf {};
-    REQUIRE(statx(-1, PATHNAME, 0, STATX__RESERVED, &statxbuf) == -1);
-    REQUIRE(errno == EINVAL);
+    EXPECT_EQ(statx(-1, PATHNAME, 0, STATX__RESERVED, &statxbuf), -1);
+    EXPECT_EQ(errno, EINVAL);
 }
 
-TEST_CASE("Test statx syscall with empty path and no AT_EMPTY_PATH flag", "[syscall]") {
+TEST(SystemCallTest, TestStatxWithEmptyPathAndNoEmptyPath) {
     struct statx statxbuf {};
-    REQUIRE(statx(AT_FDCWD, "", 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf) == -1);
-    REQUIRE(errno == ENOENT);
+    EXPECT_EQ(statx(AT_FDCWD, "", 0, STATX_BASIC_STATS | STATX_BTIME, &statxbuf), -1);
+    EXPECT_EQ(errno, ENOENT);
 }

--- a/tests/syscall/src/write.cpp
+++ b/tests/syscall/src/write.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 
 #include <array>
 #include <memory>
@@ -8,55 +8,57 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
-TEST_CASE("Test file creation, write and close", "[syscall]") {
+TEST(SystemCallTest, TestFileCreateWriteClose) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
     int fd = open(PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(fd, BUFFER, strlen(BUFFER)) == strlen(BUFFER));
-    REQUIRE(close(fd) != -1);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_NE(close(fd), -1);
     fd = open(PATHNAME, O_RDONLY, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
+    EXPECT_NE(fd, -1);
     std::unique_ptr<char[]> buf(new char[strlen(BUFFER)]);
-    REQUIRE(read(fd, buf.get(), strlen(BUFFER)) == strlen(BUFFER));
+    EXPECT_EQ(read(fd, buf.get(), strlen(BUFFER)), strlen(BUFFER));
     buf[strlen(BUFFER)] = '\0';
-    REQUIRE(std::string_view(BUFFER) == std::string_view(buf.get()));
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(std::string_view(BUFFER), std::string_view(buf.get()));
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test file creation, write with lseek and close") {
+TEST(SystemCallTest, TestFileCreateWriteLseekClose) {
     constexpr const char *PATHNAME       = "test_file.txt";
     constexpr std::array<int, 12> BUFFER = {1, 2, 3, 4, 5, 6, 7, 8, 9};
     int fd = open(PATHNAME, O_CREAT | O_RDWR | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(write(fd, BUFFER.data(), 3 * sizeof(int)) == 3 * sizeof(int));
-    REQUIRE(lseek(fd, 3 * sizeof(int), SEEK_CUR) == 2 * 3 * sizeof(int));
-    REQUIRE(write(fd, BUFFER.data() + 6, 3 * sizeof(int)) == 3 * sizeof(int));
-    REQUIRE(lseek(fd, 3 * sizeof(int), SEEK_SET) == 3 * sizeof(int));
-    REQUIRE(write(fd, BUFFER.data() + 3, 3 * sizeof(int)) == 3 * sizeof(int));
-    REQUIRE(lseek(fd, 0, SEEK_SET) == 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(write(fd, BUFFER.data(), 3 * sizeof(int)), 3 * sizeof(int));
+    EXPECT_EQ(lseek(fd, 3 * sizeof(int), SEEK_CUR), 2 * 3 * sizeof(int));
+    EXPECT_EQ(write(fd, BUFFER.data() + 6, 3 * sizeof(int)), 3 * sizeof(int));
+    EXPECT_EQ(lseek(fd, 3 * sizeof(int), SEEK_SET), 3 * sizeof(int));
+    EXPECT_EQ(write(fd, BUFFER.data() + 3, 3 * sizeof(int)), 3 * sizeof(int));
+    EXPECT_EQ(lseek(fd, 0, SEEK_SET), 0);
     std::array<int, 12> buf{};
-    REQUIRE(read(fd, buf.data(), 3 * sizeof(int)) == 3 * sizeof(int));
-    REQUIRE(lseek(fd, 3 * sizeof(int), SEEK_CUR) == 2 * 3 * sizeof(int));
-    REQUIRE(read(fd, buf.data() + 6, 3 * sizeof(int)) == 3 * sizeof(int));
-    REQUIRE(lseek(fd, 3 * sizeof(int), SEEK_SET) == 3 * sizeof(int));
-    REQUIRE(read(fd, buf.data() + 3, 3 * sizeof(int)) == 3 * sizeof(int));
-    REQUIRE(BUFFER == buf);
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_EQ(read(fd, buf.data(), 3 * sizeof(int)), 3 * sizeof(int));
+    EXPECT_EQ(lseek(fd, 3 * sizeof(int), SEEK_CUR), 2 * 3 * sizeof(int));
+    EXPECT_EQ(read(fd, buf.data() + 6, 3 * sizeof(int)), 3 * sizeof(int));
+    EXPECT_EQ(lseek(fd, 3 * sizeof(int), SEEK_SET), 3 * sizeof(int));
+    EXPECT_EQ(read(fd, buf.data() + 3, 3 * sizeof(int)), 3 * sizeof(int));
+    EXPECT_EQ(BUFFER, buf);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }
 
-TEST_CASE("Test file creation, buffered write and close", "[syscall]") {
+TEST(SystemCallTest, TestFileCreateBufferedWriteClose) {
     constexpr const char *PATHNAME              = "test_file.txt";
     constexpr const std::array<int, 10> BUFFER1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     constexpr const std::array<int, 8> BUFFER2  = {10, 11, 12, 13, 14, 15, 16, 17};
     constexpr const std::array<int, 2> BUFFER3  = {18, 19};
+    constexpr const int TOTAL_SIZE =
+        BUFFER1.size() * sizeof(int) + BUFFER2.size() * sizeof(int) + BUFFER3.size() * sizeof(int);
 
     struct iovec iov_write[3];
     iov_write[0].iov_base = const_cast<int *>(BUFFER1.data());
@@ -67,10 +69,10 @@ TEST_CASE("Test file creation, buffered write and close", "[syscall]") {
     iov_write[2].iov_len  = BUFFER3.size() * sizeof(int);
 
     int fd = open(PATHNAME, O_CREAT | O_RDWR | O_TRUNC, S_IRUSR | S_IWUSR);
-    REQUIRE(fd != -1);
-    REQUIRE(access(PATHNAME, F_OK) == 0);
-    REQUIRE(writev(fd, iov_write, 3));
-    REQUIRE(lseek(fd, 0, SEEK_SET) == 0);
+    EXPECT_NE(fd, -1);
+    EXPECT_EQ(access(PATHNAME, F_OK), 0);
+    EXPECT_EQ(writev(fd, iov_write, 3), TOTAL_SIZE);
+    EXPECT_EQ(lseek(fd, 0, SEEK_SET), 0);
 
     std::array<int, 10> buf1{};
     std::array<int, 8> buf2{};
@@ -84,12 +86,12 @@ TEST_CASE("Test file creation, buffered write and close", "[syscall]") {
     iov_read[2].iov_base = const_cast<int *>(buf3.data());
     iov_read[2].iov_len  = buf3.size() * sizeof(int);
 
-    REQUIRE(readv(fd, iov_read, 3));
-    REQUIRE(BUFFER1 == buf1);
-    REQUIRE(BUFFER2 == buf2);
-    REQUIRE(BUFFER3 == buf3);
+    EXPECT_EQ(readv(fd, iov_read, 3), TOTAL_SIZE);
+    EXPECT_EQ(BUFFER1, buf1);
+    EXPECT_EQ(BUFFER2, buf2);
+    EXPECT_EQ(BUFFER3, buf3);
 
-    REQUIRE(close(fd) != -1);
-    REQUIRE(unlink(PATHNAME) != -1);
-    REQUIRE(access(PATHNAME, F_OK) != 0);
+    EXPECT_NE(close(fd), -1);
+    EXPECT_NE(unlink(PATHNAME), -1);
+    EXPECT_NE(access(PATHNAME, F_OK), 0);
 }


### PR DESCRIPTION
The `Catch2` test suite does not support `fork` system calls very well. This is a strong limitation when thinking about MPI automated tests. This commit migrates the whole test suite from `Catch2` to `GoogleTests`. The main improvements are:

- Now the `capio_server` executable is started directly from the test suite, further automating the CI/CD logic
- The `Ctest` executable has been dropped in favour of a direct `gtest` execution, reducing overhead and allowing to invoke al ltests in a single CAPIO POSIX process