### PR TITLE
Fix `getcwd` return value

### DIFF
--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -1,5 +1,6 @@
 #ifndef CAPIO_POSIX_HANDLERS_GETCWD_HPP
 #define CAPIO_POSIX_HANDLERS_GETCWD_HPP
+
 int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     auto buf  = reinterpret_cast<char *>(arg0);
     auto size = static_cast<size_t>(arg1);
@@ -25,6 +26,7 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
         LOG("CWD: %s", cwd.c_str());
         cwd.native().copy(buf, size);
         buf[length] = '\0';
+        *result     = static_cast<int>(length) + 1;
     }
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }

--- a/tests/syscall/src/directory.cpp
+++ b/tests/syscall/src/directory.cpp
@@ -91,8 +91,9 @@ TEST_CASE("Test directory creation, reopening, and close in a different director
 TEST_CASE("Test obtaining the current directory with getcwd system call", "[syscall]") {
     auto expected_path = std::string(std::getenv("PWD"));
     char obtained_path[PATH_MAX];
-    getcwd(obtained_path, PATH_MAX);
+    char *result = getcwd(obtained_path, PATH_MAX);
     REQUIRE(expected_path == std::string(obtained_path));
+    REQUIRE(result != nullptr);
 }
 
 TEST_CASE("Test getcwd system call when path is longer than size", "[syscall]") {


### PR DESCRIPTION
The `sys_getcwd` system call should return the length of the path stored in the `buf` argument. Prior to this commit, the CAPIO `getcwd_handler` was not returning any explicit result in case of success, leaving the `result` variable point to an unitialized memory region. This behaviour was the cause of several issues. This commit fixes the `getcwd_handler`, implementing the standard POSIX behaviour.