### PR TITLE
Store independent file offsets in client and server

### DIFF
--- a/src/common/capio/queue.hpp
+++ b/src/common/capio/queue.hpp
@@ -81,20 +81,6 @@ template <class T, class Mutex> class Queue {
 
     inline auto get_name() { return this->_shm_name; }
 
-    inline void write(const T *data, long int num_bytes) {
-        START_LOG(capio_syscall(SYS_gettid), "call(data=0x%08x)", data);
-
-        off64_t n_writes = num_bytes / _elem_size;
-        size_t r         = num_bytes % _elem_size;
-
-        for (int i = 0; i < n_writes; i++) {
-            _write(data + i * _elem_size, _elem_size);
-        }
-        if (r) {
-            _write(data + n_writes * _elem_size, r);
-        }
-    }
-
     inline void read(T *buff_rcv, long int num_bytes) {
         START_LOG(capio_syscall(SYS_gettid), "call(buff_rcv=0x%08x)", buff_rcv);
 
@@ -112,6 +98,20 @@ template <class T, class Mutex> class Queue {
     inline void read(T *buf_rcv) {
         START_LOG(capio_syscall(SYS_gettid), "call(buff_rcv=0x%08x)", buf_rcv);
         this->read(buf_rcv, _elem_size);
+    }
+
+    inline void write(const T *data, long int num_bytes) {
+        START_LOG(capio_syscall(SYS_gettid), "call(data=0x%08x)", data);
+
+        off64_t n_writes = num_bytes / _elem_size;
+        size_t r         = num_bytes % _elem_size;
+
+        for (int i = 0; i < n_writes; i++) {
+            _write(data + i * _elem_size, _elem_size);
+        }
+        if (r) {
+            _write(data + n_writes * _elem_size, r);
+        }
     }
 
     inline void write(const T *data) {

--- a/src/posix/handlers/read.hpp
+++ b/src/posix/handlers/read.hpp
@@ -15,8 +15,7 @@ inline ssize_t capio_read(int fd, void *buffer, off64_t count, long tid) {
         off64_t offset      = get_capio_fd_offset(fd);
         off64_t end_of_read = read_request(fd, count, tid);
         off64_t bytes_read  = end_of_read - offset;
-        read_data(tid, buffer, bytes_read);
-        set_capio_fd_offset(fd, offset + bytes_read);
+        read_data(tid, fd, buffer, bytes_read);
         return bytes_read;
     } else {
         return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -14,8 +14,7 @@ inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) 
             ERR_EXIT("Capio does not support writes bigger than "
                      "SSIZE_MAX yet");
         }
-        write_request(fd, count, tid);
-        write_data(tid, buffer, count);
+        write_data(tid, fd, buffer, count);
 
         return count;
     } else {

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -34,137 +34,137 @@ static int not_implemented_handler(long arg0, long arg1, long arg2, long arg3, l
     return 0;
 }
 
-static constexpr size_t CAPIO_NR_SYSCALLS = 1 + std::max({
+static constexpr long CAPIO_NR_SYSCALLS = 1 + std::max({
 #ifdef SYS_access
-                                                    SYS_access,
+                                                  SYS_access,
 #endif
 #ifdef SYS_chdir
-                                                    SYS_chdir,
+                                                  SYS_chdir,
 #endif
 #ifdef SYS_chmod
-                                                    SYS_chmod,
+                                                  SYS_chmod,
 #endif
 #ifdef SYS_chown
-                                                    SYS_chown,
+                                                  SYS_chown,
 #endif
 #ifdef SYS_close
-                                                    SYS_close,
+                                                  SYS_close,
 #endif
 #ifdef SYS_creat
-                                                    SYS_creat,
+                                                  SYS_creat,
 #endif
 #ifdef SYS_dup
-                                                    SYS_dup,
+                                                  SYS_dup,
 #endif
 #ifdef SYS_dup2
-                                                    SYS_dup2,
+                                                  SYS_dup2,
 #endif
 #ifdef SYS_dup3
-                                                    SYS_dup3,
+                                                  SYS_dup3,
 #endif
 #ifdef SYS_execve
-                                                    SYS_execve,
+                                                  SYS_execve,
 #endif
 #ifdef SYS_exit
-                                                    SYS_exit,
+                                                  SYS_exit,
 #endif
 #ifdef SYS_exit_group
-                                                    SYS_exit_group,
+                                                  SYS_exit_group,
 #endif
 #ifdef SYS_faccessat
-                                                    SYS_faccessat,
+                                                  SYS_faccessat,
 #endif
 #ifdef SYS_faccessat2
-                                                    SYS_faccessat2,
+                                                  SYS_faccessat2,
 #endif
 #ifdef SYS_fcntl
-                                                    SYS_fcntl,
+                                                  SYS_fcntl,
 #endif
 #ifdef SYS_fgetxattr
-                                                    SYS_fgetxattr,
+                                                  SYS_fgetxattr,
 #endif
 #ifdef SYS_flistxattr
-                                                    SYS_flistxattr,
+                                                  SYS_flistxattr,
 #endif
 #ifdef SYS_fork
-                                                    SYS_fork,
+                                                  SYS_fork,
 #endif
 #ifdef SYS_fstat
-                                                    SYS_fstat,
+                                                  SYS_fstat,
 #endif
 #ifdef SYS_fstatfs
-                                                    SYS_fstatfs,
+                                                  SYS_fstatfs,
 #endif
 #ifdef SYS_getcwd
-                                                    SYS_getcwd,
+                                                  SYS_getcwd,
 #endif
 #ifdef SYS_getdents
-                                                    SYS_getdents,
+                                                  SYS_getdents,
 #endif
 #ifdef SYS_getdents64
-                                                    SYS_getdents64,
+                                                  SYS_getdents64,
 #endif
 #ifdef SYS_getxattr
-                                                    SYS_getxattr,
+                                                  SYS_getxattr,
 #endif
 #ifdef SYS_ioctl
-                                                    SYS_ioctl,
+                                                  SYS_ioctl,
 #endif
 #ifdef SYS_lgetxattr
-                                                    SYS_lgetxattr,
+                                                  SYS_lgetxattr,
 #endif
 #ifdef SYS_lseek
-                                                    SYS_lseek,
+                                                  SYS_lseek,
 #endif
 #ifdef SYS_lstat
-                                                    SYS_lstat,
+                                                  SYS_lstat,
 #endif
 #ifdef SYS_mkdir
-                                                    SYS_mkdir,
+                                                  SYS_mkdir,
 #endif
 #ifdef SYS_mkdirat
-                                                    SYS_mkdirat,
+                                                  SYS_mkdirat,
 #endif
 #ifdef SYS_newfstatat
-                                                    SYS_newfstatat,
+                                                  SYS_newfstatat,
 #endif
 #ifdef SYS_open
-                                                    SYS_open,
+                                                  SYS_open,
 #endif
 #ifdef SYS_openat
-                                                    SYS_openat,
+                                                  SYS_openat,
 #endif
 #ifdef SYS_read
-                                                    SYS_read,
+                                                  SYS_read,
 #endif
 #ifdef SYS_readv
-                                                    SYS_readv,
+                                                  SYS_readv,
 #endif
 #ifdef SYS_rename
-                                                    SYS_rename,
+                                                  SYS_rename,
 #endif
 #ifdef SYS_rmdir
-                                                    SYS_rmdir,
+                                                  SYS_rmdir,
 #endif
 #ifdef SYS_stat
-                                                    SYS_stat,
+                                                  SYS_stat,
 #endif
 #ifdef SYS_statx
-                                                    SYS_statx,
+                                                  SYS_statx,
 #endif
 #ifdef SYS_unlink
-                                                    SYS_unlink,
+                                                  SYS_unlink,
 #endif
 #ifdef SYS_unlinkat
-                                                    SYS_unlinkat,
+                                                  SYS_unlinkat,
 #endif
 #ifdef SYS_write
-                                                    SYS_write,
+                                                  SYS_write,
 #endif
 #ifdef SYS_writev
-                                                    SYS_writev,
+                                                  SYS_writev,
 #endif
-                                                });
+                                              });
 
 static constexpr std::array<CPHandler_t, CAPIO_NR_SYSCALLS> build_syscall_table() {
     std::array<CPHandler_t, CAPIO_NR_SYSCALLS> _syscallTable{0};

--- a/src/posix/utils/data.hpp
+++ b/src/posix/utils/data.hpp
@@ -1,6 +1,7 @@
 #ifndef CAPIO_POSIX_UTILS_DATA_HPP
 #define CAPIO_POSIX_UTILS_DATA_HPP
 
+#include "requests.hpp"
 #include "types.hpp"
 
 CPThreadDataBufs_t *threads_data_bufs;
@@ -29,14 +30,17 @@ inline void register_data_listener(long tid) {
 /**
  * Receives @count bytes for thread @tid and writes them into @buf
  * @param tid
+ * @param fd
  * @param buffer
+ * @param offset
  * @param count
  * @return
  */
-inline void read_data(long tid, void *buffer, off64_t count) {
-    START_LOG(tid, "call(buffer=0x%08x, count=%ld)", buffer, count);
+inline void read_data(long tid, int fd, void *buffer, off64_t count) {
+    START_LOG(tid, "call(fd=%d, buffer=0x%08x, count=%ld)", fd, buffer, count);
 
     threads_data_bufs->at(tid).second->read(reinterpret_cast<char *>(buffer), count);
+    set_capio_fd_offset(fd, get_capio_fd_offset(fd) + count);
 }
 
 /**
@@ -46,10 +50,12 @@ inline void read_data(long tid, void *buffer, off64_t count) {
  * @param count
  * @return
  */
-inline void write_data(long tid, const void *buffer, off64_t count) {
-    START_LOG(tid, "call(buffer=0x%08x, count=%ld)", buffer, count);
+inline void write_data(long tid, int fd, const void *buffer, off64_t count) {
+    START_LOG(tid, "call(fd=%d, buffer=0x%08x, count=%ld)", fd, buffer, count);
 
+    write_request(fd, count, tid);
     threads_data_bufs->at(tid).first->write(reinterpret_cast<const char *>(buffer), count);
+    set_capio_fd_offset(fd, get_capio_fd_offset(fd) + count);
 }
 
 #endif // CAPIO_POSIX_UTILS_DATA_HPP

--- a/src/posix/utils/env.hpp
+++ b/src/posix/utils/env.hpp
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <iostream>
 
+#include "capio/logger.hpp"
+
 const char *get_capio_app_name() {
     static char *capio_app_name = std::getenv("CAPIO_APP_NAME");
 

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -241,7 +241,6 @@ inline void write_request(const int fd, const off64_t count, const long tid) {
     char req[CAPIO_REQUEST_MAX_SIZE];
     int num_writes_batch = get_num_writes_batch(tid);
     long int offset      = get_capio_fd_offset(fd);
-    set_capio_fd_offset(fd, offset + count);
     // FIXME: works only if there is only one writer at time for each file
     if (actual_num_writes == num_writes_batch) {
         sprintf(req, "%04d %ld %d %ld %ld", CAPIO_REQUEST_WRITE, tid, fd, offset, count);

--- a/src/posix/utils/types.hpp
+++ b/src/posix/utils/types.hpp
@@ -6,7 +6,7 @@
 
 #include "capio/queue.hpp"
 
-typedef std::unordered_map<int, std::tuple<off64_t *, off64_t, int, bool>> CPFiles_t;
+typedef std::unordered_map<int, std::tuple<std::shared_ptr<off64_t>, off64_t, int, bool>> CPFiles_t;
 typedef std::pair<off64_t, off64_t> CPStatResponse_t;
 typedef std::unordered_map<long, CircularBuffer<off_t> *> CPBufResponse_t;
 typedef std::unordered_map<int, std::string> CPFileDescriptors_t;

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -23,11 +23,11 @@ inline void request_remote_getdents(int tid, int fd, off64_t count) {
         (end_of_read <= end_of_sector ||
          (end_of_sector == -1 ? 0 : end_of_sector) == c_file.real_file_size)) {
         LOG("Handling local read");
-        send_dirent_to_client(tid, c_file, offset, count);
+        send_dirent_to_client(tid, fd, c_file, offset, count);
     } else if (end_of_read <= end_of_sector) {
         LOG("?");
         c_file.create_buffer_if_needed(path, false);
-        send_data_to_client(tid, c_file.get_buffer(), offset, count);
+        send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
     } else {
         LOG("Delegating to backend remote read");
         handle_remote_read_request(tid, fd, count, true);
@@ -75,7 +75,7 @@ inline void handle_getdents(int tid, int fd, long int count) {
                capio_dir == path) {
         CapioFile &c_file = get_capio_file(path);
         off64_t offset    = get_capio_file_offset(tid, fd);
-        send_dirent_to_client(tid, c_file, offset, count);
+        send_dirent_to_client(tid, fd, c_file, offset, count);
     } else {
         LOG("File is remote");
         CapioFile &c_file = get_capio_file(path);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -30,7 +30,7 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
     }
 
     c_file.create_buffer_if_needed(path, false);
-    send_data_to_client(tid, c_file.get_buffer(), process_offset, bytes_read);
+    send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, bytes_read);
 
     // TODO: check if the file was moved to the disk
 }
@@ -70,12 +70,12 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool is_prod) {
                 return;
             }
             c_file.create_buffer_if_needed(path, false);
-            send_data_to_client(tid, c_file.get_buffer(), process_offset,
+            send_data_to_client(tid, fd, c_file.get_buffer(), process_offset,
                                 end_of_sector - process_offset);
         }
     } else {
         c_file.create_buffer_if_needed(path, false);
-        send_data_to_client(tid, c_file.get_buffer(), process_offset, count);
+        send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, count);
     }
 }
 
@@ -96,7 +96,7 @@ inline void request_remote_read(int tid, int fd, off64_t count) {
     } else if (end_of_read <= end_of_sector) {
         LOG("Data is present locally and can be served to client");
         c_file.create_buffer_if_needed(path, false);
-        send_data_to_client(tid, c_file.get_buffer(), offset, count);
+        send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
     } else {
         LOG("Delegating to backend remote read");
         handle_remote_read_request(tid, fd, count, false);

--- a/src/server/handlers/seek.hpp
+++ b/src/server/handlers/seek.hpp
@@ -3,18 +3,20 @@
 
 #include "stat.hpp"
 
-inline void handle_lseek(int tid, int fd, size_t offset) {
+inline void handle_lseek(int tid, int fd, off64_t offset) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, offset=%ld)", tid, fd, offset);
 
-    CapioFile &c_file = get_capio_file(get_capio_file_path(tid, fd));
-    write_response(tid, c_file.get_sector_end(offset));
+    set_capio_file_offset(tid, fd, offset);
+    write_response(tid, offset);
 }
 
-void handle_seek_data(int tid, int fd, size_t offset) {
+void handle_seek_data(int tid, int fd, off64_t offset) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, offset=%ld)", tid, fd, offset);
 
     CapioFile &c_file = get_capio_file(get_capio_file_path(tid, fd));
-    write_response(tid, c_file.seek_data(offset));
+    offset            = c_file.seek_data(offset);
+    set_capio_file_offset(tid, fd, offset);
+    write_response(tid, offset);
 }
 
 inline void handle_seek_end(int tid, int fd) {
@@ -24,24 +26,26 @@ inline void handle_seek_end(int tid, int fd) {
     reply_stat(tid, get_capio_file_path(tid, fd));
 }
 
-inline void handle_seek_hole(int tid, int fd, size_t offset) {
+inline void handle_seek_hole(int tid, int fd, off64_t offset) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, offset=%ld)", tid, fd, offset);
 
     CapioFile &c_file = get_capio_file(get_capio_file_path(tid, fd));
-    write_response(tid, c_file.seek_hole(offset));
+    offset            = c_file.seek_hole(offset);
+    set_capio_file_offset(tid, fd, offset);
+    write_response(tid, offset);
 }
 
 void lseek_handler(const char *const str) {
     int tid, fd;
-    size_t offset;
-    sscanf(str, "%d %d %zu", &tid, &fd, &offset);
+    off64_t offset;
+    sscanf(str, "%d %d %ld", &tid, &fd, &offset);
     handle_lseek(tid, fd, offset);
 }
 
 void seek_data_handler(const char *const str) {
     int tid, fd;
-    size_t offset;
-    sscanf(str, "%d %d %zu", &tid, &fd, &offset);
+    off64_t offset;
+    sscanf(str, "%d %d %ld", &tid, &fd, &offset);
     handle_seek_data(tid, fd, offset);
 }
 
@@ -53,8 +57,8 @@ void seek_end_handler(const char *const str) {
 
 void seek_hole_handler(const char *const str) {
     int tid, fd;
-    size_t offset;
-    sscanf(str, "%d %d %zu", &tid, &fd, &offset);
+    off64_t offset;
+    sscanf(str, "%d %d %ld", &tid, &fd, &offset);
     handle_seek_hole(tid, fd, offset);
 }
 

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -11,10 +11,8 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count) {
     off64_t end_of_write              = base_offset + count;
     const std::filesystem::path &path = get_capio_file_path(tid, fd);
     CapioFile &c_file                 = get_capio_file(path);
-    size_t file_shm_size              = c_file.get_buf_size();
+    off64_t file_shm_size             = c_file.get_buf_size();
     auto *data_buf                    = data_buffers[tid].first;
-    off64_t n_reads                   = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    off64_t r                         = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
 
     c_file.create_buffer_if_needed(path, true);
     if (end_of_write > file_shm_size) {
@@ -31,6 +29,7 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count) {
         // TODO: it works only if there is one prod per file
         update_dir(tid, path);
     }
+    set_capio_file_offset(tid, fd, end_of_write);
 }
 
 void write_handler(const char *const str) {

--- a/src/server/remote/handlers/read.hpp
+++ b/src/server/remote/handlers/read.hpp
@@ -108,9 +108,9 @@ inline void handle_read_reply(int tid, int fd, long count, off64_t file_size, of
         bytes_read = end_of_sector - offset;
     }
     if (is_getdents) {
-        send_dirent_to_client(tid, c_file, offset, bytes_read);
+        send_dirent_to_client(tid, fd, c_file, offset, bytes_read);
     } else {
-        send_data_to_client(tid, c_file.get_buffer(), offset, bytes_read);
+        send_data_to_client(tid, fd, c_file.get_buffer(), offset, bytes_read);
     }
 }
 

--- a/src/server/utils/location.hpp
+++ b/src/server/utils/location.hpp
@@ -9,8 +9,7 @@
 constexpr char CAPIO_SERVER_FILES_LOCATION_NAME[]     = "files_location_%s.txt";
 constexpr char CAPIO_SERVER_INVALIDATE_FILE_PATH_CHAR = '#';
 
-// unordered map indexed by path file containing {node_name, offset_in_memory}
-CSFilesLocationMap_t files_location;
+std::unordered_map<std::string, std::pair<const char *const, off64_t>> files_location;
 std::mutex files_location_mutex;
 
 int files_location_fd;

--- a/src/server/utils/types.hpp
+++ b/src/server/utils/types.hpp
@@ -10,11 +10,11 @@
 
 #include "utils/capio_file.hpp"
 
+#include "capio_file.hpp"
+
 typedef std::unordered_map<int, int> CSPidsMap_T;
 typedef std::unordered_map<int, std::string> CSAppsMap_t;
 typedef std::unordered_map<std::string, std::unordered_set<std::string>> CSFilesSentMap_t;
-typedef std::unordered_map<int, std::unordered_map<int, std::pair<CapioFile *, off64_t *>>>
-    CSProcessFileMap_t;
 typedef std::unordered_map<int, std::unordered_map<int, std::filesystem::path>>
     CSProcessFileMetadataMap_t;
 typedef std::unordered_map<int, std::pair<SPSCQueue *, SPSCQueue *>> CSDataBufferMap_t;
@@ -26,7 +26,6 @@ typedef std::vector<std::tuple<std::string, std::string, std::string, std::strin
                                long int, bool, long int>>
     CSMetadataConfGlobs_t;
 typedef std::unordered_map<int, std::unordered_map<std::string, bool>> CSWritersMap_t;
-typedef std::unordered_map<std::string, std::pair<const char *const, off64_t>> CSFilesLocationMap_t;
 typedef std::unordered_map<std::string,
                            std::list<std::tuple<const std::filesystem::path, size_t, std::string,
                                                 std::vector<std::string> *, Semaphore *>>>

--- a/tests/unit/syscall/src/stat.cpp
+++ b/tests/unit/syscall/src/stat.cpp
@@ -240,6 +240,7 @@ TEST(SystemCallTest, TestFileCreateWriteCloseWithStat) {
     EXPECT_NE(fp, nullptr);
     EXPECT_EQ(access(PATHNAME, F_OK), 0);
     EXPECT_EQ(fwrite(array, sizeof(int), ARRAY_SIZE, fp), ARRAY_SIZE);
+    EXPECT_EQ(ftell(fp), ARRAY_SIZE * sizeof(int));
     EXPECT_NE(fseek(fp, 0, SEEK_SET), -1);
     int num;
     for (int i = 0; i < ARRAY_SIZE; i++) {


### PR DESCRIPTION
Before this commit, a file's offset was stored into a shared memory location to be accessed and update by both CAPIO client and server. However, this implementation is tricky for implementing read prefetching and write buffering on the client side, because in that setting the two offsets should be different. This commit separates the two values, ensuring that both are kept updated in a coherent way.