### PR TITLE
Began working on adding DIR futures

### DIFF
--- a/src/common/capio/filesystem.hpp
+++ b/src/common/capio/filesystem.hpp
@@ -106,7 +106,7 @@ inline bool is_capio_path(const std::filesystem::path &path_to_check) {
     START_LOG(gettid(), "call(capio_path=%s)", capio_path.c_str());
     auto computed = replaceSymbol(capio_path, '.', "\\.");
     computed      = replaceSymbol(computed, '/', "\\/");
-    computed      = replaceSymbol(computed, '*', R"([a-zA-Z0-9\/\.\-_]*)");
+    computed      = replaceSymbol(computed, '*', R"([a-zA-Z0-9\/\.\-_:]*)");
     computed      = replaceSymbol(computed, '+', ".");
     LOG("Computed regex: %s", computed.c_str());
     return std::regex(computed);

--- a/src/common/capio/requests.hpp
+++ b/src/common/capio/requests.hpp
@@ -16,6 +16,6 @@ constexpr const int CAPIO_REQUEST_WRITE_MEM = 11;
 constexpr const int CAPIO_REQUEST_QUERY_MEM_FILE = 12;
 constexpr const int CAPIO_REQUEST_POSIX_DIR_COMMITTED = 13;
 
-constexpr const int CAPIO_NR_REQUESTS = 13;
+constexpr const int CAPIO_NR_REQUESTS = 14;
 
 #endif // CAPIO_COMMON_REQUESTS_HPP

--- a/src/common/capio/requests.hpp
+++ b/src/common/capio/requests.hpp
@@ -1,19 +1,20 @@
 #ifndef CAPIO_COMMON_REQUESTS_HPP
 #define CAPIO_COMMON_REQUESTS_HPP
 
-constexpr const int CAPIO_REQUEST_CONSENT        = 0;
-constexpr const int CAPIO_REQUEST_CLOSE          = 1;
-constexpr const int CAPIO_REQUEST_CREATE         = 2;
-constexpr const int CAPIO_REQUEST_EXIT_GROUP     = 3;
-constexpr const int CAPIO_REQUEST_HANDSHAKE      = 4;
-constexpr const int CAPIO_REQUEST_MKDIR          = 5;
-constexpr const int CAPIO_REQUEST_OPEN           = 6;
-constexpr const int CAPIO_REQUEST_READ           = 7;
-constexpr const int CAPIO_REQUEST_READ_MEM       = 8;
-constexpr const int CAPIO_REQUEST_RENAME         = 9;
-constexpr const int CAPIO_REQUEST_WRITE          = 10;
-constexpr const int CAPIO_REQUEST_WRITE_MEM      = 11;
+constexpr const int CAPIO_REQUEST_CONSENT = 0;
+constexpr const int CAPIO_REQUEST_CLOSE = 1;
+constexpr const int CAPIO_REQUEST_CREATE = 2;
+constexpr const int CAPIO_REQUEST_EXIT_GROUP = 3;
+constexpr const int CAPIO_REQUEST_HANDSHAKE = 4;
+constexpr const int CAPIO_REQUEST_MKDIR = 5;
+constexpr const int CAPIO_REQUEST_OPEN = 6;
+constexpr const int CAPIO_REQUEST_READ = 7;
+constexpr const int CAPIO_REQUEST_READ_MEM = 8;
+constexpr const int CAPIO_REQUEST_RENAME = 9;
+constexpr const int CAPIO_REQUEST_WRITE = 10;
+constexpr const int CAPIO_REQUEST_WRITE_MEM = 11;
 constexpr const int CAPIO_REQUEST_QUERY_MEM_FILE = 12;
+constexpr const int CAPIO_REQUEST_POSIX_DIR_COMMITTED = 13;
 
 constexpr const int CAPIO_NR_REQUESTS = 13;
 

--- a/src/common/capio/requests.hpp
+++ b/src/common/capio/requests.hpp
@@ -1,19 +1,19 @@
 #ifndef CAPIO_COMMON_REQUESTS_HPP
 #define CAPIO_COMMON_REQUESTS_HPP
 
-constexpr const int CAPIO_REQUEST_CONSENT = 0;
-constexpr const int CAPIO_REQUEST_CLOSE = 1;
-constexpr const int CAPIO_REQUEST_CREATE = 2;
-constexpr const int CAPIO_REQUEST_EXIT_GROUP = 3;
-constexpr const int CAPIO_REQUEST_HANDSHAKE = 4;
-constexpr const int CAPIO_REQUEST_MKDIR = 5;
-constexpr const int CAPIO_REQUEST_OPEN = 6;
-constexpr const int CAPIO_REQUEST_READ = 7;
-constexpr const int CAPIO_REQUEST_READ_MEM = 8;
-constexpr const int CAPIO_REQUEST_RENAME = 9;
-constexpr const int CAPIO_REQUEST_WRITE = 10;
-constexpr const int CAPIO_REQUEST_WRITE_MEM = 11;
-constexpr const int CAPIO_REQUEST_QUERY_MEM_FILE = 12;
+constexpr const int CAPIO_REQUEST_CONSENT             = 0;
+constexpr const int CAPIO_REQUEST_CLOSE               = 1;
+constexpr const int CAPIO_REQUEST_CREATE              = 2;
+constexpr const int CAPIO_REQUEST_EXIT_GROUP          = 3;
+constexpr const int CAPIO_REQUEST_HANDSHAKE           = 4;
+constexpr const int CAPIO_REQUEST_MKDIR               = 5;
+constexpr const int CAPIO_REQUEST_OPEN                = 6;
+constexpr const int CAPIO_REQUEST_READ                = 7;
+constexpr const int CAPIO_REQUEST_READ_MEM            = 8;
+constexpr const int CAPIO_REQUEST_RENAME              = 9;
+constexpr const int CAPIO_REQUEST_WRITE               = 10;
+constexpr const int CAPIO_REQUEST_WRITE_MEM           = 11;
+constexpr const int CAPIO_REQUEST_QUERY_MEM_FILE      = 12;
 constexpr const int CAPIO_REQUEST_POSIX_DIR_COMMITTED = 13;
 
 constexpr const int CAPIO_NR_REQUESTS = 14;

--- a/src/posix/handlers.hpp
+++ b/src/posix/handlers.hpp
@@ -1,6 +1,10 @@
 #ifndef CAPIO_POSIX_HANDLERS_HPP
 #define CAPIO_POSIX_HANDLERS_HPP
 
+/********************/
+// SYSCALL HANDLERS //
+/********************/
+
 #include "handlers/access.hpp"
 #include "handlers/chdir.hpp"
 #include "handlers/close.hpp"
@@ -25,5 +29,12 @@
 #include "handlers/statx.hpp"
 #include "handlers/unlink.hpp"
 #include "handlers/write.hpp"
+
+
+/********************/
+// POSIX  HANDLERS  //
+/********************/
+
+#include "handlers/posix_readdir.hpp"
 
 #endif // CAPIO_POSIX_HANDLERS_HPP

--- a/src/posix/handlers.hpp
+++ b/src/posix/handlers.hpp
@@ -30,7 +30,6 @@
 #include "handlers/unlink.hpp"
 #include "handlers/write.hpp"
 
-
 /********************/
 // POSIX  HANDLERS  //
 /********************/

--- a/src/posix/handlers/open.hpp
+++ b/src/posix/handlers/open.hpp
@@ -103,7 +103,8 @@ int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     int flags   = static_cast<int>(arg2);
     mode_t mode = static_cast<int>(arg3);
     auto tid    = static_cast<pid_t>(syscall_no_intercept(SYS_gettid));
-    START_LOG(tid, "call(path=%s, flags=%d, mode=%d)", pathname.data(), flags, mode);
+    START_LOG(tid, "call(dirfd=%ld, path=%s, flags=%d, mode=%d)", dirfd, pathname.data(), flags,
+              mode);
 
     std::string path = compute_abs_path(pathname.data(), dirfd);
 

--- a/src/posix/handlers/posix_readdir.hpp
+++ b/src/posix/handlers/posix_readdir.hpp
@@ -1,0 +1,115 @@
+#ifndef POSIX_READDIR_HPP
+#define POSIX_READDIR_HPP
+
+#include <capio/logger.hpp>
+#include <dirent.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+
+// Map &DIR -> dirpath
+std::unordered_map<unsigned long int, std::string> opened_directory;
+
+DIR *opendir(const char *name) {
+    char realpath[PATH_MAX]{0};
+    capio_realpath(name, realpath);
+    START_LOG(gettid(), "call(path=%s)", realpath);
+
+    static DIR *(*real_opendir)(const char *) = NULL;
+
+    if (!real_opendir) {
+        syscall_no_intercept_flag = true;
+        real_opendir              = (DIR * (*) (const char *) ) dlsym(RTLD_NEXT, "opendir");
+        syscall_no_intercept_flag = false;
+        if (!real_opendir) {
+            ERR_EXIT("Failed to find original opendir: %s\n", dlerror());
+        }
+    }
+
+    if (!is_capio_path(realpath)) {
+        LOG("Not a CAPIO path. continuing execution");
+        auto dir = real_opendir(realpath);
+
+        return dir;
+    }
+
+    LOG("Performing consent request to open directory %s", realpath);
+    consent_request_cache_fs->consent_request(realpath, gettid(), __FUNCTION__);
+
+    syscall_no_intercept_flag = true;
+    auto dir                  = real_opendir(realpath);
+    syscall_no_intercept_flag = false;
+
+    LOG("Opened directory with offset %ld", dir);
+    opened_directory.insert({reinterpret_cast<unsigned long int>(dir), std::string(realpath)});
+
+    return dir;
+}
+
+int closedir(DIR *dirp) {
+    START_LOG(capio_syscall(SYS_gettid), "call(dir=%ld)", dirp);
+
+    static int (*real_closedir)(DIR *) = NULL;
+    if (!real_closedir) {
+        syscall_no_intercept_flag = true;
+        real_closedir             = (int (*)(DIR *)) dlsym(RTLD_NEXT, "closedir");
+        syscall_no_intercept_flag = false;
+        if (!real_closedir) {
+            ERR_EXIT("Failed to find original closedir: %s\n", dlerror());
+        }
+    }
+
+    if (const auto pos = opened_directory.find(reinterpret_cast<unsigned long int>(dirp));
+        pos != opened_directory.end()) {
+        opened_directory.erase(pos);
+        LOG("removed dir from map of opened files");
+    }
+    syscall_no_intercept_flag = true;
+    auto return_code          = real_closedir(dirp);
+    syscall_no_intercept_flag = false;
+    LOG("Return code of closedir = %d", return_code);
+
+    return return_code;
+}
+
+struct dirent *readdir(DIR *dirp) {
+    syscall_no_intercept_flag                    = true;
+    static struct dirent *(*real_readdir)(DIR *) = NULL;
+    if (!real_readdir) {
+        real_readdir = (struct dirent * (*) (DIR *) ) dlsym(RTLD_NEXT, "readdir");
+    }
+
+    struct dirent *entry;
+    while ((entry = real_readdir(dirp)) != NULL) {
+        // Example: skip hidden files
+        if (entry->d_name[0] == '.') {
+            continue;
+        }
+        printf("[HOOK] readdir: %s\n", entry->d_name);
+        return entry;
+    }
+    syscall_no_intercept_flag = false;
+
+    return NULL; // end of directory
+}
+
+struct dirent64 *readdir64(DIR *dirp) {
+    syscall_no_intercept_flag                        = true;
+    static struct dirent64 *(*real_readdir64)(DIR *) = NULL;
+    if (!real_readdir64) {
+        real_readdir64 = (struct dirent64 * (*) (DIR *) ) dlsym(RTLD_NEXT, "readdir64");
+    }
+
+    struct dirent64 *entry;
+    while ((entry = real_readdir64(dirp)) != NULL) {
+        if (entry->d_name[0] == '.') {
+            continue;
+        }
+        printf("[HOOK] readdir64: %s\n", entry->d_name);
+        return entry;
+    }
+    syscall_no_intercept_flag = false;
+    return NULL;
+}
+
+#endif // POSIX_READDIR_HPP

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -366,8 +366,6 @@ static constexpr std::array<CPHandler_t, CAPIO_NR_SYSCALLS> build_syscall_table(
     return _syscallTable;
 }
 
-
-
 static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3, long arg4,
                 long arg5, long *result) {
     static constexpr std::array<CPHandler_t, CAPIO_NR_SYSCALLS> syscallTable =

--- a/src/posix/libcapio_posix.cpp
+++ b/src/posix/libcapio_posix.cpp
@@ -366,6 +366,8 @@ static constexpr std::array<CPHandler_t, CAPIO_NR_SYSCALLS> build_syscall_table(
     return _syscallTable;
 }
 
+
+
 static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3, long arg4,
                 long arg5, long *result) {
     static constexpr std::array<CPHandler_t, CAPIO_NR_SYSCALLS> syscallTable =

--- a/src/posix/utils/requests.hpp
+++ b/src/posix/utils/requests.hpp
@@ -74,8 +74,9 @@ inline std::vector<std::regex> *file_in_memory_request(const long pid) {
     return regex_vector;
 }
 
-inline capio_off64_t posix_directory_committed_request(const long pid, const std::filesystem::path &path,
-                                               char *token_path) {
+inline capio_off64_t posix_directory_committed_request(const long pid,
+                                                       const std::filesystem::path &path,
+                                                       char *token_path) {
     START_LOG(capio_syscall(SYS_gettid), "call(path=%s)", path.c_str());
     char req[CAPIO_REQ_MAX_SIZE];
 

--- a/src/server/capio-cl-engine/capio_cl_engine.hpp
+++ b/src/server/capio-cl-engine/capio_cl_engine.hpp
@@ -377,6 +377,12 @@ class CapioCLEngine {
     void setFileDeps(const std::filesystem::path &path,
                      const std::vector<std::string> &dependencies) {
         START_LOG(gettid(), "call()");
+        if (dependencies.empty()) {
+            return;
+        }
+        if (_locations.find(path) == _locations.end()) {
+            this->newFile(path);
+        }
         std::get<9>(_locations.at(path)) = dependencies;
         for (const auto &itm : dependencies) {
             LOG("Creating new fie (if it exists) for path %s", itm.c_str());

--- a/src/server/capio-cl-engine/capio_cl_engine.hpp
+++ b/src/server/capio-cl-engine/capio_cl_engine.hpp
@@ -141,6 +141,7 @@ class CapioCLEngine {
      * @return
      */
     bool contains(const std::filesystem::path &file) {
+        START_LOG(gettid(), "call(file=%s)", file.c_str());
         return std::any_of(_locations.begin(), _locations.end(), [&](auto &itm) {
             return std::regex_match(file.c_str(), std::get<10>(itm.second));
         });

--- a/src/server/capio-cl-engine/capio_cl_engine.hpp
+++ b/src/server/capio-cl-engine/capio_cl_engine.hpp
@@ -431,6 +431,13 @@ class CapioCLEngine {
 
         return files;
     }
+
+    std::vector<std::string> getPathsInConfig() {
+        std::vector<std::string> paths;
+        std::transform(_locations.begin(), _locations.end(), std::back_inserter(paths),
+                       [](auto pair) { return pair.first; });
+        return paths;
+    }
 };
 
 inline CapioCLEngine *capio_cl_engine;

--- a/src/server/client-manager/handlers/posix_readdir.hpp
+++ b/src/server/client-manager/handlers/posix_readdir.hpp
@@ -1,0 +1,18 @@
+
+#ifndef POSIX_READDIR_HPP
+#define POSIX_READDIR_HPP
+
+inline void posix_readdir_handler(const char *const str) {
+    pid_t pid;
+    char path[PATH_MAX];
+    sscanf(str, "%d %s", &pid, path);
+    START_LOG(gettid(), "call(pid=%d, path=%s", pid, path);
+
+    auto metadata_token = file_manager->getMetadataPath(path);
+    LOG("sending to pid %ld token path of %s", pid, metadata_token.c_str());
+
+    client_manager->reply_to_client(pid, metadata_token.length());
+    storage_service->reply_to_client_raw(pid, metadata_token.c_str(), metadata_token.length());
+}
+
+#endif // POSIX_READDIR_HPP

--- a/src/server/client-manager/request_handler_engine.hpp
+++ b/src/server/client-manager/request_handler_engine.hpp
@@ -8,7 +8,7 @@
 #include "file-manager/file_manager.hpp"
 
 /*
- * REQUESTS handlers
+ * SYSCALL REQUESTS handlers
  */
 #include "handlers/close.hpp"
 #include "handlers/consent.hpp"
@@ -21,6 +21,11 @@
 #include "handlers/rename.hpp"
 #include "handlers/write.hpp"
 
+/*
+ * POSIX GLIBC REQUESTS handlers
+ */
+#include "handlers/posix_readdir.hpp"
+
 /**
  * @brief Class that handles the system calls received from the posix client application
  *
@@ -32,19 +37,20 @@ class RequestHandlerEngine {
     static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handlers_table() {
         std::array<CSHandler_t, CAPIO_NR_REQUESTS> _request_handlers{0};
 
-        _request_handlers[CAPIO_REQUEST_CONSENT]        = consent_to_proceed_handler;
-        _request_handlers[CAPIO_REQUEST_CLOSE]          = close_handler;
-        _request_handlers[CAPIO_REQUEST_CREATE]         = create_handler;
-        _request_handlers[CAPIO_REQUEST_EXIT_GROUP]     = exit_handler;
-        _request_handlers[CAPIO_REQUEST_HANDSHAKE]      = handshake_handler;
-        _request_handlers[CAPIO_REQUEST_MKDIR]          = create_handler;
-        _request_handlers[CAPIO_REQUEST_OPEN]           = open_handler;
-        _request_handlers[CAPIO_REQUEST_READ]           = read_handler;
-        _request_handlers[CAPIO_REQUEST_RENAME]         = rename_handler;
-        _request_handlers[CAPIO_REQUEST_WRITE]          = write_handler;
-        _request_handlers[CAPIO_REQUEST_QUERY_MEM_FILE] = files_to_store_in_memory_handler;
-        _request_handlers[CAPIO_REQUEST_READ_MEM]       = read_mem_handler;
-        _request_handlers[CAPIO_REQUEST_WRITE_MEM]      = write_mem_handler;
+        _request_handlers[CAPIO_REQUEST_CONSENT]             = consent_to_proceed_handler;
+        _request_handlers[CAPIO_REQUEST_CLOSE]               = close_handler;
+        _request_handlers[CAPIO_REQUEST_CREATE]              = create_handler;
+        _request_handlers[CAPIO_REQUEST_EXIT_GROUP]          = exit_handler;
+        _request_handlers[CAPIO_REQUEST_HANDSHAKE]           = handshake_handler;
+        _request_handlers[CAPIO_REQUEST_MKDIR]               = create_handler;
+        _request_handlers[CAPIO_REQUEST_OPEN]                = open_handler;
+        _request_handlers[CAPIO_REQUEST_READ]                = read_handler;
+        _request_handlers[CAPIO_REQUEST_RENAME]              = rename_handler;
+        _request_handlers[CAPIO_REQUEST_WRITE]               = write_handler;
+        _request_handlers[CAPIO_REQUEST_QUERY_MEM_FILE]      = files_to_store_in_memory_handler;
+        _request_handlers[CAPIO_REQUEST_READ_MEM]            = read_mem_handler;
+        _request_handlers[CAPIO_REQUEST_WRITE_MEM]           = write_mem_handler;
+        _request_handlers[CAPIO_REQUEST_POSIX_DIR_COMMITTED] = posix_readdir_handler;
 
         return _request_handlers;
     }

--- a/src/server/file-manager/file_manager.hpp
+++ b/src/server/file-manager/file_manager.hpp
@@ -31,6 +31,7 @@ class CapioFileManager {
     ~CapioFileManager() { START_LOG(gettid(), "call()"); }
 
     static uintmax_t get_file_size_if_exists(const std::filesystem::path &path);
+    static std::string getMetadataPath(const std::string &path);
     static void increaseCloseCount(const std::filesystem::path &path);
     static bool isCommitted(const std::filesystem::path &path);
     static void setCommitted(const std::filesystem::path &path);
@@ -39,6 +40,7 @@ class CapioFileManager {
     void addThreadAwaitingCreation(const std::string &path, pid_t tid);
     void checkFilesAwaitingCreation();
     void checkFileAwaitingData();
+    void checkDirectoriesNFiles() const;
 };
 
 inline CapioFileManager *file_manager;

--- a/src/server/file-manager/file_manager_impl.hpp
+++ b/src/server/file-manager/file_manager_impl.hpp
@@ -390,12 +390,12 @@ inline void CapioFileManager::checkFileAwaitingData() {
  * @brief commit firectories that have NFILES inside them if their commit rule is n_files
  */
 inline void CapioFileManager::checkDirectoriesNFiles() const {
-    START_LOG(gettid(), "call()");
+
     for (const auto &path_config : capio_cl_engine->getPathsInConfig()) {
         if (!capio_cl_engine->isDirectory(path_config)) {
             continue;
         }
-
+        START_LOG(gettid(), "call()");
         auto n_files = capio_cl_engine->getDirectoryFileCount(path_config);
         if (n_files > 0) {
             LOG("Directory %s needs $ld files before being committed", path_config.c_str(),

--- a/src/server/file-manager/file_manager_impl.hpp
+++ b/src/server/file-manager/file_manager_impl.hpp
@@ -398,7 +398,7 @@ inline void CapioFileManager::checkDirectoriesNFiles() const {
         START_LOG(gettid(), "call()");
         auto n_files = capio_cl_engine->getDirectoryFileCount(path_config);
         if (n_files > 0) {
-            LOG("Directory %s needs $ld files before being committed", path_config.c_str(),
+            LOG("Directory %s needs %ld files before being committed", path_config.c_str(),
                 n_files);
             // There must be n_files inside the directory to commit the file
             long count = 0;

--- a/src/server/file-manager/file_manager_impl.hpp
+++ b/src/server/file-manager/file_manager_impl.hpp
@@ -402,8 +402,11 @@ inline void CapioFileManager::checkDirectoriesNFiles() const {
                 n_files);
             // There must be n_files inside the directory to commit the file
             long count = 0;
-            for (const auto &entry : std::filesystem::directory_iterator(path_config)) {
-                ++count;
+            if (std::filesystem::exists(path_config)) {
+                auto iterator = std::filesystem::directory_iterator(path_config);
+                for (const auto &entry : iterator) {
+                    ++count;
+                }
             }
 
             LOG("Directory %s has %ld files inside", path_config.c_str(), count);

--- a/src/server/file-manager/file_manager_impl.hpp
+++ b/src/server/file-manager/file_manager_impl.hpp
@@ -6,10 +6,14 @@
 #include "storage-service/capio_storage_service.hpp"
 #include "utils/distributed_semaphore.hpp"
 
+inline std::string CapioFileManager::getMetadataPath(const std::string &path) {
+    return get_capio_metadata_path() / (path.substr(path.find(get_capio_dir()) + 1) + ".capio");
+}
+
 /**
  * @brief Creates the directory structure for the metadata file and proceed to return the path
  * pointing to the metadata token file. For improvements in performances, a hash map is included to
- * cache the computed paths. For thread safety conserns, see
+ * cache the computed paths. For thread safety concerns, see
  * https://en.cppreference.com/w/cpp/container#Thread_safety
  *
  * @param path real path of the file
@@ -19,8 +23,8 @@ inline std::string CapioFileManager::getAndCreateMetadataPath(const std::string 
     START_LOG(gettid(), "call(path=%s)", path.c_str());
     static std::unordered_map<std::string, std::string> metadata_paths;
     if (metadata_paths.find(path) == metadata_paths.end()) {
-        std::filesystem::path result =
-            get_capio_metadata_path() / (path.substr(path.find(get_capio_dir()) + 1) + ".capio");
+        std::filesystem::path result = getMetadataPath(path);
+
         metadata_paths.emplace(path, result);
         LOG("Creating metadata directory (%s)", result.parent_path().c_str());
         std::filesystem::create_directories(result.parent_path());
@@ -379,6 +383,35 @@ inline void CapioFileManager::checkFileAwaitingData() {
             ++iter;
         }
         LOG("Completed handling.");
+    }
+}
+
+/**
+ * @brief commit firectories that have NFILES inside them if their commit rule is n_files
+ */
+inline void CapioFileManager::checkDirectoriesNFiles() const {
+    START_LOG(gettid(), "call()");
+    for (const auto &path_config : capio_cl_engine->getPathsInConfig()) {
+        if (!capio_cl_engine->isDirectory(path_config)) {
+            continue;
+        }
+
+        auto n_files = capio_cl_engine->getDirectoryFileCount(path_config);
+        if (n_files > 0) {
+            LOG("Directory %s needs $ld files before being committed", path_config.c_str(),
+                n_files);
+            // There must be n_files inside the directory to commit the file
+            long count = 0;
+            for (const auto &entry : std::filesystem::directory_iterator(path_config)) {
+                ++count;
+            }
+
+            LOG("Directory %s has %ld files inside", path_config.c_str(), count);
+            if (count >= n_files) {
+                LOG("Committing directory");
+                this->setCommitted(path_config);
+            }
+        }
     }
 }
 

--- a/src/server/file-manager/fs_monitor.hpp
+++ b/src/server/file-manager/fs_monitor.hpp
@@ -32,6 +32,7 @@ class FileSystemMonitor {
 
             file_manager->checkFilesAwaitingCreation();
             file_manager->checkFileAwaitingData();
+            file_manager->checkDirectoriesNFiles();
 
             nanosleep(&sleep, nullptr);
         }

--- a/src/server/storage-service/capio_storage_service.hpp
+++ b/src/server/storage-service/capio_storage_service.hpp
@@ -138,6 +138,16 @@ class CapioStorageService {
     }
 
     /**
+     * Send raw data to client without fetching from the storage manager itself
+     * @param pid
+     * @param data
+     * @param len
+     */
+    void reply_to_client_raw(pid_t pid, const char *data, const capio_off64_t len) const {
+        _server_to_client_queue->at(pid)->write(data, len);
+    }
+
+    /**
      * Receive the file content from the client application
      * @param tid
      * @param file


### PR DESCRIPTION
This commit adds the capability of performing streaming on contents of directory when the readdir and readdir64 glibc methods are invoked. Contrary to other POSIX handlers, here we patch directly methods from the glibc instead of system calls, trough the linux loader