### PR TITLE
Changed backend to be proactive in file management

### DIFF
--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -26,7 +26,7 @@ inline void request_remote_getdents(int tid, int fd, off64_t count) {
         send_dirent_to_client(tid, fd, c_file, offset, count);
     } else if (end_of_read <= end_of_sector) {
         LOG("?");
-        c_file.create_buffer_if_needed(path, false);
+        c_file.create_buffer_if_needed(false);
         send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
     } else {
         LOG("Delegating to backend remote read");

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -27,7 +27,7 @@ inline void request_remote_getdents(int tid, int fd, off64_t count) {
     } else if (end_of_read <= end_of_sector) {
         LOG("?");
         c_file.create_buffer_if_needed(path, false);
-        send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
+        send_data_to_client(tid, fd, c_file.read(offset, count), offset, count);
     } else {
         LOG("Delegating to backend remote read");
         handle_remote_read_request(tid, fd, count, true);

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -26,8 +26,8 @@ inline void request_remote_getdents(int tid, int fd, off64_t count) {
         send_dirent_to_client(tid, fd, c_file, offset, count);
     } else if (end_of_read <= end_of_sector) {
         LOG("?");
-        c_file.create_buffer_if_needed(false);
-        send_data_to_client(tid, fd, c_file.read(offset, count), offset, count);
+        c_file.create_buffer_if_needed(path, false);
+        send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
     } else {
         LOG("Delegating to backend remote read");
         handle_remote_read_request(tid, fd, count, true);

--- a/src/server/handlers/getdents.hpp
+++ b/src/server/handlers/getdents.hpp
@@ -26,7 +26,7 @@ inline void request_remote_getdents(int tid, int fd, off64_t count) {
         send_dirent_to_client(tid, fd, c_file, offset, count);
     } else if (end_of_read <= end_of_sector) {
         LOG("?");
-        c_file.create_buffer_if_needed(path, false);
+        c_file.create_buffer_if_needed(false);
         send_data_to_client(tid, fd, c_file.read(offset, count), offset, count);
     } else {
         LOG("Delegating to backend remote read");

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -29,7 +29,7 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
         bytes_read = end_of_sector - process_offset;
     }
 
-    c_file.create_buffer_if_needed(path, false);
+    c_file.create_buffer_if_needed(false);
     send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, bytes_read);
 
     // TODO: check if the file was moved to the disk
@@ -74,12 +74,12 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool is_prod) {
                 write_response(tid, process_offset);
                 return;
             }
-            c_file.create_buffer_if_needed(path, false);
+            c_file.create_buffer_if_needed(false);
             send_data_to_client(tid, fd, c_file.get_buffer(), process_offset,
                                 end_of_sector - process_offset);
         }
     } else {
-        c_file.create_buffer_if_needed(path, false);
+        c_file.create_buffer_if_needed(false);
         send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, count);
     }
 }
@@ -100,7 +100,7 @@ inline void request_remote_read(int tid, int fd, off64_t count) {
         handle_local_read(tid, fd, count, true);
     } else if (end_of_read <= end_of_sector) {
         LOG("Data is present locally and can be served to client");
-        c_file.create_buffer_if_needed(path, false);
+        c_file.create_buffer_if_needed(false);
         send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
     } else {
         LOG("Delegating to backend remote read");

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -29,7 +29,7 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
         bytes_read = end_of_sector - process_offset;
     }
 
-    c_file.create_buffer_if_needed(path, false);
+    c_file.create_buffer_if_needed(false);
     auto buf = c_file.read(process_offset, bytes_read);
     send_data_to_client(tid, fd, buf, process_offset, bytes_read);
 
@@ -75,12 +75,12 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool is_prod) {
                 write_response(tid, process_offset);
                 return;
             }
-            c_file.create_buffer_if_needed(path, false);
+            c_file.create_buffer_if_needed(false);
             auto buf = c_file.read(process_offset, end_of_sector - process_offset);
             send_data_to_client(tid, fd, buf, process_offset, end_of_sector - process_offset);
         }
     } else {
-        c_file.create_buffer_if_needed(path, false);
+        c_file.create_buffer_if_needed(false);
         send_data_to_client(tid, fd, c_file.read(process_offset, count), process_offset, count);
     }
 }
@@ -101,7 +101,7 @@ inline void request_remote_read(int tid, int fd, off64_t count) {
         handle_local_read(tid, fd, count, true);
     } else if (end_of_read <= end_of_sector) {
         LOG("Data is present locally and can be served to client");
-        c_file.create_buffer_if_needed(path, false);
+        c_file.create_buffer_if_needed(false);
         send_data_to_client(tid, fd, c_file.read(offset, count), offset, count);
     } else {
         LOG("Delegating to backend remote read");

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -30,7 +30,8 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
     }
 
     c_file.create_buffer_if_needed(path, false);
-    send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, bytes_read);
+    auto buf = c_file.read(process_offset, bytes_read);
+    send_data_to_client(tid, fd, buf, process_offset, bytes_read);
 
     // TODO: check if the file was moved to the disk
 }
@@ -75,12 +76,12 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool is_prod) {
                 return;
             }
             c_file.create_buffer_if_needed(path, false);
-            send_data_to_client(tid, fd, c_file.get_buffer(), process_offset,
-                                end_of_sector - process_offset);
+            auto buf = c_file.read(process_offset, end_of_sector - process_offset);
+            send_data_to_client(tid, fd, buf, process_offset, end_of_sector - process_offset);
         }
     } else {
         c_file.create_buffer_if_needed(path, false);
-        send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, count);
+        send_data_to_client(tid, fd, c_file.read(process_offset, count), process_offset, count);
     }
 }
 
@@ -101,7 +102,7 @@ inline void request_remote_read(int tid, int fd, off64_t count) {
     } else if (end_of_read <= end_of_sector) {
         LOG("Data is present locally and can be served to client");
         c_file.create_buffer_if_needed(path, false);
-        send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
+        send_data_to_client(tid, fd, c_file.read(offset, count), offset, count);
     } else {
         LOG("Delegating to backend remote read");
         handle_remote_read_request(tid, fd, count, false);

--- a/src/server/handlers/read.hpp
+++ b/src/server/handlers/read.hpp
@@ -29,9 +29,8 @@ inline void handle_pending_read(int tid, int fd, long int process_offset, long i
         bytes_read = end_of_sector - process_offset;
     }
 
-    c_file.create_buffer_if_needed(false);
-    auto buf = c_file.read(process_offset, bytes_read);
-    send_data_to_client(tid, fd, buf, process_offset, bytes_read);
+    c_file.create_buffer_if_needed(path, false);
+    send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, bytes_read);
 
     // TODO: check if the file was moved to the disk
 }
@@ -75,13 +74,13 @@ inline void handle_local_read(int tid, int fd, off64_t count, bool is_prod) {
                 write_response(tid, process_offset);
                 return;
             }
-            c_file.create_buffer_if_needed(false);
-            auto buf = c_file.read(process_offset, end_of_sector - process_offset);
-            send_data_to_client(tid, fd, buf, process_offset, end_of_sector - process_offset);
+            c_file.create_buffer_if_needed(path, false);
+            send_data_to_client(tid, fd, c_file.get_buffer(), process_offset,
+                                end_of_sector - process_offset);
         }
     } else {
-        c_file.create_buffer_if_needed(false);
-        send_data_to_client(tid, fd, c_file.read(process_offset, count), process_offset, count);
+        c_file.create_buffer_if_needed(path, false);
+        send_data_to_client(tid, fd, c_file.get_buffer(), process_offset, count);
     }
 }
 
@@ -101,8 +100,8 @@ inline void request_remote_read(int tid, int fd, off64_t count) {
         handle_local_read(tid, fd, count, true);
     } else if (end_of_read <= end_of_sector) {
         LOG("Data is present locally and can be served to client");
-        c_file.create_buffer_if_needed(false);
-        send_data_to_client(tid, fd, c_file.read(offset, count), offset, count);
+        c_file.create_buffer_if_needed(path, false);
+        send_data_to_client(tid, fd, c_file.get_buffer(), offset, count);
     } else {
         LOG("Delegating to backend remote read");
         handle_remote_read_request(tid, fd, count, false);

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -74,7 +74,7 @@ inline void reply_stat(int tid, const std::filesystem::path &path) {
     } else {
         LOG("Delegating backend to reply to remote stats");
         // send a request for file. then start a thread to wait for the request completion
-        c_file.create_buffer_if_needed(path, false);
+        c_file.create_buffer_if_needed(false);
         handle_remote_stat_request(tid, path);
     }
 }

--- a/src/server/handlers/stat.hpp
+++ b/src/server/handlers/stat.hpp
@@ -74,7 +74,7 @@ inline void reply_stat(int tid, const std::filesystem::path &path) {
     } else {
         LOG("Delegating backend to reply to remote stats");
         // send a request for file. then start a thread to wait for the request completion
-        c_file.create_buffer_if_needed(false);
+        c_file.create_buffer_if_needed(path, false);
         handle_remote_stat_request(tid, path);
     }
 }

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -19,7 +19,7 @@ void write_handler(const char *const str) {
     off64_t file_shm_size             = c_file.get_buf_size();
     auto *data_buf                    = data_buffers[tid].first;
 
-    c_file.create_buffer_if_needed(path, false);
+    c_file.create_buffer_if_needed(false);
     if (end_of_write > file_shm_size) {
         c_file.expand_buffer(end_of_write);
     }

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -19,7 +19,7 @@ void write_handler(const char *const str) {
     off64_t file_shm_size             = c_file.get_buf_size();
     auto *data_buf                    = data_buffers[tid].first;
 
-    c_file.create_buffer_if_needed(true);
+    c_file.create_buffer_if_needed(path, false);
     if (end_of_write > file_shm_size) {
         c_file.expand_buffer(end_of_write);
     }

--- a/src/server/handlers/write.hpp
+++ b/src/server/handlers/write.hpp
@@ -19,7 +19,7 @@ void write_handler(const char *const str) {
     off64_t file_shm_size             = c_file.get_buf_size();
     auto *data_buf                    = data_buffers[tid].first;
 
-    c_file.create_buffer_if_needed(path, true);
+    c_file.create_buffer_if_needed(true);
     if (end_of_write > file_shm_size) {
         c_file.expand_buffer(end_of_write);
     }

--- a/src/server/remote/backend.hpp
+++ b/src/server/remote/backend.hpp
@@ -43,6 +43,8 @@ class RemoteRequest {
  */
 class Backend {
   public:
+    enum backendActions { writeFile, readFile };
+
     virtual ~Backend() = default;
 
     /**
@@ -85,6 +87,33 @@ class Backend {
      * @param target
      */
     virtual void send_request(const char *message, int message_len, const std::string &target) = 0;
+
+    /**
+     * This method is used to notify the backend that a local action has occurred
+     *
+     * @param actions The action that has occurred
+     * @param buffer The buffer to which action applies
+     * @param buffer_size The size of @param buffer
+     * @return 0 if nothing happens, or the method is not implemented, 1 if the
+     * action has been registered, -1 on error
+     */
+    virtual int notify_backend(enum backendActions actions, void *buffer, ssize_t buffer_size) {
+        START_LOG(gettid(), "call()");
+        return 0;
+    };
+
+    /**
+     * Get the backend name
+     * @return a null terminated pointer to char handlede by the capio backend. as such,
+     * no free, or delete operator shall be called on that pointer
+     */
+    virtual std::string &backend_name() = 0;
+
+    /**
+     * Let CAPIO server know if backend stores the files inside the memory of a nod or not
+     * @return
+     */
+    virtual bool store_file_in_memory() { return true; };
 };
 
 Backend *backend;

--- a/src/server/remote/backend.hpp
+++ b/src/server/remote/backend.hpp
@@ -97,17 +97,11 @@ class Backend {
      * @return 0 if nothing happens, or the method is not implemented, 1 if the
      * action has been registered, -1 on error
      */
-    virtual int notify_backend(enum backendActions actions, void *buffer, ssize_t buffer_size) {
+    virtual int notify_backend(enum backendActions actions, const std::filesystem::path &file_path,
+                               void *buffer, size_t offset, size_t buffer_size) {
         START_LOG(gettid(), "call()");
         return 0;
     };
-
-    /**
-     * Get the backend name
-     * @return a null terminated pointer to char handlede by the capio backend. as such,
-     * no free, or delete operator shall be called on that pointer
-     */
-    virtual std::string &backend_name() = 0;
 
     /**
      * Let CAPIO server know if backend stores the files inside the memory of a nod or not

--- a/src/server/remote/backend/mpi.hpp
+++ b/src/server/remote/backend/mpi.hpp
@@ -9,8 +9,7 @@ class MPIBackend : public Backend {
 
   protected:
     MPI_Request req{};
-    int rank                  = -1;
-    std::string _backend_name = "mpi";
+    int rank = -1;
 
     /*
      * This structure holds inside the information to convert from hostname to MPI rank*/
@@ -46,7 +45,6 @@ class MPIBackend : public Backend {
         MPI_Finalize();
     }
 
-    inline std::string &backend_name() override { return _backend_name; }
     inline bool store_file_in_memory() override { return true; }
 
     inline const std::set<std::string> get_nodes() override { return nodes; }
@@ -143,9 +141,6 @@ class MPIBackend : public Backend {
 };
 
 class MPISYNCBackend : public MPIBackend {
-  private:
-    std::string _backend_name = "mpifs";
-
   public:
     MPISYNCBackend(int argc, char *argv[]) : MPIBackend(argc, argv) {
         START_LOG(gettid(), "call()");
@@ -156,8 +151,6 @@ class MPISYNCBackend : public MPIBackend {
         START_LOG(gettid(), "Call()");
         MPI_Finalize();
     }
-
-    inline std::string &backend_name() override { return _backend_name; }
 
     RemoteRequest read_next_request() override {
         START_LOG(gettid(), "call()");

--- a/src/server/remote/backend/mpi.hpp
+++ b/src/server/remote/backend/mpi.hpp
@@ -9,7 +9,8 @@ class MPIBackend : public Backend {
 
   protected:
     MPI_Request req{};
-    int rank = -1;
+    int rank                  = -1;
+    std::string _backend_name = "mpi";
 
     /*
      * This structure holds inside the information to convert from hostname to MPI rank*/
@@ -44,6 +45,9 @@ class MPIBackend : public Backend {
         START_LOG(gettid(), "Call()");
         MPI_Finalize();
     }
+
+    inline std::string &backend_name() override { return _backend_name; }
+    inline bool store_file_in_memory() override { return true; }
 
     inline const std::set<std::string> get_nodes() override { return nodes; }
 
@@ -139,6 +143,9 @@ class MPIBackend : public Backend {
 };
 
 class MPISYNCBackend : public MPIBackend {
+  private:
+    std::string _backend_name = "mpifs";
+
   public:
     MPISYNCBackend(int argc, char *argv[]) : MPIBackend(argc, argv) {
         START_LOG(gettid(), "call()");
@@ -149,6 +156,8 @@ class MPISYNCBackend : public MPIBackend {
         START_LOG(gettid(), "Call()");
         MPI_Finalize();
     }
+
+    inline std::string &backend_name() override { return _backend_name; }
 
     RemoteRequest read_next_request() override {
         START_LOG(gettid(), "call()");

--- a/src/server/remote/handlers/read.hpp
+++ b/src/server/remote/handlers/read.hpp
@@ -81,7 +81,7 @@ inline void handle_read_reply(int tid, int fd, long count, off64_t file_size, of
     c_file.set_complete(complete);
 
     off64_t end_of_sector = c_file.get_sector_end(offset);
-    c_file.create_buffer_if_needed(path, false);
+    c_file.create_buffer_if_needed(false);
     off64_t bytes_read;
     off64_t end_of_read = offset + count;
     if (end_of_sector > end_of_read) {
@@ -183,7 +183,7 @@ handle_remote_read_batch_reply(const std::string &source, int tid, int fd, off64
         auto c_file_opt = get_capio_file_opt(path);
         if (c_file_opt) {
             CapioFile &c_file = c_file_opt->get();
-            c_file.create_buffer_if_needed(path, false);
+            c_file.create_buffer_if_needed(false);
             size_t file_shm_size = c_file.get_buf_size();
             if (nbytes > file_shm_size) {
                 c_file.expand_buffer(nbytes);
@@ -233,7 +233,7 @@ inline void handle_remote_read_reply(const std::string &source, int tid, int fd,
     off64_t offset                    = get_capio_file_offset(tid, fd);
     CapioFile &c_file                 = get_capio_file(path);
 
-    c_file.create_buffer_if_needed(path, false);
+    c_file.create_buffer_if_needed(false);
     if (nbytes != 0) {
         auto file_shm_size  = c_file.get_buf_size();
         auto file_size_recv = offset + nbytes;

--- a/src/server/remote/handlers/read.hpp
+++ b/src/server/remote/handlers/read.hpp
@@ -81,7 +81,7 @@ inline void handle_read_reply(int tid, int fd, long count, off64_t file_size, of
     c_file.set_complete(complete);
 
     off64_t end_of_sector = c_file.get_sector_end(offset);
-    c_file.create_buffer_if_needed(path, false);
+    c_file.create_buffer_if_needed(false);
     off64_t bytes_read;
     off64_t end_of_read = offset + count;
     if (end_of_sector > end_of_read) {
@@ -184,7 +184,7 @@ handle_remote_read_batch_reply(const std::string &source, int tid, int fd, off64
         auto c_file_opt = get_capio_file_opt(path);
         if (c_file_opt) {
             CapioFile &c_file = c_file_opt->get();
-            c_file.create_buffer_if_needed(path, false);
+            c_file.create_buffer_if_needed(false);
             size_t file_shm_size = c_file.get_buf_size();
             if (nbytes > file_shm_size) {
                 c_file.expand_buffer(nbytes);
@@ -234,7 +234,7 @@ inline void handle_remote_read_reply(const std::string &source, int tid, int fd,
     off64_t offset                    = get_capio_file_offset(tid, fd);
     CapioFile &c_file                 = get_capio_file(path);
 
-    c_file.create_buffer_if_needed(path, false);
+    c_file.create_buffer_if_needed(false);
     if (nbytes != 0) {
         auto file_shm_size  = c_file.get_buf_size();
         auto file_size_recv = offset + nbytes;

--- a/src/server/remote/handlers/read.hpp
+++ b/src/server/remote/handlers/read.hpp
@@ -27,7 +27,7 @@ inline void serve_remote_read(const std::filesystem::path &path, const std::stri
     // send request
     serve_remote_read_request(tid, fd, count, nbytes, file_size, complete, is_getdents, dest);
     // send data
-    backend->send_file(c_file.get_buffer() + offset, nbytes, dest);
+    backend->send_file(c_file.read(offset, count), nbytes, dest);
 }
 
 std::vector<std::string> *files_available(const std::string &prefix, const std::string &app_name,
@@ -93,7 +93,7 @@ inline void handle_read_reply(int tid, int fd, long count, off64_t file_size, of
     if (is_getdents) {
         send_dirent_to_client(tid, fd, c_file, offset, bytes_read);
     } else {
-        send_data_to_client(tid, fd, c_file.get_buffer(), offset, bytes_read);
+        send_data_to_client(tid, fd, c_file.read(offset, bytes_read), offset, bytes_read);
     }
 }
 
@@ -122,7 +122,8 @@ inline void send_files_batch(const std::string &prefix, const std::string &dest,
     for (const std::string &path : *files_to_send) {
         LOG("Sending file %s to target %s", path.c_str(), dest.c_str());
         CapioFile &c_file = get_capio_file(path);
-        backend->send_file(c_file.get_buffer(), c_file.get_stored_size(), dest);
+        backend->send_file(c_file.read(0, c_file.get_stored_size()), c_file.get_stored_size(),
+                           dest);
     }
 }
 

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -281,7 +281,7 @@ class CapioFile {
     inline char *read(ssize_t offset, ssize_t count) {
         START_LOG(gettid(), "call(offset=%ld)", offset);
         if (_store_in_memory) {
-            return _buf;
+            return _buf + offset;
         } else {
             char *buffer = static_cast<char *>(malloc(count));
             backend->notify_backend(Backend::backendActions::readFile, _file_name, buffer, offset,

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -223,7 +223,7 @@ class CapioFile {
      * To be called when a process
      * execute a read or a write syscall
      */
-    void create_buffer(const std::filesystem::path &path, bool home_node) {
+    void create_buffer(bool home_node) {
         START_LOG(gettid(), "call(path=%s, home_node=%s)", _file_name.c_str(),
                   home_node ? "true" : "false");
         if (_store_in_memory) {
@@ -257,9 +257,9 @@ class CapioFile {
         }
     }
 
-    inline void create_buffer_if_needed(const std::filesystem::path &path, bool home_node) {
+    inline void create_buffer_if_needed(bool home_node) {
         if (buf_to_allocate()) {
-            create_buffer(path, home_node);
+            create_buffer(home_node);
         }
     }
 

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -69,34 +69,35 @@ class CapioFile {
         return (it == _sectors.rend()) ? 0 : it->second;
     }
 
-    /*   enum _seek_type { data, hole };
-       off64_t _seek(enum _seek_type type, off64_t offset) const {
-           START_LOG(gettid(), "call(type=%s, offset=%ld)", type == _seek_type::data ? "data" :
-       "hole", offset); if (_store_in_memory) {
+    enum _seek_type { data, hole };
+    off64_t _seek(_seek_type type, off64_t offset) const {
+        START_LOG(gettid(), "call(type=%s, offset=%ld)", type == _seek_type::data ? "data" : "hole",
+                  offset);
+        if (_store_in_memory) {
 
-               if (_sectors.empty()) {
-                   return offset == 0 ? 0 : -1;
-               }
-               auto it = _sectors.upper_bound(std::make_pair(offset, 0));
-               if (it == _sectors.begin()) {
-                   return type == _seek_type::data ? it->first : offset;
-               }
-               --it;
-               if (offset <= it->second) {
-                   return type == _seek_type::data ? offset : it->first;
-               } else {
-                   ++it;
-                   if (it == _sectors.end()) {
-                       return -1;
-                   } else {
-                       return type == _seek_type::data ? it->first : offset;
-                   }
-               }
-           } else {
-               // TODO: Implement this
-               return -1;
-           }
-       }*/
+            if (_sectors.empty()) {
+                return offset == 0 ? 0 : -1;
+            }
+            auto it = _sectors.upper_bound(std::make_pair(offset, 0));
+            if (it == _sectors.begin()) {
+                return type == _seek_type::data ? it->first : offset;
+            }
+            --it;
+            if (offset <= it->second) {
+                return type == _seek_type::data ? offset : it->first;
+            } else {
+                ++it;
+                if (it == _sectors.end()) {
+                    return -1;
+                } else {
+                    return type == _seek_type::data ? it->first : offset;
+                }
+            }
+        } else {
+            // TODO: Implement this
+            return -1;
+        }
+    }
 
   public:
     bool first_write          = true;
@@ -280,7 +281,7 @@ class CapioFile {
     inline char *read(ssize_t offset, ssize_t count) {
         START_LOG(gettid(), "call(offset=%ld)", offset);
         if (_store_in_memory) {
-            return _buf + offset;
+            return _buf;
         } else {
             char *buffer = static_cast<char *>(malloc(count));
             backend->notify_backend(Backend::backendActions::readFile, _file_name, buffer, offset,
@@ -444,35 +445,7 @@ class CapioFile {
      * containing data. If offset points to data, then the file offset is set to offset. Fails
      * if offset points past the end of the file.
      */
-    [[nodiscard]] off64_t seek_data(off64_t offset) {
-        START_LOG(gettid(), "call(offset=%ld)", offset);
-        if (_store_in_memory) {
-            if (_sectors.empty()) {
-                if (offset == 0) {
-                    return 0;
-                } else {
-                    return -1;
-                }
-            }
-            auto it = _sectors.upper_bound(std::make_pair(offset, 0));
-            if (it == _sectors.begin()) {
-                return it->first;
-            }
-            --it;
-            if (offset <= it->second) {
-                return offset;
-            } else {
-                ++it;
-                if (it == _sectors.end()) {
-                    return -1;
-                } else {
-                    return it->first;
-                }
-            }
-        } else {
-            return -1;
-        }
-    }
+    [[nodiscard]] off64_t seek_data(off64_t offset) { return _seek(_seek_type::data, offset); }
 
     /*
      * From the manual:
@@ -483,33 +456,7 @@ class CapioFile {
      * Fails if offset points past the end of the file.
      */
     [[nodiscard]] off64_t seek_hole(off64_t offset) const {
-        START_LOG(gettid(), "call(offset=%ld)", offset);
-        if (_store_in_memory) {
-            if (_sectors.empty()) {
-                if (offset == 0) {
-                    return 0;
-                } else {
-                    return -1;
-                }
-            }
-            auto it = _sectors.upper_bound(std::make_pair(offset, 0));
-            if (it == _sectors.begin()) {
-                return offset;
-            }
-            --it;
-            if (offset <= it->second) {
-                return it->second;
-            } else {
-                ++it;
-                if (it == _sectors.end()) {
-                    return -1;
-                } else {
-                    return offset;
-                }
-            }
-        } else {
-            return -1;
-        }
+        return _seek(_seek_type::hole, offset);
     }
 
     inline void remove_fd(int tid, int fd) {

--- a/src/server/utils/capio_file.hpp
+++ b/src/server/utils/capio_file.hpp
@@ -223,7 +223,7 @@ class CapioFile {
      * To be called when a process
      * execute a read or a write syscall
      */
-    void create_buffer(bool home_node) {
+    void create_buffer(const std::filesystem::path &path, bool home_node) {
         START_LOG(gettid(), "call(path=%s, home_node=%s)", _file_name.c_str(),
                   home_node ? "true" : "false");
         if (_store_in_memory) {
@@ -257,9 +257,9 @@ class CapioFile {
         }
     }
 
-    inline void create_buffer_if_needed(bool home_node) {
+    inline void create_buffer_if_needed(const std::filesystem::path &path, bool home_node) {
         if (buf_to_allocate()) {
-            create_buffer(home_node);
+            create_buffer(path, home_node);
         }
     }
 
@@ -278,14 +278,13 @@ class CapioFile {
         return _buf;
     }
 
-    inline char *read(ssize_t offset, ssize_t count) {
-        START_LOG(gettid(), "call(offset=%ld)", offset);
+    inline char *get_buffer(off64_t offset = 0, ssize_t size = CAPIO_DEFAULT_FILE_INITIAL_SIZE) {
         if (_store_in_memory) {
-            return _buf + offset;
+            return _buf;
         } else {
-            char *buffer = static_cast<char *>(malloc(count));
+            char *buffer = static_cast<char *>(malloc(size));
             backend->notify_backend(Backend::backendActions::readFile, _file_name, buffer, offset,
-                                    count);
+                                    size);
             return buffer;
         }
     }

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -32,6 +32,8 @@ inline off64_t send_dirent_to_client(int tid, int fd, CapioFile &c_file, off64_t
     off64_t actual_size = (last_entry - first_entry) * static_cast<off64_t>(sizeof(linux_dirent64));
     char *incoming      = c_file.read(0, actual_size);
 
+    LOG("Actual size: %ld. Dirent contains %d items", actual_size, last_entry);
+
     if (actual_size > 0) {
         auto dirents = std::unique_ptr<linux_dirent64[]>(new linux_dirent64[actual_size]);
 
@@ -47,8 +49,7 @@ inline off64_t send_dirent_to_client(int tid, int fd, CapioFile &c_file, off64_t
 
             LOG("DIRENT NAME: %s - TARGET NAME: %s", dir_entity->d_name, current_dirent.d_name);
         }
-        auto buf = reinterpret_cast<char *>(dirents.get()) - offset;
-        send_data_to_client(tid, fd, buf, offset, actual_size);
+        send_data_to_client(tid, fd, reinterpret_cast<char *>(dirents.get()), 0, actual_size);
     } else {
         write_response(tid, offset);
     }

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -17,7 +17,7 @@ void send_data_to_client(int tid, int fd, char *buf, off64_t offset, off64_t cou
 
     write_response(tid, offset + count);
     data_buffers[tid].second->write(buf, count);
-    set_capio_file_offset(tid, fd, count);
+    set_capio_file_offset(tid, fd, offset + count);
 }
 
 inline off64_t send_dirent_to_client(int tid, int fd, CapioFile &c_file, off64_t offset,

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -16,7 +16,7 @@ void send_data_to_client(int tid, int fd, char *buf, off64_t offset, off64_t cou
               offset, count);
 
     write_response(tid, offset + count);
-    data_buffers[tid].second->write(buf + offset, count);
+    data_buffers[tid].second->write(buf, count);
     set_capio_file_offset(tid, fd, offset + count);
 }
 
@@ -47,9 +47,8 @@ inline off64_t send_dirent_to_client(int tid, int fd, CapioFile &c_file, off64_t
 
             LOG("DIRENT NAME: %s - TARGET NAME: %s", dir_entity->d_name, current_dirent.d_name);
         }
-
-        send_data_to_client(tid, fd, reinterpret_cast<char *>(dirents.get()) - offset, offset,
-                            actual_size);
+        auto buf = reinterpret_cast<char *>(dirents.get()) - offset;
+        send_data_to_client(tid, fd, buf, offset, actual_size);
     } else {
         write_response(tid, offset);
     }

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -16,8 +16,8 @@ void send_data_to_client(int tid, int fd, char *buf, off64_t offset, off64_t cou
               offset, count);
 
     write_response(tid, offset + count);
-    data_buffers[tid].second->write(buf + offset, count);
-    set_capio_file_offset(tid, fd, offset + count);
+    data_buffers[tid].second->write(buf, count);
+    set_capio_file_offset(tid, fd, count);
 }
 
 inline off64_t send_dirent_to_client(int tid, int fd, CapioFile &c_file, off64_t offset,
@@ -26,11 +26,11 @@ inline off64_t send_dirent_to_client(int tid, int fd, CapioFile &c_file, off64_t
 
     struct linux_dirent64 *dir_entity;
 
-    char *incoming      = c_file.get_buffer();
     int first_entry     = static_cast<int>(offset / sizeof(linux_dirent64));
     off64_t end_of_read = std::min(offset + count, c_file.get_stored_size());
     int last_entry      = static_cast<int>(end_of_read / sizeof(linux_dirent64));
     off64_t actual_size = (last_entry - first_entry) * static_cast<off64_t>(sizeof(linux_dirent64));
+    char *incoming      = c_file.read(0, actual_size);
 
     if (actual_size > 0) {
         auto dirents = std::unique_ptr<linux_dirent64[]>(new linux_dirent64[actual_size]);

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -49,7 +49,7 @@ inline off64_t send_dirent_to_client(int tid, int fd, CapioFile &c_file, off64_t
 
             LOG("DIRENT NAME: %s - TARGET NAME: %s", dir_entity->d_name, current_dirent.d_name);
         }
-        send_data_to_client(tid, fd, reinterpret_cast<char *>(dirents.get()), 0, actual_size);
+        send_data_to_client(tid, fd, reinterpret_cast<char *>(dirents.get()), offset, actual_size);
     } else {
         write_response(tid, offset);
     }

--- a/src/server/utils/common.hpp
+++ b/src/server/utils/common.hpp
@@ -16,7 +16,7 @@ void send_data_to_client(int tid, int fd, char *buf, off64_t offset, off64_t cou
               offset, count);
 
     write_response(tid, offset + count);
-    data_buffers[tid].second->write(buf, count);
+    data_buffers[tid].second->write(buf + offset, count);
     set_capio_file_offset(tid, fd, offset + count);
 }
 

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -42,13 +42,13 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path,
     ld.d_reclen = sizeof(linux_dirent64);
 
     CapioFile &c_file = get_capio_file(dir);
-    c_file.create_buffer_if_needed(true);
+    c_file.create_buffer_if_needed(dir, true);
 
     off64_t file_size    = c_file.get_stored_size();
     off64_t data_size    = file_size + ld.d_reclen;
     size_t file_shm_size = c_file.get_buf_size();
     ld.d_off             = data_size;
-    void *file_shm       = c_file.read(0, file_size);
+    void *file_shm       = c_file.get_buffer();
 
     if (data_size > file_shm_size) {
         file_shm = c_file.expand_buffer(data_size);

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -43,11 +43,12 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path,
 
     CapioFile &c_file = get_capio_file(dir);
     c_file.create_buffer_if_needed(dir, true);
-    void *file_shm       = c_file.get_buffer();
+
     off64_t file_size    = c_file.get_stored_size();
     off64_t data_size    = file_size + ld.d_reclen;
     size_t file_shm_size = c_file.get_buf_size();
     ld.d_off             = data_size;
+    void *file_shm       = c_file.read(0, file_size);
 
     if (data_size > file_shm_size) {
         file_shm = c_file.expand_buffer(data_size);

--- a/src/server/utils/filesystem.hpp
+++ b/src/server/utils/filesystem.hpp
@@ -42,7 +42,7 @@ void write_entry_dir(int tid, const std::filesystem::path &file_path,
     ld.d_reclen = sizeof(linux_dirent64);
 
     CapioFile &c_file = get_capio_file(dir);
-    c_file.create_buffer_if_needed(dir, true);
+    c_file.create_buffer_if_needed(true);
 
     off64_t file_size    = c_file.get_stored_size();
     off64_t data_size    = file_size + ld.d_reclen;

--- a/src/server/utils/metadata.hpp
+++ b/src/server/utils/metadata.hpp
@@ -148,7 +148,7 @@ CapioFile &create_capio_file(const std::filesystem::path &path, bool is_dir, siz
                 init_size = CAPIO_DEFAULT_DIR_INITIAL_SIZE;
                 LOG("Glob %s is a directory", path.c_str());
             }
-            c_file = new CapioFile(is_dir, false, init_size, backend->store_file_in_memory());
+            c_file = new CapioFile(path, is_dir, false, init_size, backend->store_file_in_memory());
             add_capio_file(path, c_file);
         } else {
             LOG("Path %s is found in metadata_conf_globs", path.c_str());
@@ -164,8 +164,8 @@ CapioFile &create_capio_file(const std::filesystem::path &path, bool is_dir, siz
             metadata_conf[path] =
                 std::make_tuple(committed, mode, app_name, n_files, permanent, n_close);
             LOG("Creating new capio_file. committed=%s, mode=%s", committed.c_str(), mode.c_str());
-            c_file = new CapioFile(committed, mode, is_dir, n_files, permanent, init_size, n_close,
-                                   backend->store_file_in_memory());
+            c_file = new CapioFile(path, committed, mode, is_dir, n_files, permanent, init_size,
+                                   n_close, backend->store_file_in_memory());
             add_capio_file(path, c_file);
         }
     } else {
@@ -176,8 +176,8 @@ CapioFile &create_capio_file(const std::filesystem::path &path, bool is_dir, siz
             init_size = CAPIO_DEFAULT_DIR_INITIAL_SIZE;
         }
         LOG("Creating new capio_file. committed=%s, mode=%s", committed.c_str(), mode.c_str());
-        c_file = new CapioFile(committed, mode, is_dir, n_files, permanent, init_size, n_close,
-                               backend->store_file_in_memory());
+        c_file = new CapioFile(path, committed, mode, is_dir, n_files, permanent, init_size,
+                               n_close, backend->store_file_in_memory());
         add_capio_file(path, c_file);
     }
     return *c_file;

--- a/src/server/utils/metadata.hpp
+++ b/src/server/utils/metadata.hpp
@@ -148,7 +148,7 @@ CapioFile &create_capio_file(const std::filesystem::path &path, bool is_dir, siz
                 init_size = CAPIO_DEFAULT_DIR_INITIAL_SIZE;
                 LOG("Glob %s is a directory", path.c_str());
             }
-            c_file = new CapioFile(is_dir, false, init_size);
+            c_file = new CapioFile(is_dir, false, init_size, backend->store_file_in_memory());
             add_capio_file(path, c_file);
         } else {
             LOG("Path %s is found in metadata_conf_globs", path.c_str());
@@ -164,7 +164,8 @@ CapioFile &create_capio_file(const std::filesystem::path &path, bool is_dir, siz
             metadata_conf[path] =
                 std::make_tuple(committed, mode, app_name, n_files, permanent, n_close);
             LOG("Creating new capio_file. committed=%s, mode=%s", committed.c_str(), mode.c_str());
-            c_file = new CapioFile(committed, mode, is_dir, n_files, permanent, init_size, n_close);
+            c_file = new CapioFile(committed, mode, is_dir, n_files, permanent, init_size, n_close,
+                                   backend->store_file_in_memory());
             add_capio_file(path, c_file);
         }
     } else {
@@ -175,7 +176,8 @@ CapioFile &create_capio_file(const std::filesystem::path &path, bool is_dir, siz
             init_size = CAPIO_DEFAULT_DIR_INITIAL_SIZE;
         }
         LOG("Creating new capio_file. committed=%s, mode=%s", committed.c_str(), mode.c_str());
-        c_file = new CapioFile(committed, mode, is_dir, n_files, permanent, init_size, n_close);
+        c_file = new CapioFile(committed, mode, is_dir, n_files, permanent, init_size, n_close,
+                               backend->store_file_in_memory());
         add_capio_file(path, c_file);
     }
     return *c_file;

--- a/src/server/utils/signals.hpp
+++ b/src/server/utils/signals.hpp
@@ -10,10 +10,12 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
               strsignal(signum), info != nullptr ? info->si_pid : -1);
 
     std::cout << std::endl
-              << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "shutting down server" << std::endl;
+              << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+              << "shutting down server" << std::endl;
 
     if (signum == SIGSEGV) {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Segfault detected!" << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "[ " << node_name << " ]"
+                  << "Segfault detected!" << std::endl;
     }
 
     // free all the memory used
@@ -22,19 +24,20 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
             delete_capio_file_from_tid(it.first, fd);
         }
     }
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "shm cleanup completed" << std::endl;
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+              << "shm cleanup completed" << std::endl;
 
     for (auto &p : data_buffers) {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "Deleting data buffer for "
-                  << p.second.first->get_name() << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+                  << "Deleting data buffer for " << p.second.first->get_name() << std::endl;
         delete p.second.first;
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "Deleting data buffer for "
-                  << p.second.second->get_name() << std::endl;
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+                  << "Deleting data buffer for " << p.second.second->get_name() << std::endl;
         delete p.second.second;
     }
 
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "data_buffers cleanup completed"
-              << std::endl;
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+              << "data_buffers cleanup completed" << std::endl;
 
     destroy_server();
 

--- a/src/server/utils/signals.hpp
+++ b/src/server/utils/signals.hpp
@@ -10,11 +10,11 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
               strsignal(signum), info != nullptr ? info->si_pid : -1);
 
     std::cout << std::endl
-              << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+              << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ] "
               << "shutting down server" << std::endl;
 
     if (signum == SIGSEGV) {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "[ " << node_name << " ]"
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "[ " << node_name << " ] "
                   << "Segfault detected!" << std::endl;
     }
 
@@ -24,14 +24,14 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
             delete_capio_file_from_tid(it.first, fd);
         }
     }
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ] "
               << "shm cleanup completed" << std::endl;
 
     for (auto &p : data_buffers) {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ] "
                   << "Deleting data buffer for " << p.second.first->get_name() << std::endl;
         delete p.second.first;
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ]"
+        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "[ " << node_name << " ] "
                   << "Deleting data buffer for " << p.second.second->get_name() << std::endl;
         delete p.second.second;
     }

--- a/tests/unit/server/src/capio_file.cpp
+++ b/tests/unit/server/src/capio_file.cpp
@@ -6,7 +6,7 @@
 #include "utils/capio_file.hpp"
 
 TEST(ServerTest, TestInsertSingleSector) {
-    CapioFile c_file;
+    CapioFile c_file("test");
     c_file.insert_sector(1, 3);
     auto &sectors = c_file.get_sectors();
     EXPECT_EQ(sectors.size(), 1);
@@ -14,7 +14,7 @@ TEST(ServerTest, TestInsertSingleSector) {
 }
 
 TEST(ServerTest, TestInsertTwoNonOverlappingSectors) {
-    CapioFile c_file;
+    CapioFile c_file("test");
     c_file.insert_sector(5, 7);
     c_file.insert_sector(1, 3);
     auto &sectors = c_file.get_sectors();
@@ -26,7 +26,7 @@ TEST(ServerTest, TestInsertTwoNonOverlappingSectors) {
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectors) {
-    CapioFile c_file;
+    CapioFile c_file("test");
     c_file.insert_sector(2, 4);
     c_file.insert_sector(1, 3);
     auto &sectors = c_file.get_sectors();
@@ -35,7 +35,7 @@ TEST(ServerTest, TestInsertTwoOverlappingSectors) {
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectorsSameStart) {
-    CapioFile c_file;
+    CapioFile c_file("test");
     c_file.insert_sector(1, 4);
     c_file.insert_sector(1, 3);
     auto &sectors = c_file.get_sectors();
@@ -44,7 +44,7 @@ TEST(ServerTest, TestInsertTwoOverlappingSectorsSameStart) {
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectorsSameEnd) {
-    CapioFile c_file;
+    CapioFile c_file("test");
     c_file.insert_sector(1, 4);
     c_file.insert_sector(2, 4);
     auto &sectors = c_file.get_sectors();
@@ -53,7 +53,7 @@ TEST(ServerTest, TestInsertTwoOverlappingSectorsSameEnd) {
 }
 
 TEST(ServerTest, TestInsertTwoOverlappingSectorsNested) {
-    CapioFile c_file;
+    CapioFile c_file("test");
     c_file.insert_sector(1, 4);
     c_file.insert_sector(2, 3);
     auto &sectors = c_file.get_sectors();


### PR DESCRIPTION
This commit adds the following changes:
- backend is able to inform whether it requires to store data in memory or not
- capio file uses realloc instead of duplicating memory when expanding buffers
- capio file stores data inside memory only if backend requires to store data in memory
- backend has a new method that is used to notify of a read and/or a write of a capio_file
- capio_file now has the name of the file inside the class