### PR TITLE
Fixed a bug in `seek_end_request`

### DIFF
--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -183,8 +183,9 @@ inline off64_t seek_end_request(const int fd, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_SEEK_END, tid, fd);
     buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
-    off64_t res;
+    off64_t res, is_dir;
     bufs_response->at(tid)->read(&res);
+    bufs_response->at(tid)->read(&is_dir);
     return res;
 }
 


### PR DESCRIPTION
This commit fixes the communication protocol in the `seek_end_request`. The server was sending two different response objects, but the client was retrieving only one of them, leaving the other in the queue and generating potential issues in subsequent communications.