### PR TITLE
Improve CAPIO POSIX compatibility

### DIFF
--- a/src/posix/handlers/access.hpp
+++ b/src/posix/handlers/access.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_ACCESS_HPP
 #define CAPIO_POSIX_HANDLERS_ACCESS_HPP
 
+#if defined(SYS_access) || defined(SYS_faccessat) || defined(SYS_faccessat2)
+
 #include "utils/common.hpp"
 #include "utils/filesystem.hpp"
 
@@ -62,4 +64,5 @@ int faccessat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
     return posix_return_value(capio_faccessat(dirfd, pathname, mode, flags, tid), result);
 }
 
+#endif // SYS_access || SYS_faccessat || SYS_faccessat2
 #endif // CAPIO_POSIX_HANDLERS_ACCESS_HPP

--- a/src/posix/handlers/chdir.hpp
+++ b/src/posix/handlers/chdir.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_CHDIR_HPP
 #define CAPIO_POSIX_HANDLERS_CHDIR_HPP
 
+#if defined(SYS_chdir)
+
 #include "utils/filesystem.hpp"
 
 /*
@@ -39,4 +41,5 @@ int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_chdir
 #endif // CAPIO_POSIX_HANDLERS_CHDIR_HPP

--- a/src/posix/handlers/close.hpp
+++ b/src/posix/handlers/close.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_CLOSE_HPP
 #define CAPIO_POSIX_HANDLERS_CLOSE_HPP
 
+#if defined(SYS_close)
+
 #include "utils/requests.hpp"
 
 int close_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -16,4 +18,5 @@ int close_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_close
 #endif // CAPIO_POSIX_HANDLERS_CLOSE_HPP

--- a/src/posix/handlers/dup.hpp
+++ b/src/posix/handlers/dup.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_DUP_HPP
 #define CAPIO_POSIX_HANDLERS_DUP_HPP
 
+#if defined(SYS_dup) || defined(SYS_dup2) || defined(SYS_dup3)
+
 #include "capio/syscall.hpp"
 #include "utils/requests.hpp"
 
@@ -81,4 +83,5 @@ int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_dup || SYS_dup2 || SYS_dup3
 #endif // CAPIO_POSIX_HANDLERS_DUP_HPP

--- a/src/posix/handlers/execve.hpp
+++ b/src/posix/handlers/execve.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_EXECVE_HPP
 #define CAPIO_POSIX_HANDLERS_EXECVE_HPP
 
+#if defined(SYS_execve)
+
 #include "utils/snapshot.hpp"
 
 int execve_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -12,4 +14,5 @@ int execve_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_execve
 #endif // CAPIO_POSIX_HANDLERS_EXECVE_HPP

--- a/src/posix/handlers/exit_group.hpp
+++ b/src/posix/handlers/exit_group.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_EXIT_GROUP_HPP
 #define CAPIO_POSIX_HANDLERS_EXIT_GROUP_HPP
 
+#if defined(SYS_exit) || defined(SYS_exit_group)
+
 #include "capio/logger.hpp"
 
 #include "utils/requests.hpp"
@@ -25,4 +27,5 @@ int exit_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_exit || SYS_exit_group
 #endif // CAPIO_POSIX_HANDLERS_EXIT_GROUP_HPP

--- a/src/posix/handlers/fchmod.hpp
+++ b/src/posix/handlers/fchmod.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 #define CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 
+#if defined(SYS_chmod)
+
 int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int fd = static_cast<int>(arg0);
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
@@ -13,4 +15,5 @@ int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
+#endif // SYS_chmod
 #endif // CAPIO_POSIX_HANDLERS_FCHMOD_HPP

--- a/src/posix/handlers/fchown.hpp
+++ b/src/posix/handlers/fchown.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCHOWN_HPP
 #define CAPIO_POSIX_HANDLERS_FCHOWN_HPP
 
+#if defined(SYS_chown)
+
 int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int fd = static_cast<int>(arg0);
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
@@ -13,4 +15,5 @@ int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
+#endif // SYS_chown
 #endif // CAPIO_POSIX_HANDLERS_FCHOWN_HPP

--- a/src/posix/handlers/fcntl.hpp
+++ b/src/posix/handlers/fcntl.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCNTL_HPP
 #define CAPIO_POSIX_HANDLERS_FCNTL_HPP
 
+#if defined(SYS_fcntl)
+
 #include "utils/requests.hpp"
 
 int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -60,4 +62,5 @@ int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_fcntl
 #endif // CAPIO_POSIX_HANDLERS_FCNTL_HPP

--- a/src/posix/handlers/fgetxattr.hpp
+++ b/src/posix/handlers/fgetxattr.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_FGETXATTR_HPP
 #define CAPIO_POSIX_HANDLERS_FGETXATTR_HPP
 
+#if defined(SYS_fgetxattr)
+
 int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                       long *result) {
     std::string name(reinterpret_cast<const char *>(arg1));
@@ -22,4 +24,5 @@ int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_fgetxattr
 #endif // CAPIO_POSIX_HANDLERS_FGETXATTR_HPP

--- a/src/posix/handlers/fork.hpp
+++ b/src/posix/handlers/fork.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_FORK_HPP
 #define CAPIO_POSIX_HANDLERS_FORK_HPP
 
+#if defined(SYS_fork)
+
 #include "utils/clone.hpp"
 #include "utils/requests.hpp"
 
@@ -22,4 +24,5 @@ int fork_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
+#endif // SYS_fork
 #endif // CAPIO_POSIX_HANDLERS_FORK_HPP

--- a/src/posix/handlers/getcwd.hpp
+++ b/src/posix/handlers/getcwd.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_GETCWD_HPP
 #define CAPIO_POSIX_HANDLERS_GETCWD_HPP
 
+#if defined(SYS_getcwd)
+
 int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     auto buf  = reinterpret_cast<char *>(arg0);
     auto size = static_cast<size_t>(arg1);
@@ -31,4 +33,5 @@ int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
+#endif // SYS_getcwd
 #endif // CAPIO_POSIX_HANDLERS_GETCWD_HPP

--- a/src/posix/handlers/getdents.hpp
+++ b/src/posix/handlers/getdents.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_GETDENTS_HPP
 #define CAPIO_POSIX_HANDLERS_GETDENTS_HPP
 
+#if defined(SYS_getdents) || defined(SYS_getdents64)
+
 #include "utils/common.hpp"
 #include "utils/data.hpp"
 
@@ -51,4 +53,5 @@ inline int getdents64_handler(long arg0, long arg1, long arg2, long arg3, long a
     return getdents_handler_impl(arg0, arg1, arg2, result, true);
 }
 
+#endif // SYS_getdents || SYS_getdents64
 #endif // CAPIO_POSIX_HANDLERS_GETDENTS_HPP

--- a/src/posix/handlers/ioctl.hpp
+++ b/src/posix/handlers/ioctl.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_IOCTL_HPP
 #define CAPIO_POSIX_HANDLERS_IOCTL_HPP
 
+#if defined(SYS_ioctl)
+
 int ioctl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     auto fd      = static_cast<int>(arg0);
     auto request = static_cast<unsigned long>(arg1);
@@ -15,4 +17,5 @@ int ioctl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
 }
 
+#endif // SYS_ioctl
 #endif // CAPIO_POSIX_HANDLERS_IOCTL_HPP

--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_LSEEK_HPP
 #define CAPIO_POSIX_HANDLERS_LSEEK_HPP
 
+#if defined(SYS_lseek)
+
 #include "utils/common.hpp"
 
 // TODO: EOVERFLOW is not addressed
@@ -59,4 +61,5 @@ int lseek_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return posix_return_value(capio_lseek(fd, offset, whence, tid), result);
 }
 
+#endif // SYS_lseek
 #endif // CAPIO_POSIX_HANDLERS_LSEEK_HPP

--- a/src/posix/handlers/mkdir.hpp
+++ b/src/posix/handlers/mkdir.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_MKDIR_HPP
 #define CAPIO_POSIX_HANDLERS_MKDIR_HPP
 
+#if defined(SYS_mkdir) || defined(SYS_mkdirat) || defined(SYS_rmdir)
+
 #include "utils/common.hpp"
 #include "utils/filesystem.hpp"
 
@@ -112,4 +114,5 @@ int rmdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return posix_return_value(capio_rmdir(pathname, tid), result);
 }
 
+#endif // SYS_mkdir || SYS_mkdirat || SYS_rmdir
 #endif // CAPIO_POSIX_HANDLERS_MKDIR_HPP

--- a/src/posix/handlers/read.hpp
+++ b/src/posix/handlers/read.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_READ_HPP
 #define CAPIO_POSIX_HANDLERS_READ_HPP
 
+#if defined(SYS_read) || defined(SYS_readv)
+
 #include "utils/data.hpp"
 
 inline ssize_t capio_read(int fd, const void *buffer, off64_t count, long tid) {
@@ -68,4 +70,5 @@ int readv_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return posix_return_value(capio_readv(fd, iov, iovcnt, tid), result);
 }
 
+#endif // SYS_read || SYS_readv
 #endif // CAPIO_POSIX_HANDLERS_READ_HPP

--- a/src/posix/handlers/rename.hpp
+++ b/src/posix/handlers/rename.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_RENAME_HPP
 #define CAPIO_POSIX_HANDLERS_RENAME_HPP
 
+#if defined(SYS_rename)
+
 #include "utils/filesystem.hpp"
 
 int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
@@ -34,4 +36,5 @@ int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     }
 }
 
+#endif // SYS_rename
 #endif // CAPIO_POSIX_HANDLERS_RENAME_HPP

--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_STAT_HPP
 #define CAPIO_POSIX_HANDLERS_STAT_HPP
 
+#if defined(SYS_fstat) || defined(SYS_lstat) || defined(SYS_newfstatat) || defined(SYS_stat)
+
 #include <sys/vfs.h>
 
 #include "capio/env.hpp"
@@ -168,4 +170,5 @@ int stat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     return posix_return_value(capio_lstat_wrapper(pathname, buf, tid), result);
 }
 
+#endif // SYS_fstat || SYS_lstat || SYS_newfstatat || SYS_stat
 #endif // CAPIO_POSIX_HANDLERS_STAT_HPP

--- a/src/posix/handlers/statfs.hpp
+++ b/src/posix/handlers/statfs.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_STATFS_HPP
 #define CAPIO_POSIX_HANDLERS_STATFS_HPP
 
+#if defined(SYS_fstatfs)
+
 int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                     long *result) {
     auto fd   = static_cast<int>(arg0);
@@ -18,4 +20,5 @@ int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long 
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#endif // SYS_fstatfs
 #endif // CAPIO_POSIX_HANDLERS_STATFS_HPP

--- a/src/posix/handlers/statx.hpp
+++ b/src/posix/handlers/statx.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_STATX_HPP
 #define CAPIO_POSIX_HANDLERS_STATX_HPP
 
+#if defined(SYS_statx)
+
 #include "utils/common.hpp"
 
 inline void fill_statxbuf(struct statx *statxbuf, off_t file_size, bool is_dir, ino_t inode,
@@ -106,4 +108,5 @@ int statx_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     return posix_return_value(capio_statx(dirfd, pathname, flags, mask, buf, tid), result);
 }
 
+#endif // SYS_statx
 #endif // CAPIO_POSIX_HANDLERS_STATX_HPP

--- a/src/posix/handlers/unlink.hpp
+++ b/src/posix/handlers/unlink.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_UNLINK_HPP
 #define CAPIO_POSIX_HANDLERS_UNLINK_HPP
 
+#if defined(SYS_unlink) || defined(SYS_unlinkat)
+
 #include "utils/common.hpp"
 
 off64_t capio_unlink_abs(const std::filesystem::path &abs_path, long tid, bool is_dir) {
@@ -77,4 +79,5 @@ int unlinkat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long
     return posix_return_value(capio_unlinkat(dirfd, pathname, flags, tid), result);
 }
 
+#endif // SYS_unlink || SYS_unlinkat
 #endif // CAPIO_POSIX_HANDLERS_UNLINK_HPP

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -1,6 +1,8 @@
 #ifndef CAPIO_POSIX_HANDLERS_WRITE_HPP
 #define CAPIO_POSIX_HANDLERS_WRITE_HPP
 
+#if defined(SYS_write) || defined(SYS_writev)
+
 #include "utils/common.hpp"
 #include "utils/requests.hpp"
 
@@ -68,4 +70,5 @@ int writev_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return posix_return_value(capio_writev(fd, iov, iovcnt, tid), result);
 }
 
+#endif // SYS_write || SYS_writev
 #endif // CAPIO_POSIX_HANDLERS_WRITE_HPP

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -37,218 +37,132 @@ static int not_implemented_handler(long arg0, long arg1, long arg2, long arg3, l
 static constexpr size_t CAPIO_NR_SYSCALLS = 1 + std::max({
 #ifdef SYS_access
                                                     SYS_access,
-#else
-                                                    0,
 #endif
 #ifdef SYS_chdir
                                                     SYS_chdir,
-#else
-                                                    0,
 #endif
 #ifdef SYS_chmod
                                                     SYS_chmod,
-#else
-                                                    0,
 #endif
 #ifdef SYS_chown
                                                     SYS_chown,
-#else
-                                                    0,
 #endif
 #ifdef SYS_close
                                                     SYS_close,
-#else
-                                                    0,
 #endif
 #ifdef SYS_creat
                                                     SYS_creat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_dup
                                                     SYS_dup,
-#else
-                                                    0,
 #endif
 #ifdef SYS_dup2
                                                     SYS_dup2,
-#else
-                                                    0,
 #endif
 #ifdef SYS_dup3
                                                     SYS_dup3,
-#else
-                                                    0,
 #endif
 #ifdef SYS_execve
                                                     SYS_execve,
-#else
-                                                    0,
 #endif
 #ifdef SYS_exit
                                                     SYS_exit,
-#else
-                                                    0,
 #endif
 #ifdef SYS_exit_group
                                                     SYS_exit_group,
-#else
-                                                    0,
 #endif
 #ifdef SYS_faccessat
                                                     SYS_faccessat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_faccessat2
                                                     SYS_faccessat2,
-#else
-                                                    0,
 #endif
 #ifdef SYS_fcntl
                                                     SYS_fcntl,
-#else
-                                                    0,
 #endif
 #ifdef SYS_fgetxattr
                                                     SYS_fgetxattr,
-#else
-                                                    0,
 #endif
 #ifdef SYS_flistxattr
                                                     SYS_flistxattr,
-#else
-                                                    0,
 #endif
 #ifdef SYS_fork
                                                     SYS_fork,
-#else
-                                                    0,
 #endif
 #ifdef SYS_fstat
                                                     SYS_fstat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_fstatfs
                                                     SYS_fstatfs,
-#else
-                                                    0,
 #endif
 #ifdef SYS_getcwd
                                                     SYS_getcwd,
-#else
-                                                    0,
 #endif
 #ifdef SYS_getdents
                                                     SYS_getdents,
-#else
-                                                    0,
 #endif
 #ifdef SYS_getdents64
                                                     SYS_getdents64,
-#else
-                                                    0,
 #endif
 #ifdef SYS_getxattr
                                                     SYS_getxattr,
-#else
-                                                    0,
 #endif
 #ifdef SYS_ioctl
                                                     SYS_ioctl,
-#else
-                                                    0,
 #endif
 #ifdef SYS_lgetxattr
                                                     SYS_lgetxattr,
-#else
-                                                    0,
 #endif
 #ifdef SYS_lseek
                                                     SYS_lseek,
-#else
-                                                    0,
 #endif
 #ifdef SYS_lstat
                                                     SYS_lstat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_mkdir
                                                     SYS_mkdir,
-#else
-                                                    0,
 #endif
 #ifdef SYS_mkdirat
                                                     SYS_mkdirat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_newfstatat
                                                     SYS_newfstatat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_open
                                                     SYS_open,
-#else
-                                                    0,
 #endif
 #ifdef SYS_openat
                                                     SYS_openat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_read
                                                     SYS_read,
-#else
-                                                    0,
 #endif
 #ifdef SYS_readv
                                                     SYS_readv,
-#else
-                                                    0,
 #endif
 #ifdef SYS_rename
                                                     SYS_rename,
-#else
-                                                    0,
 #endif
 #ifdef SYS_rmdir
                                                     SYS_rmdir,
-#else
-                                                    0,
 #endif
 #ifdef SYS_stat
                                                     SYS_stat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_statx
                                                     SYS_statx,
-#else
-                                                    0,
 #endif
 #ifdef SYS_unlink
                                                     SYS_unlink,
-#else
-                                                    0,
 #endif
 #ifdef SYS_unlinkat
                                                     SYS_unlinkat,
-#else
-                                                    0,
 #endif
 #ifdef SYS_write
                                                     SYS_write,
-#else
-                                                    0,
 #endif
 #ifdef SYS_writev
                                                     SYS_writev,
-#else
-                                                    0,
 #endif
                                                 });
 

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -7,8 +7,6 @@
 #include <array>
 #include <string>
 
-#include <asm-generic/unistd.h>
-
 #include "capio/syscall.hpp"
 
 #include "utils/clone.hpp"
@@ -36,10 +34,228 @@ static int not_implemented_handler(long arg0, long arg1, long arg2, long arg3, l
     return 0;
 }
 
-static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
-    std::array<CPHandler_t, __NR_syscalls> _syscallTable{0};
+static constexpr size_t CAPIO_NR_SYSCALLS = 1 + std::max({
+#ifdef SYS_access
+                                                    SYS_access,
+#else
+                                                    0,
+#endif
+#ifdef SYS_chdir
+                                                    SYS_chdir,
+#else
+                                                    0,
+#endif
+#ifdef SYS_chmod
+                                                    SYS_chmod,
+#else
+                                                    0,
+#endif
+#ifdef SYS_chown
+                                                    SYS_chown,
+#else
+                                                    0,
+#endif
+#ifdef SYS_close
+                                                    SYS_close,
+#else
+                                                    0,
+#endif
+#ifdef SYS_creat
+                                                    SYS_creat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_dup
+                                                    SYS_dup,
+#else
+                                                    0,
+#endif
+#ifdef SYS_dup2
+                                                    SYS_dup2,
+#else
+                                                    0,
+#endif
+#ifdef SYS_dup3
+                                                    SYS_dup3,
+#else
+                                                    0,
+#endif
+#ifdef SYS_execve
+                                                    SYS_execve,
+#else
+                                                    0,
+#endif
+#ifdef SYS_exit
+                                                    SYS_exit,
+#else
+                                                    0,
+#endif
+#ifdef SYS_exit_group
+                                                    SYS_exit_group,
+#else
+                                                    0,
+#endif
+#ifdef SYS_faccessat
+                                                    SYS_faccessat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_faccessat2
+                                                    SYS_faccessat2,
+#else
+                                                    0,
+#endif
+#ifdef SYS_fcntl
+                                                    SYS_fcntl,
+#else
+                                                    0,
+#endif
+#ifdef SYS_fgetxattr
+                                                    SYS_fgetxattr,
+#else
+                                                    0,
+#endif
+#ifdef SYS_flistxattr
+                                                    SYS_flistxattr,
+#else
+                                                    0,
+#endif
+#ifdef SYS_fork
+                                                    SYS_fork,
+#else
+                                                    0,
+#endif
+#ifdef SYS_fstat
+                                                    SYS_fstat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_fstatfs
+                                                    SYS_fstatfs,
+#else
+                                                    0,
+#endif
+#ifdef SYS_getcwd
+                                                    SYS_getcwd,
+#else
+                                                    0,
+#endif
+#ifdef SYS_getdents
+                                                    SYS_getdents,
+#else
+                                                    0,
+#endif
+#ifdef SYS_getdents64
+                                                    SYS_getdents64,
+#else
+                                                    0,
+#endif
+#ifdef SYS_getxattr
+                                                    SYS_getxattr,
+#else
+                                                    0,
+#endif
+#ifdef SYS_ioctl
+                                                    SYS_ioctl,
+#else
+                                                    0,
+#endif
+#ifdef SYS_lgetxattr
+                                                    SYS_lgetxattr,
+#else
+                                                    0,
+#endif
+#ifdef SYS_lseek
+                                                    SYS_lseek,
+#else
+                                                    0,
+#endif
+#ifdef SYS_lstat
+                                                    SYS_lstat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_mkdir
+                                                    SYS_mkdir,
+#else
+                                                    0,
+#endif
+#ifdef SYS_mkdirat
+                                                    SYS_mkdirat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_newfstatat
+                                                    SYS_newfstatat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_open
+                                                    SYS_open,
+#else
+                                                    0,
+#endif
+#ifdef SYS_openat
+                                                    SYS_openat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_read
+                                                    SYS_read,
+#else
+                                                    0,
+#endif
+#ifdef SYS_readv
+                                                    SYS_readv,
+#else
+                                                    0,
+#endif
+#ifdef SYS_rename
+                                                    SYS_rename,
+#else
+                                                    0,
+#endif
+#ifdef SYS_rmdir
+                                                    SYS_rmdir,
+#else
+                                                    0,
+#endif
+#ifdef SYS_stat
+                                                    SYS_stat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_statx
+                                                    SYS_statx,
+#else
+                                                    0,
+#endif
+#ifdef SYS_unlink
+                                                    SYS_unlink,
+#else
+                                                    0,
+#endif
+#ifdef SYS_unlinkat
+                                                    SYS_unlinkat,
+#else
+                                                    0,
+#endif
+#ifdef SYS_write
+                                                    SYS_write,
+#else
+                                                    0,
+#endif
+#ifdef SYS_writev
+                                                    SYS_writev,
+#else
+                                                    0,
+#endif
+                                                });
 
-    for (int i = 0; i < __NR_syscalls; i++) {
+static constexpr std::array<CPHandler_t, CAPIO_NR_SYSCALLS> build_syscall_table() {
+    std::array<CPHandler_t, CAPIO_NR_SYSCALLS> _syscallTable{0};
+
+    for (int i = 0; i < CAPIO_NR_SYSCALLS; i++) {
         _syscallTable[i] = not_handled_handler;
     }
 
@@ -151,6 +367,9 @@ static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
 #ifdef SYS_rename
     _syscallTable[SYS_rename] = rename_handler;
 #endif
+#ifdef SYS_rmdir
+    _syscallTable[SYS_rmdir] = rmdir_handler;
+#endif
 #ifdef SYS_stat
     _syscallTable[SYS_stat] = stat_handler;
 #endif
@@ -169,17 +388,15 @@ static constexpr std::array<CPHandler_t, __NR_syscalls> build_syscall_table() {
 #ifdef SYS_writev
     _syscallTable[SYS_writev] = writev_handler;
 #endif
-#ifdef SYS_rmdir
-    _syscallTable[SYS_rmdir] = rmdir_handler;
-#endif
 
     return _syscallTable;
 }
 
 static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3, long arg4,
                 long arg5, long *result) {
-    static const std::array<CPHandler_t, __NR_syscalls> syscallTable = build_syscall_table();
-    static const char *capio_dir                                     = std::getenv("CAPIO_DIR");
+    static constexpr std::array<CPHandler_t, CAPIO_NR_SYSCALLS> syscallTable =
+        build_syscall_table();
+    static const char *capio_dir = std::getenv("CAPIO_DIR");
 
 #ifdef SYS_futex
     /**
@@ -204,7 +421,13 @@ static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3,
 
     START_LOG(syscall_no_intercept(SYS_gettid), "call(syscall_number=%ld)", syscall_number);
 
-    // NB: if capio dir is not set as environment variable,
+    // If the syscall_number is higher than the maximum
+    // syscall captured by CAPIO, simply return
+    if (syscall_number >= CAPIO_NR_SYSCALLS) {
+        return 1;
+    }
+
+    // If CAPIO_DIR is not set as environment variable,
     // then capio will not intercept the system calls
     if (capio_dir == nullptr) {
         LOG("CAPIO_DIR env var not set. returning control to kernel");

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -56,7 +56,7 @@ ENDIF (MPI_LINK_FLAGS)
 #####################################
 # Link libraries
 #####################################
-target_link_libraries(${TARGET_NAME} PRIVATE ${MPI_LIBRARIES} rt stdc++fs)
+target_link_libraries(${TARGET_NAME} PRIVATE ${MPI_LIBRARIES} pthread rt stdc++fs)
 
 #####################################
 # Install rules


### PR DESCRIPTION
This commit improves CAPIO compatibility with old Linux kernels in three ways:

- It includes syscall handlers only when the related system calls are effectively defined, reducing the risk of compiling errors;
- If substitutes the flawed `__NR_syscalls` import with a compile-time calculation of the syscall table size, avoiding compatibility issues with misspecified `__NR_syscalls` values
- It explicitly includes the `pthread` library in the CAPIO Server `CMakeLists.txt` file