### PR TITLE
Fixing missing open handler

### DIFF
--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -96,4 +96,12 @@ int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return posix_return_value(capio_openat(dirfd, pathname, flags, tid), result);
 }
 
+int open_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+    const std::string_view pathname(reinterpret_cast<const char *>(arg0));
+    int flags = static_cast<int>(arg1);
+    long tid  = syscall_no_intercept(SYS_gettid);
+
+    return posix_return_value(capio_openat(AT_FDCWD, pathname, flags, tid), result);
+}
+
 #endif // CAPIO_POSIX_HANDLERS_OPENAT_HPP

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -136,6 +136,9 @@ static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
 #ifdef SYS_newfstatat
     _syscallTable[SYS_newfstatat] = fstatat_handler;
 #endif
+#ifdef SYS_open
+    _syscallTable[SYS_open] = open_handler;
+#endif
 #ifdef SYS_openat
     _syscallTable[SYS_openat] = openat_handler;
 #endif


### PR DESCRIPTION
This commit add the explicit `open_handler` for older kernel versions that are not implementing `open` with `sys_openat`