### PR TITLE
Refactor of queue read/write fragmentation

### DIFF
--- a/src/posix/handlers/lseek.hpp
+++ b/src/posix/handlers/lseek.hpp
@@ -12,38 +12,49 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
     if (exists_capio_fd(fd)) {
         off64_t file_offset = get_capio_fd_offset(fd);
         if (whence == SEEK_SET) {
+            LOG("whence %d is SEEK_SET", whence);
             if (offset >= 0) {
                 set_capio_fd_offset(fd, offset);
                 seek_request(fd, offset, tid);
+                LOG("the new offset of file %d is %ld", fd, offset);
                 return offset;
             } else {
                 errno = EINVAL;
                 return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else if (whence == SEEK_CUR) {
+            LOG("whence %d is SEEK_CUR", whence);
             off64_t new_offset = file_offset + offset;
             if (new_offset >= 0) {
                 set_capio_fd_offset(fd, new_offset);
                 seek_request(fd, new_offset, tid);
+                LOG("the new offset of file %d is %ld", fd, new_offset);
                 return new_offset;
             } else {
                 errno = EINVAL;
                 return CAPIO_POSIX_SYSCALL_ERRNO;
             }
         } else if (whence == SEEK_END) {
+            LOG("whence %d is SEEK_END", whence);
             seek_end_request(fd, tid);
             off64_t new_offset = file_offset + offset;
             set_capio_fd_offset(fd, new_offset);
+            LOG("the new offset of file %d is %ld", fd, new_offset);
             return new_offset;
         } else if (whence == SEEK_DATA) {
+            LOG("whence %d is SEEK_DATA", whence);
             off64_t new_offset = seek_data_request(fd, file_offset, tid);
             set_capio_fd_offset(fd, new_offset);
+            LOG("the new offset of file %d is %ld", fd, new_offset);
             return new_offset;
         } else if (whence == SEEK_HOLE) {
+            LOG("whence %d is SEEK_HOLE", whence);
             off64_t new_offset = seek_hole_request(fd, file_offset, tid);
             set_capio_fd_offset(fd, new_offset);
+            LOG("the new offset of file %d is %ld", fd, new_offset);
             return new_offset;
         } else {
+            LOG("whence %d is invalid", whence);
             errno = EINVAL;
             return CAPIO_POSIX_SYSCALL_ERRNO;
         }

--- a/src/posix/handlers/read.hpp
+++ b/src/posix/handlers/read.hpp
@@ -5,16 +5,15 @@
 
 #include "utils/data.hpp"
 
-inline ssize_t capio_read(int fd, const void *buffer, off64_t count, long tid) {
+inline ssize_t capio_read(int fd, void *buffer, off64_t count, long tid) {
     START_LOG(tid, "call(fd=%d, buf=0x%08x, count=%ld)", fd, buffer, count);
 
     if (exists_capio_fd(fd)) {
         if (count >= SSIZE_MAX) {
             ERR_EXIT("CAPIO does not support read bigger than SSIZE_MAX yet");
         }
-        off64_t count_off   = count;
         off64_t offset      = get_capio_fd_offset(fd);
-        off64_t end_of_read = read_request(fd, count_off, tid);
+        off64_t end_of_read = read_request(fd, count, tid);
         off64_t bytes_read  = end_of_read - offset;
         read_data(tid, buffer, bytes_read);
         set_capio_fd_offset(fd, offset + bytes_read);

--- a/src/posix/handlers/write.hpp
+++ b/src/posix/handlers/write.hpp
@@ -14,8 +14,7 @@ inline ssize_t capio_write(int fd, const void *buffer, off64_t count, long tid) 
             ERR_EXIT("Capio does not support writes bigger than "
                      "SSIZE_MAX yet");
         }
-        off64_t count_off = count;
-        write_request(fd, count_off, tid);
+        write_request(fd, count, tid);
         write_data(tid, buffer, count);
 
         return count;

--- a/src/posix/utils/data.hpp
+++ b/src/posix/utils/data.hpp
@@ -33,21 +33,10 @@ inline void register_data_listener(long tid) {
  * @param count
  * @return
  */
-inline void read_data(long tid, const void *buffer, off64_t count) {
+inline void read_data(long tid, void *buffer, off64_t count) {
     START_LOG(tid, "call(buffer=0x%08x, count=%ld)", buffer, count);
-    auto data_buf  = threads_data_bufs->at(tid).second;
-    size_t n_reads = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    size_t r       = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    size_t i       = 0;
-    while (i < n_reads) {
-        LOG("READING %ld bytes from queue", CAPIO_DATA_BUFFER_ELEMENT_SIZE);
-        data_buf->read((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
-        ++i;
-    }
-    if (r) {
-        LOG("READING %ld bytes from queue", r);
-        data_buf->read((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
-    }
+
+    threads_data_bufs->at(tid).second->read(reinterpret_cast<char *>(buffer), count);
 }
 
 /**
@@ -59,18 +48,8 @@ inline void read_data(long tid, const void *buffer, off64_t count) {
  */
 inline void write_data(long tid, const void *buffer, off64_t count) {
     START_LOG(tid, "call(buffer=0x%08x, count=%ld)", buffer, count);
-    auto data_buf   = threads_data_bufs->at(tid).first;
-    size_t n_writes = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    size_t r        = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
 
-    size_t i = 0;
-    while (i < n_writes) {
-        data_buf->write((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
-        ++i;
-    }
-    if (r) {
-        data_buf->write((char *) buffer + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
-    }
+    threads_data_bufs->at(tid).first->write(reinterpret_cast<const char *>(buffer), count);
 }
 
 #endif // CAPIO_POSIX_UTILS_DATA_HPP

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -8,7 +8,7 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count) {
     START_LOG(gettid(), "call(tid=%d, fd=%d, base_offset=%ld, count=%ld)", tid, fd, base_offset,
               count);
     // check if another process is waiting for this data
-    off64_t end_of_read               = base_offset + count;
+    off64_t end_of_write              = base_offset + count;
     const std::filesystem::path &path = get_capio_file_path(tid, fd);
     CapioFile &c_file                 = get_capio_file(path);
     size_t file_shm_size              = c_file.get_buf_size();
@@ -17,19 +17,14 @@ inline void handle_write(int tid, int fd, off64_t base_offset, off64_t count) {
     off64_t r                         = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
 
     c_file.create_buffer_if_needed(path, true);
-    if (end_of_read > file_shm_size) {
-        c_file.expand_buffer(end_of_read);
+    if (end_of_write > file_shm_size) {
+        c_file.expand_buffer(end_of_write);
     }
-    for (int i = 0; i < n_reads; i++) {
-        c_file.read_from_queue(*data_buf, base_offset + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
-    }
-    if (r) {
-        c_file.read_from_queue(*data_buf, base_offset + n_reads * CAPIO_DATA_BUFFER_ELEMENT_SIZE,
-                               r);
-    }
+    c_file.read_from_queue(*data_buf, base_offset, count);
+
     int pid            = pids[tid];
     writers[pid][path] = true;
-    c_file.insert_sector(base_offset, end_of_read);
+    c_file.insert_sector(base_offset, end_of_write);
     if (c_file.first_write) {
         c_file.first_write = false;
         write_file_location(path);

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -14,17 +14,7 @@ void send_data_to_client(int tid, char *buf, off64_t offset, off64_t count) {
     START_LOG(gettid(), "call(tid=%d,buf=0x%08x, offset=%ld, count=%ld)", tid, buf, offset, count);
 
     write_response(tid, offset + count);
-    auto *data_buf  = data_buffers[tid].second;
-    size_t n_writes = count / CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    size_t r        = count % CAPIO_DATA_BUFFER_ELEMENT_SIZE;
-    size_t i        = 0;
-    while (i < n_writes) {
-        data_buf->write(buf + offset + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE);
-        ++i;
-    }
-    if (r) {
-        data_buf->write(buf + offset + i * CAPIO_DATA_BUFFER_ELEMENT_SIZE, r);
-    }
+    data_buffers[tid].second->write(buf + offset, count);
 }
 
 inline off64_t send_dirent_to_client(int tid, CapioFile &c_file, off64_t offset, off64_t count) {


### PR DESCRIPTION
This commit moves the read/write fragmentation inside the `Queue` class, as it is very implementation-dependent. This simplifies the code, avoiding redundant code duplication in client and server.