### PR TITLE
Performance improvement for data transfer

### DIFF
--- a/src/server/client-manager/handlers/read.hpp
+++ b/src/server/client-manager/handlers/read.hpp
@@ -90,10 +90,12 @@ inline void read_mem_handler(const char *const str) {
         read_begin_offset + size_to_send >= storage_service->sizeOf(path)) {
         LOG("File is committed, and end of read >= than file size."
             " signaling it to posix application by setting offset MSB to 1");
-        size_to_send = 0x8000000000000000 | size_to_send;
+        LOG("Sending offset: %llu", 0x8000000000000000 |size_to_send);
+        client_manager->reply_to_client(tid, 0x8000000000000000 | size_to_send);
+    } else {
+        LOG("File is not committed. Sending offset: %llu", size_to_send);
+        client_manager->reply_to_client(tid, size_to_send);
     }
-    LOG("Sending offset: %llu", size_to_send);
-    client_manager->reply_to_client(tid, size_to_send);
 
     LOG("Need to sent to client %llu bytes, asking storage service to send data", size_to_send);
     storage_service->reply_to_client(tid, path, read_begin_offset, size_to_send);

--- a/src/server/storage-service/CapioFile/CapioMemoryFile.hpp
+++ b/src/server/storage-service/CapioFile/CapioMemoryFile.hpp
@@ -193,11 +193,12 @@ public:
      */
     std::size_t writeToQueue(SPSCQueue &queue, std::size_t offset,
                              std::size_t length) const override {
+        START_LOG(gettid(), "call(offset=%llu, length=%llu)", offset, length);
         std::size_t bytesRead = 0;
 
         while (bytesRead < length) {
             const auto [map_offset,mem_block_offset_begin , buffer_view_size] =
-                compute_offsets(offset, length);
+                compute_offsets(offset, length - bytesRead);
 
             if (const auto it = memoryBlocks.lower_bound(map_offset); it != memoryBlocks.end()) {
                 auto &[blockOffset, block] = *it;
@@ -210,6 +211,7 @@ public:
                 queue.write(block.data() + mem_block_offset_begin, buffer_view_size);
 
                 bytesRead += buffer_view_size;
+                offset += buffer_view_size;
             }
         }
         return bytesRead;


### PR DESCRIPTION
Since caches are used to improve performance for small size IO
operation, when a read() operation that targets a size greater than the
size of the read cache line size is issued, the cache is being bypassed
and the read operation occurs directly from the shared memory segment.