### PR TITLE
Bump version of taywee/args

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -13,7 +13,7 @@ set(TARGET_SOURCES
 FetchContent_Declare(
         args
         GIT_REPOSITORY https://github.com/Taywee/args.git
-        GIT_TAG 6.4.6
+        GIT_TAG 6.4.7
 )
 FetchContent_Declare(
         simdjson


### PR DESCRIPTION
Updated dependency version of taywee/args to address deprecation of cmake <= 3.10