### PR TITLE
Protected access to unordered_map

### DIFF
--- a/src/server/capio-cl-engine/capio_cl_engine.hpp
+++ b/src/server/capio-cl-engine/capio_cl_engine.hpp
@@ -277,8 +277,8 @@ class CapioCLEngine {
 
     void setDirectory(const std::string &path) {
         START_LOG(gettid(), "call(path=%s)", path.c_str());
-        if (_locations.find(path) != _locations.end()) {
-            std::get<6>(_locations.at(path)) = false;
+        if (const auto itm = _locations.find(path); itm != _locations.end()) {
+            std::get<6>(itm->second) = false;
         }
     }
 

--- a/src/server/file-manager/file_manager_impl.hpp
+++ b/src/server/file-manager/file_manager_impl.hpp
@@ -358,7 +358,7 @@ inline void CapioFileManager::checkFileAwaitingData() {
         // and as such, the file already exists
         // actual update, end eventual removal from map is handled by the
         // CapioFileManager class and not by the FileSystemMonitor class
-        CapioFileManager::_unlockThreadAwaitingData(iter->first, iter->second);
+        _unlockThreadAwaitingData(iter->first, iter->second);
 
         // cleanup of map while iterating over it
         if (iter->second.empty()) {

--- a/src/server/storage-service/capio_storage_service.hpp
+++ b/src/server/storage-service/capio_storage_service.hpp
@@ -24,7 +24,6 @@ class CapioStorageService {
     [[nodiscard]] auto getFile(const std::string &file_name) const {
         if (_stored_files->find(file_name) == _stored_files->end()) {
             createFile(file_name);
-            return _stored_files->at(file_name);
         }
         return _stored_files->at(file_name);
     }


### PR DESCRIPTION
This commit protects access to some unordered maps that were previusly not protected, increasing the resilinacy against out_of_bound execptions.