### PR TITLE
Added option for injection of debug code

### DIFF
--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -296,6 +296,32 @@ class Logger {
         LOG("error while opening %s", _shm_name.c_str());                                          \
         __SHM_CHECK_CLI_MSG;                                                                       \
     }
+
+/**
+ * This macro is used to inject code into debug mode.
+ * To use, this macro needs a self calling lambda function, that is a lambda
+ * in the following form:
+ *
+ * [](){}()
+ *
+ * For example, a debug code to print a value might be injected in this way:
+ *
+ * int value = 10;
+ * DBG([](int i){printf("%d", i);}(value) );
+ *
+ * This is useful to print or run debug actions with variables defined outside
+ * of the scope of the given lambda function
+ *
+ * Be careful that the code defined inside the DBG macro is not compiled when
+ * building in Release.
+ */
+#define DBG(lambda)                                                                                \
+    {                                                                                              \
+        START_LOG(capio_syscall(SYS_GETTID),                                                       \
+                    "[  DBG  ]~~~~~~~~~~~~ START ~~~~~~~~~~~~~~[  DBG  ]"))                        \
+        lambda;                                                                                    \
+        LOG("[  DBG  ]~~~~~~~~~~~~ END  ~~~~~~~~~~~~~~[  DBG  ]");                                 \
+    }
 #else
 
 #define ERR_EXIT(message, ...) exit(EXIT_FAILURE)
@@ -307,7 +333,7 @@ class Logger {
     if (sem == SEM_FAILED) {                                                                       \
         __SHM_CHECK_CLI_MSG;                                                                       \
     }
-
+#define DBG(lambda)
 #endif
 
 #endif // CAPIO_COMMON_LOGGER_HPP


### PR DESCRIPTION
Thic pr adds the option to inject lambda functions to debug at runtime the CAPIO code.

The new define DBG macro requires a lambda function in the form of `[](){}()` so that parameters can be passed to it without the need of variadic functions. This macro includes the lambda function only when compiling in Debug and lefts out the lambda when compiling in Release