### PR TITLE
Reduced request buffer sizes

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -12,14 +12,14 @@ concurrency:
 jobs:
   codespell-check:
     name: "Check codespell conformance"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: "Run codespell"
         uses: codespell-project/actions-codespell@v2
   docker-check:
     name: "Check Docker image"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         cmake-build-type:
@@ -72,7 +72,7 @@ jobs:
               --gtest_print_time=1
   format-check:
     name: "Check ${{ matrix.path }} clang-format conformance"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         path:
@@ -87,7 +87,7 @@ jobs:
           check-path: "${{ matrix.path }}"
   unit-tests:
     name: "Build ${{ matrix.build_type }} with ${{ matrix.cxx }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         build_type:

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -12,14 +12,14 @@ concurrency:
 jobs:
   codespell-check:
     name: "Check codespell conformance"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: "Run codespell"
         uses: codespell-project/actions-codespell@v2
   docker-check:
     name: "Check Docker image"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         cmake-build-type:
@@ -72,7 +72,7 @@ jobs:
               --gtest_print_time=1
   format-check:
     name: "Check ${{ matrix.path }} clang-format conformance"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         path:
@@ -87,7 +87,7 @@ jobs:
           check-path: "${{ matrix.path }}"
   unit-tests:
     name: "Build ${{ matrix.build_type }} with ${{ matrix.cxx }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build_type:

--- a/src/common/capio/constants.hpp
+++ b/src/common/capio/constants.hpp
@@ -23,10 +23,11 @@ constexpr char CAPIO_SHM_CANARY_ERROR[] =
     "is already running. Clean shared memory and then retry";
 
 // CAPIO communication constants
+constexpr int CAPIO_REQ_BUFF_CNT                     = 512; // Max number of elements inside buffers
 constexpr int CAPIO_CACHE_LINES_DEFAULT              = 10;
 constexpr int CAPIO_CACHE_LINE_SIZE_DEFAULT          = 256 * 1024;
 constexpr size_t CAPIO_SERVER_REQUEST_MAX_SIZE       = sizeof(char) * (PATH_MAX + 81920);
-constexpr size_t CAPIO_REQUEST_MAX_SIZE              = 256 * sizeof(char);
+constexpr size_t CAPIO_REQ_MAX_SIZE                  = 256 * sizeof(char);
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER[]         = "[ \033[1;32m SERVER \033[0m ] ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER_WARNING[] = "[ \033[1;33m SERVER \033[0m ] ";
 constexpr char CAPIO_SERVER_CLI_LOG_SERVER_ERROR[]   = "[ \033[1;31m SERVER \033[0m ] ";
@@ -66,7 +67,7 @@ constexpr char SHM_SPSC_PREFIX_WRITE[] = "capio_write_tid_";
 constexpr char SHM_SPSC_PREFIX_READ[]  = "capio_read_tid_";
 
 // CAPIO common - shared channel by client and server
-constexpr char SHM_COMM_CHAN_NAME_REQ[]  = "request_buffer";
+constexpr char SHM_COMM_CHAN_NAME[]      = "request_buffer";
 constexpr char SHM_COMM_CHAN_NAME_RESP[] = "response_buffer_";
 
 // CAPIO logger - shm errors

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -15,9 +15,9 @@ CPBufResponse_t *bufs_response;
  * @return
  */
 inline void init_client() {
-    // TODO: replace number with constexpr
+
     buf_requests =
-        new CircularBuffer<char>(SHM_COMM_CHAN_NAME_REQ, 1024 * 1024, CAPIO_REQUEST_MAX_SIZE);
+        new CircularBuffer<char>(SHM_COMM_CHAN_NAME, CAPIO_REQ_BUFF_CNT, CAPIO_REQ_MAX_SIZE);
     bufs_response = new CPBufResponse_t();
 }
 
@@ -29,45 +29,45 @@ inline void init_client() {
 inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
     auto *p_buf_response = new CircularBuffer<off_t>(SHM_COMM_CHAN_NAME_RESP + std::to_string(tid),
-                                                     8 * 1024 * 1024, sizeof(off_t));
+                                                     CAPIO_REQ_BUFF_CNT, sizeof(off_t));
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 
 inline off64_t access_request(const std::filesystem::path &path, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_ACCESS, tid, path.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline void clone_request(const long parent_tid, const long child_tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d  %ld %ld", CAPIO_REQUEST_CLONE, parent_tid, child_tid);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void close_request(const int fd, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_CLOSE, tid, fd);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline off64_t rename_request(const long tid, const std::filesystem::path &old_path,
                               const std::filesystem::path &newpath) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %s %s %ld", CAPIO_REQUEST_RENAME, old_path.c_str(), newpath.c_str(), tid);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline off64_t create_request(const int fd, const std::filesystem::path &path, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE, tid, fd, path.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
@@ -75,52 +75,52 @@ inline off64_t create_request(const int fd, const std::filesystem::path &path, c
 
 inline off64_t create_exclusive_request(const int fd, const std::filesystem::path &path,
                                         const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE_EXCLUSIVE, tid, fd, path.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline void dup_request(const int old_fd, const int new_fd, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %d", CAPIO_REQUEST_DUP, tid, old_fd, new_fd);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void exit_group_request(const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld", CAPIO_REQUEST_EXIT_GROUP, tid);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline off64_t getdents_request(const int fd, const off64_t count, bool is64bit, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", is64bit ? CAPIO_REQUEST_GETDENTS64 : CAPIO_REQUEST_GETDENTS,
             tid, fd, count);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline void handshake_anonymous_request(const long tid, const long pid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %ld", CAPIO_REQUEST_HANDSHAKE_ANONYMOUS, tid, pid);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void handshake_named_request(const long tid, const long pid, const std::string &app_name) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %ld %s", CAPIO_REQUEST_HANDSHAKE_NAMED, tid, pid, app_name.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline CPStatResponse_t fstat_request(const int fd, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_FSTAT, tid, fd);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     // FIXME: these two reads don't work in multithreading
     off64_t file_size;
     bufs_response->at(tid)->read(&file_size);
@@ -130,27 +130,27 @@ inline CPStatResponse_t fstat_request(const int fd, const long tid) {
 }
 
 inline off64_t mkdir_request(const std::filesystem::path &path, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_MKDIR, tid, path.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline off64_t open_request(const int fd, const std::filesystem::path &path, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_OPEN, tid, fd, path.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline off64_t read_request(const int fd, const off64_t count, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", CAPIO_REQUEST_READ, tid, fd, count);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
@@ -158,27 +158,27 @@ inline off64_t read_request(const int fd, const off64_t count, const long tid) {
 
 inline off64_t rename_request(const std::filesystem::path &oldpath,
                               const std::filesystem::path &newpath, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %s %s %ld", CAPIO_REQUEST_RENAME, oldpath.c_str(), newpath.c_str(), tid);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline off64_t seek_data_request(const int fd, const off64_t offset, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK_DATA, tid, fd, offset);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline off64_t seek_end_request(const int fd, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_SEEK_END, tid, fd);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res, is_dir;
     bufs_response->at(tid)->read(&res);
     bufs_response->at(tid)->read(&is_dir);
@@ -186,18 +186,18 @@ inline off64_t seek_end_request(const int fd, const long tid) {
 }
 
 inline off64_t seek_hole_request(const int fd, const off64_t offset, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK_HOLE, tid, fd, offset);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline off64_t seek_request(const int fd, const off64_t offset, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK, tid, fd, offset);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
@@ -205,9 +205,9 @@ inline off64_t seek_request(const int fd, const off64_t offset, const long tid) 
 
 inline CPStatResponse_t stat_request(const std::filesystem::path &path, const long tid) {
     START_LOG(tid, "call(path=%s)", path.c_str());
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_STAT, tid, path.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t file_size;
     bufs_response->at(tid)->read(&file_size);
     off64_t is_dir;
@@ -218,27 +218,27 @@ inline CPStatResponse_t stat_request(const std::filesystem::path &path, const lo
 }
 
 inline off64_t unlink_request(const std::filesystem::path &path, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_UNLINK, tid, path.c_str());
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline off64_t rmdir_request(const std::filesystem::path &dir_path, long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %s %ld", CAPIO_REQUEST_RMDIR, dir_path.c_str(), tid);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
     return res;
 }
 
 inline void write_request(const int fd, const off64_t count, const long tid) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", CAPIO_REQUEST_WRITE, tid, fd, count);
-    buf_requests->write(req, CAPIO_REQUEST_MAX_SIZE);
+    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 #endif // CAPIO_POSIX_UTILS_REQUESTS_HPP

--- a/src/server/capio_server.cpp
+++ b/src/server/capio_server.cpp
@@ -117,7 +117,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
 
     internal_server_sem.unlock();
 
-    auto str = std::unique_ptr<char[]>(new char[CAPIO_REQUEST_MAX_SIZE]);
+    auto str = std::unique_ptr<char[]>(new char[CAPIO_REQ_MAX_SIZE]);
     while (true) {
         LOG(CAPIO_LOG_SERVER_REQUEST_START);
         int code = read_next_request(str.get());

--- a/src/server/utils/requests.hpp
+++ b/src/server/utils/requests.hpp
@@ -14,8 +14,7 @@ CSBufResponse_t *bufs_response;
  * @return
  */
 inline void init_server() {
-    // TODO: replace number with constexpr
-    buf_requests  = new CSBufRequest_t(SHM_COMM_CHAN_NAME_REQ, 1024 * 1024, CAPIO_REQUEST_MAX_SIZE,
+    buf_requests  = new CSBufRequest_t(SHM_COMM_CHAN_NAME, CAPIO_REQ_BUFF_CNT, CAPIO_REQ_MAX_SIZE,
                                        workflow_name);
     bufs_response = new CSBufResponse_t();
 }
@@ -41,8 +40,9 @@ inline void destroy_server() {
  */
 inline void register_listener(long tid) {
     // TODO: replace numbers with constexpr
-    auto *p_buf_response = new CircularBuffer<off_t>(SHM_COMM_CHAN_NAME_RESP + std::to_string(tid),
-                                                     8 * 1024 * 1024, sizeof(off_t), workflow_name);
+    auto *p_buf_response =
+        new CircularBuffer<off_t>(SHM_COMM_CHAN_NAME_RESP + std::to_string(tid), CAPIO_REQ_BUFF_CNT,
+                                  sizeof(off_t), workflow_name);
     bufs_response->insert(std::make_pair(tid, p_buf_response));
 }
 
@@ -65,7 +65,7 @@ inline void remove_listener(int tid) {
  * @return request code
  */
 inline auto read_next_request(char *str) {
-    char req[CAPIO_REQUEST_MAX_SIZE];
+    char req[CAPIO_REQ_MAX_SIZE];
     buf_requests->read(req);
     START_LOG(gettid(), "call(req=%s)", req);
     int code       = -1;


### PR DESCRIPTION
This commit reduces the amount of items that are pre-allocated inside buffers to a more reasonable number (from `1024 * 1024 * 8` to `512`). This reduces memory usages on compute nodes.