### PR TITLE
Clear CAPIO path cache after `unlink`

### DIFF
--- a/src/posix/handlers/unlink.hpp
+++ b/src/posix/handlers/unlink.hpp
@@ -13,6 +13,9 @@ off64_t capio_unlink_abs(const std::filesystem::path &abs_path, long tid, bool i
             off64_t res = is_dir ? rmdir_request(abs_path, tid) : unlink_request(abs_path, tid);
             if (res == -1) {
                 errno = ENOENT;
+            } else {
+                LOG("Removing %s from capio_files_path", abs_path.c_str());
+                delete_capio_path(abs_path);
             }
             return res;
         }

--- a/src/posix/utils/filesystem.hpp
+++ b/src/posix/utils/filesystem.hpp
@@ -134,8 +134,9 @@ inline void delete_capio_fd(int fd) {
  * @return
  */
 inline void delete_capio_path(const std::string &path) {
-    for (auto fd : capio_files_paths->at(path)) {
-        delete_capio_fd(fd);
+    auto it = capio_files_paths->at(path).begin();
+    while (it != capio_files_paths->at(path).end()) {
+        delete_capio_fd(*it++);
     }
     capio_files_paths->erase(path);
 }


### PR DESCRIPTION
The `delete_capio_path` method removes a path from the local CAPIO POSIX cache. However, before this commit, it was invoked just after `rmdir`, leaving leftovers whenever an `unlink` system call was invoked. This commit fixes this behaviour.

In addition, this commit changes the internal logic of the `delete_capio_path` method to avoid segmentation faults when a `fd` object is removed from the set during the loop iterations.