### PR TITLE
Fixes lstat bug on relative path handling

### DIFF
--- a/src/posix/handlers/stat.hpp
+++ b/src/posix/handlers/stat.hpp
@@ -161,7 +161,7 @@ int lstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
     auto *buf = reinterpret_cast<struct stat *>(arg1);
     long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_lstat(pathname, buf, tid), result);
+    return posix_return_value(capio_lstat_wrapper(pathname, buf, tid), result);
 }
 
 int stat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {


### PR DESCRIPTION
Previously the `lstat` handler did not compute absolute paths from its input arguments, as the wrong function was called. In some cases, when a relative path was provided, this behaviour led to issues with path resolution.