### PR TITLE
Improve `CapioFile` test suite

### DIFF
--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -10,7 +10,9 @@
 #include "types.hpp"
 
 inline off64_t store_dirent(char *incoming, char *target_buffer, off64_t incoming_size) {
-    START_LOG(gettid(), "call(%s, %s, %to_store)", incoming, target_buffer, incoming_size);
+    START_LOG(gettid(), "call(incoming=0x%08x, target_buffer=0x%08x, incoming_size=%ld)", incoming,
+              target_buffer, incoming_size);
+
     off64_t stored_size = 0, i = 0;
     struct linux_dirent64 to_store {};
     struct linux_dirent64 *dir_entity;

--- a/tests/unit/posix/src/realpath.cpp
+++ b/tests/unit/posix/src/realpath.cpp
@@ -22,7 +22,7 @@ TEST_F(RealpathPosixTest, TestAbsolutePathsInCapioDirWhenPathExists) {
     EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
 
-TEST_F(RealpathPosixTest, TestAbsoluePathsInCapioDirWhenPathDoesNotExist) {
+TEST_F(RealpathPosixTest, TestAbsolutePathsInCapioDirWhenPathDoesNotExist) {
     const std::filesystem::path PATHNAME = get_capio_dir() / "test";
     EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
 }
@@ -36,7 +36,7 @@ TEST_F(RealpathPosixTest, TestAbsolutePathsOutsideCapioDirWhenPathExists) {
     EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
 
-TEST_F(RealpathPosixTest, TestAbsoluePathOutsideCapioDirWhenPathDoesNotExist) {
+TEST_F(RealpathPosixTest, TestAbsolutePathOutsideCapioDirWhenPathDoesNotExist) {
     const std::filesystem::path PATHNAME = "/tmp/test";
     EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
 }

--- a/tests/unit/server/src/capio_file.cpp
+++ b/tests/unit/server/src/capio_file.cpp
@@ -8,40 +8,55 @@
 TEST(ServerTest, TestInsertSingleSector) {
     CapioFile c_file;
     c_file.insert_sector(1, 3);
-    c_file.print(std::cout);
+    auto &sectors = c_file.get_sectors();
+    EXPECT_EQ(sectors.size(), 1);
+    EXPECT_NE(sectors.find({1L, 3L}), sectors.end());
 }
 
 TEST(ServerTest, TestInsertTwoNonOverlappingSectors) {
     CapioFile c_file;
     c_file.insert_sector(5, 7);
     c_file.insert_sector(1, 3);
-    c_file.print(std::cout);
+    auto &sectors = c_file.get_sectors();
+    EXPECT_EQ(sectors.size(), 2);
+    auto it = sectors.begin();
+    EXPECT_EQ(std::make_pair(1L, 3L), *it);
+    std::advance(it, 1);
+    EXPECT_EQ(std::make_pair(5L, 7L), *it);
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectors) {
     CapioFile c_file;
     c_file.insert_sector(2, 4);
     c_file.insert_sector(1, 3);
-    c_file.print(std::cout);
+    auto &sectors = c_file.get_sectors();
+    EXPECT_EQ(sectors.size(), 1);
+    EXPECT_NE(sectors.find({1L, 4L}), sectors.end());
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectorsSameStart) {
     CapioFile c_file;
     c_file.insert_sector(1, 4);
     c_file.insert_sector(1, 3);
-    c_file.print(std::cout);
+    auto &sectors = c_file.get_sectors();
+    EXPECT_EQ(sectors.size(), 1);
+    EXPECT_NE(sectors.find({1L, 4L}), sectors.end());
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectorsSameEnd) {
     CapioFile c_file;
     c_file.insert_sector(1, 4);
     c_file.insert_sector(2, 4);
-    c_file.print(std::cout);
+    auto &sectors = c_file.get_sectors();
+    EXPECT_EQ(sectors.size(), 1);
+    EXPECT_NE(sectors.find({1L, 4L}), sectors.end());
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectorsNested) {
     CapioFile c_file;
     c_file.insert_sector(1, 4);
     c_file.insert_sector(2, 3);
-    c_file.print(std::cout);
+    auto &sectors = c_file.get_sectors();
+    EXPECT_EQ(sectors.size(), 1);
+    EXPECT_NE(sectors.find({1L, 4L}), sectors.end());
 }


### PR DESCRIPTION
This commit replaces the `print` function call in the `CapioFile` test suite with a more appropriate call to `get_sectors`, which allows automated test assertions and a better regression detection. In addition, this commit adds some log messages for clarity and fixes two typos in test names.