### PR TITLE
Fixed issue in the initialization of child threads

### DIFF
--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -142,7 +142,7 @@ inline long long current_time_in_millis() {
 
 inline void log_write_to(char *buffer, size_t bufflen) {
 #ifdef __CAPIO_POSIX
-    if (current_log_level < CAPIO_LOG_LEVEL || CAPIO_LOG_LEVEL < 0) {
+    if (current_log_level < CAPIO_MAX_LOG_LEVEL || CAPIO_MAX_LOG_LEVEL < 0) {
         capio_syscall(SYS_write, logfileFD, buffer, bufflen);
         capio_syscall(SYS_write, logfileFD, "\n", 1);
     }
@@ -172,6 +172,7 @@ class SyscallLoggingSuspender {
  *
  */
 class Logger {
+  private:
     char invoker[256]{0};
     char file[256]{0};
     char format[CAPIO_LOG_MAX_MSG_LEN]{0};
@@ -204,9 +205,8 @@ class Logger {
                 capio_syscall(SYS_write, fileno(stdout), strerror(errno), strlen(strerror(errno)));
                 capio_syscall(SYS_write, fileno(stdout), "\n", 1);
                 exit(EXIT_FAILURE);
-            } else {
-                logfileOpen = true;
             }
+            logfileOpen = true;
         }
 #endif
         strncpy(this->invoker, invoker, sizeof(this->invoker));
@@ -224,8 +224,15 @@ class Logger {
 
 #if defined(CAPIO_LOG) && defined(__CAPIO_POSIX)
         if (current_log_level == 0 && logging_syscall) {
-            int syscallNumber = va_arg(argp, int);
-            auto buf1         = reinterpret_cast<char *>(capio_syscall(
+            int syscallNumber;
+
+            if (strcmp(invoker, "hook_clone_child") == 0) {
+                syscallNumber = SYS_clone;
+            } else {
+                syscallNumber = va_arg(argp, int);
+            }
+
+            auto buf1 = reinterpret_cast<char *>(capio_syscall(
                 SYS_mmap, nullptr, 50, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
             sprintf(buf1, CAPIO_LOG_POSIX_SYSCALL_START, sys_num_to_string(syscallNumber),
                     syscallNumber);

--- a/src/common/capio/logger.hpp
+++ b/src/common/capio/logger.hpp
@@ -142,7 +142,7 @@ inline long long current_time_in_millis() {
 
 inline void log_write_to(char *buffer, size_t bufflen) {
 #ifdef __CAPIO_POSIX
-    if (current_log_level < CAPIO_MAX_LOG_LEVEL || CAPIO_MAX_LOG_LEVEL < 0) {
+    if (current_log_level < CAPIO_LOG_LEVEL || CAPIO_LOG_LEVEL < 0) {
         capio_syscall(SYS_write, logfileFD, buffer, bufflen);
         capio_syscall(SYS_write, logfileFD, "\n", 1);
     }
@@ -172,7 +172,6 @@ class SyscallLoggingSuspender {
  *
  */
 class Logger {
-  private:
     char invoker[256]{0};
     char file[256]{0};
     char format[CAPIO_LOG_MAX_MSG_LEN]{0};

--- a/src/common/capio/semaphore.hpp
+++ b/src/common/capio/semaphore.hpp
@@ -43,8 +43,14 @@ class NamedSemaphore {
         : _name(std::move(name)), _require_cleanup(cleanup) {
         START_LOG(capio_syscall(SYS_gettid), " call(name=%s, init_value=%d, cleanup=%s)",
                   _name.c_str(), init_value, _require_cleanup ? "true" : "false");
-
+#ifdef __CAPIO_POSIX
+        syscall_no_intercept_flag = true;
+#endif
         _sem = sem_open(_name.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR, init_value);
+#ifdef __CAPIO_POSIX
+        syscall_no_intercept_flag = false;
+#endif
+
         if (_sem == SEM_FAILED) {
             ERR_EXIT(" sem_open %s failed", _name.c_str());
         }


### PR DESCRIPTION
 Previusly, when hook_clone_child was called, in the init of the process, some systemcalls were intercepted when they should not have. Now this commit fixes this issue by disabling the interception in the NamedSemaphore class constructor.
