### PR TITLE
Fixed a problem with handle_read in capio server

### DIFF
--- a/src/common/capio/semaphore.hpp
+++ b/src/common/capio/semaphore.hpp
@@ -54,27 +54,19 @@ class NamedSemaphore {
     }
 
     inline void lock() {
-        START_LOG(capio_syscall(SYS_gettid), "call()");
-
-        LOG(" Acquiring lock on %s", _name.c_str());
+        START_LOG(capio_syscall(SYS_gettid), "call(name=%s)", _name.c_str());
 
         if (sem_wait(_sem) == -1) {
             ERR_EXIT(" unable to acquire %s", _name.c_str());
         }
-
-        LOG(" Acquired lock on %s", _name.c_str());
     }
 
     inline void unlock() {
-        START_LOG(capio_syscall(SYS_gettid), "call()");
-
-        LOG(" Releasing lock on %s", _name.c_str());
+        START_LOG(capio_syscall(SYS_gettid), "call(name=%s)", _name.c_str());
 
         if (sem_post(_sem) == -1) {
             ERR_EXIT(" unable to release %s", _name.c_str());
         }
-
-        LOG(" Released lock on %s", _name.c_str());
     }
 };
 

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -34,6 +34,7 @@ inline void register_listener(long tid) {
 }
 
 inline off64_t access_request(const std::filesystem::path &path, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_ACCESS, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -43,12 +44,15 @@ inline off64_t access_request(const std::filesystem::path &path, const long tid)
 }
 
 inline void clone_request(const long parent_tid, const long child_tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(parent_tid=%ld, child_tid=%ld)", parent_tid,
+              child_tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d  %ld %ld", CAPIO_REQUEST_CLONE, parent_tid, child_tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void close_request(const int fd, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, tid=%ld)", fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_CLOSE, tid, fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -56,6 +60,8 @@ inline void close_request(const int fd, const long tid) {
 
 inline off64_t rename_request(const long tid, const std::filesystem::path &old_path,
                               const std::filesystem::path &newpath) {
+    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld, old_path=%s, new_path=%s)", tid,
+              old_path.c_str(), newpath.c_str());
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %s %s %ld", CAPIO_REQUEST_RENAME, old_path.c_str(), newpath.c_str(), tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -65,6 +71,7 @@ inline off64_t rename_request(const long tid, const std::filesystem::path &old_p
 }
 
 inline off64_t create_request(const int fd, const std::filesystem::path &path, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -75,6 +82,7 @@ inline off64_t create_request(const int fd, const std::filesystem::path &path, c
 
 inline off64_t create_exclusive_request(const int fd, const std::filesystem::path &path,
                                         const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE_EXCLUSIVE, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -84,18 +92,22 @@ inline off64_t create_exclusive_request(const int fd, const std::filesystem::pat
 }
 
 inline void dup_request(const int old_fd, const int new_fd, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(old_fd=%ld, new_fd=%ld, tid)", old_fd, new_fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %d", CAPIO_REQUEST_DUP, tid, old_fd, new_fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void exit_group_request(const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld)", tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld", CAPIO_REQUEST_EXIT_GROUP, tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline off64_t getdents_request(const int fd, const off64_t count, bool is64bit, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, count=%ld, is_64_bit=%s, tid=%ld)", fd,
+              count, is64bit ? "true" : "false", tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", is64bit ? CAPIO_REQUEST_GETDENTS64 : CAPIO_REQUEST_GETDENTS,
             tid, fd, count);
@@ -106,18 +118,22 @@ inline off64_t getdents_request(const int fd, const off64_t count, bool is64bit,
 }
 
 inline void handshake_anonymous_request(const long tid, const long pid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld, pid=%ld)", tid, pid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %ld", CAPIO_REQUEST_HANDSHAKE_ANONYMOUS, tid, pid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void handshake_named_request(const long tid, const long pid, const std::string &app_name) {
+    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld, pid=%ld, app_name=%s)", tid, pid,
+              app_name.c_str());
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %ld %s", CAPIO_REQUEST_HANDSHAKE_NAMED, tid, pid, app_name.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline CPStatResponse_t fstat_request(const int fd, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, tid=%ld)", fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_FSTAT, tid, fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -130,6 +146,7 @@ inline CPStatResponse_t fstat_request(const int fd, const long tid) {
 }
 
 inline off64_t mkdir_request(const std::filesystem::path &path, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_MKDIR, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -139,6 +156,7 @@ inline off64_t mkdir_request(const std::filesystem::path &path, const long tid) 
 }
 
 inline off64_t open_request(const int fd, const std::filesystem::path &path, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_OPEN, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -148,25 +166,19 @@ inline off64_t open_request(const int fd, const std::filesystem::path &path, con
 }
 
 inline off64_t read_request(const int fd, const off64_t count, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, count=%ld, tid=%ld)", fd, count, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", CAPIO_REQUEST_READ, tid, fd, count);
+    LOG("Sending read request %s", req);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
     off64_t res;
     bufs_response->at(tid)->read(&res);
-    return res;
-}
-
-inline off64_t rename_request(const std::filesystem::path &oldpath,
-                              const std::filesystem::path &newpath, const long tid) {
-    char req[CAPIO_REQ_MAX_SIZE];
-    sprintf(req, "%04d %s %s %ld", CAPIO_REQUEST_RENAME, oldpath.c_str(), newpath.c_str(), tid);
-    buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
-    off64_t res;
-    bufs_response->at(tid)->read(&res);
+    LOG("Response to request is %ld", res);
     return res;
 }
 
 inline off64_t seek_data_request(const int fd, const off64_t offset, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK_DATA, tid, fd, offset);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -176,6 +188,7 @@ inline off64_t seek_data_request(const int fd, const off64_t offset, const long 
 }
 
 inline off64_t seek_end_request(const int fd, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, tid=%ld)", fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_SEEK_END, tid, fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -186,6 +199,7 @@ inline off64_t seek_end_request(const int fd, const long tid) {
 }
 
 inline off64_t seek_hole_request(const int fd, const off64_t offset, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK_HOLE, tid, fd, offset);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -195,6 +209,7 @@ inline off64_t seek_hole_request(const int fd, const off64_t offset, const long 
 }
 
 inline off64_t seek_request(const int fd, const off64_t offset, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK, tid, fd, offset);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -204,7 +219,7 @@ inline off64_t seek_request(const int fd, const off64_t offset, const long tid) 
 }
 
 inline CPStatResponse_t stat_request(const std::filesystem::path &path, const long tid) {
-    START_LOG(tid, "call(path=%s)", path.c_str());
+    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_STAT, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -218,6 +233,7 @@ inline CPStatResponse_t stat_request(const std::filesystem::path &path, const lo
 }
 
 inline off64_t unlink_request(const std::filesystem::path &path, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_UNLINK, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -227,6 +243,7 @@ inline off64_t unlink_request(const std::filesystem::path &path, const long tid)
 }
 
 inline off64_t rmdir_request(const std::filesystem::path &dir_path, long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(dir_path=%s, tid=%ld)", dir_path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %s %ld", CAPIO_REQUEST_RMDIR, dir_path.c_str(), tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -236,6 +253,7 @@ inline off64_t rmdir_request(const std::filesystem::path &dir_path, long tid) {
 }
 
 inline void write_request(const int fd, const off64_t count, const long tid) {
+    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, count=%ld, tid=%ld)", fd, count, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", CAPIO_REQUEST_WRITE, tid, fd, count);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);


### PR DESCRIPTION
The following changes are introduced with this PR:
- Added logs to `posix/utils/requests.hpp`
- Removed dangling code from `posix/utils/requests.hpp`
- Fixed a bug in `handle_read` on capio server. This bug resulted in the offset 0 being returned instead of actually returning the expected offset, whenever the requested read was outside of sectors.