### PR TITLE
Hotfix: metadata other than capio_dir folder

### DIFF
--- a/src/common/capio/env.hpp
+++ b/src/common/capio/env.hpp
@@ -54,6 +54,8 @@ inline const std::filesystem::path &get_capio_metadata_path() {
 
         if (val == nullptr) {
             metadata_path = get_capio_dir() / ".capio_metadata";
+        } else {
+            metadata_path = std::filesystem::path(val) / ".capio_metadata";
         }
 
         if (!std::filesystem::exists(metadata_path)) {


### PR DESCRIPTION
Fixed a missing initialization of metadata_path to provided metadata directory when providing the env variable CAPIO_METADATA_DIR.