### PR TITLE
Hotfixes on env

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -12,14 +12,14 @@ concurrency:
 jobs:
   codespell-check:
     name: "Check codespell conformance"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: "Run codespell"
         uses: codespell-project/actions-codespell@v2
   docker-check:
     name: "Check Docker image"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         cmake-build-type:
@@ -72,7 +72,7 @@ jobs:
               --gtest_print_time=1
   format-check:
     name: "Check ${{ matrix.path }} clang-format conformance"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         path:
@@ -87,7 +87,7 @@ jobs:
           check-path: "${{ matrix.path }}"
   unit-tests:
     name: "Build ${{ matrix.build_type }} with ${{ matrix.cxx }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         build_type:

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -12,14 +12,14 @@ concurrency:
 jobs:
   codespell-check:
     name: "Check codespell conformance"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: "Run codespell"
         uses: codespell-project/actions-codespell@v2
   docker-check:
     name: "Check Docker image"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         cmake-build-type:
@@ -72,7 +72,7 @@ jobs:
               --gtest_print_time=1
   format-check:
     name: "Check ${{ matrix.path }} clang-format conformance"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         path:
@@ -87,7 +87,7 @@ jobs:
           check-path: "${{ matrix.path }}"
   unit-tests:
     name: "Build ${{ matrix.build_type }} with ${{ matrix.cxx }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build_type:

--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -62,7 +62,6 @@ inline long get_cache_lines() {
         if (value != nullptr) {
             LOG("Getting value from environment variable");
             data_bufs_size = strtol(value, nullptr, 10);
-            free(value);
         } else {
             LOG("Getting default value");
             data_bufs_size = CAPIO_CACHE_LINES_DEFAULT;
@@ -81,7 +80,6 @@ inline long get_cache_line_size() {
         if (value != nullptr) {
             LOG("Getting value from environment variable");
             data_bufs_count = strtol(value, nullptr, 10);
-            free(value);
         } else {
             LOG("Getting default value");
             data_bufs_count = CAPIO_CACHE_LINE_SIZE_DEFAULT;


### PR DESCRIPTION
This commit fixes a regression introduced in `env.hpp`: `free()` on `std::getenv()` shall not be invoked, as the returned pointer is not from an allocated buffer, but it is a pointer to the environment variables.