### PR TITLE
Updated `syscall_intercept` dependency

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -146,7 +146,6 @@ jobs:
         run: |
           apt update
           apt install -y      \
-            libcapstone-dev   \
             openmpi-bin       \
             libopenmpi-dev    \
             ninja-build       \
@@ -164,6 +163,28 @@ jobs:
             python3-pip       \
             python3-venv
 
+      - name: "Get compiler version"
+        run: |
+          IFS='-' read -r -a COMPILER <<< "${{ matrix.cxx }}"
+          echo "CXX_VERSION=${COMPILER[1]}" >> $GITHUB_ENV
+      - name: "Install Clang"
+        if: ${{ startsWith(matrix.cxx, 'clang-') }}
+        run: |
+          wget -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod u+x /tmp/llvm.sh
+          sudo /tmp/llvm.sh ${{ env.CXX_VERSION }}
+          rm -f /tmp/llvm.sh
+      - name: "Fix missing libclang_rt.profile for Clang 14"
+        if: ${{ matrix.cxx == 'clang-14' }}
+        run: |
+          sudo apt download libclang-rt-14-dev
+          sudo dpkg --force-all -i libclang-rt-14-dev*
+      - name: "Install GCC"
+        if: ${{ startsWith(matrix.cxx, 'g++-') }}
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt update
+          sudo apt install -y ${{ matrix.cxx }}
       - name: "Run CMake"
         shell: bash
         run: |

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -163,28 +163,6 @@ jobs:
             python3-pip       \
             python3-venv
 
-      - name: "Get compiler version"
-        run: |
-          IFS='-' read -r -a COMPILER <<< "${{ matrix.cxx }}"
-          echo "CXX_VERSION=${COMPILER[1]}" >> $GITHUB_ENV
-      - name: "Install Clang"
-        if: ${{ startsWith(matrix.cxx, 'clang-') }}
-        run: |
-          wget -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-          chmod u+x /tmp/llvm.sh
-          sudo /tmp/llvm.sh ${{ env.CXX_VERSION }}
-          rm -f /tmp/llvm.sh
-      - name: "Fix missing libclang_rt.profile for Clang 14"
-        if: ${{ matrix.cxx == 'clang-14' }}
-        run: |
-          sudo apt download libclang-rt-14-dev
-          sudo dpkg --force-all -i libclang-rt-14-dev*
-      - name: "Install GCC"
-        if: ${{ startsWith(matrix.cxx, 'g++-') }}
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y ${{ matrix.cxx }}
       - name: "Run CMake"
         shell: bash
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt update                              \
         ca-certificates                     \
         cmake                               \
         git                                 \
-        libcapstone-dev                     \
         libopenmpi-dev                      \
         ninja-build                         \
         openmpi-bin                         \
@@ -38,7 +37,6 @@ ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 RUN apt update                                                \
  && apt install -y --no-install-recommends                    \
-        libcapstone4                                          \
         openmpi-bin                                           \
         openssh-server                                        \
  && rm -rf /var/lib/apt/lists/*                               \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ CAPIO depends on the following software that needs to be manually installed:
 The following dependencies are automatically fetched during cmake configuration phase, and compiled when required.
 
 - [CAPIO-CL](https://github.com/High-Performance-IO/CAPIO-CL) To handle the CAPIO-CL configuration and enforce streaming directives
-- [syscall_intercept](https://github.com/pmem/syscall_intercept) to intercept syscalls
+- [alpha-unito/syscall_intercept](https://github.com/alpha-unito/syscall_intercept) to intercept syscalls (forked from ```pmem/syscall_interept```)
 - [Taywee/args](https://github.com/Taywee/args) to parse server command line inputs
 
 ### Compile capio

--- a/capio/posix/syscall_intercept/CMakeLists.txt
+++ b/capio/posix/syscall_intercept/CMakeLists.txt
@@ -14,13 +14,15 @@ include(ExternalProject)
 # Import external project from git
 #####################################
 ExternalProject_Add(syscall_intercept
-        GIT_REPOSITORY https://github.com/pmem/syscall_intercept.git
-        GIT_TAG ca4b13531f883597c2f04a40e095f76f6c3a6d22
+        GIT_REPOSITORY https://github.com/alpha-unito/syscall_intercept.git
+        GIT_TAG 7dbdf6ab9c576f96843ef2553b7efc7d15cf66b4
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}
         CMAKE_ARGS
+        -DSTATIC_CAPSTONE=ON
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        -DPERFORM_STYLE_CHECKS=OFF
 )

--- a/capio/tests/integration/src/main.cpp
+++ b/capio/tests/integration/src/main.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include "capio/syscall.hpp"
+
 char **build_args() {
     char **args = (char **) malloc(3 * sizeof(uintptr_t));
 
@@ -59,7 +61,7 @@ class CapioServerEnvironment : public testing::Environment {
     void SetUp() override {
         if (server_pid < 0) {
             ASSERT_NE(std::getenv("CAPIO_DIR"), nullptr);
-            ASSERT_GE(server_pid = fork(), 0);
+            ASSERT_GE(server_pid = capio_syscall(SYS_fork), 0);
             if (server_pid == 0) {
                 execvpe(args[0], args, envp);
                 _exit(127);

--- a/capio/tests/integration/src/main.cpp
+++ b/capio/tests/integration/src/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "capio/syscall.hpp"
+#include "common/syscall.hpp"
 
 char **build_args() {
     char **args = (char **) malloc(3 * sizeof(uintptr_t));

--- a/capio/tests/unit/syscall/src/clone.cpp
+++ b/capio/tests/unit/syscall/src/clone.cpp
@@ -4,6 +4,7 @@
 
 #include <fcntl.h>
 #include <semaphore.h>
+#include <syscall.h>
 #include <unistd.h>
 
 constexpr int ARRAY_SIZE = 100;
@@ -61,7 +62,7 @@ TEST(SystemCallTest, TestThreadCloneProducerConsumer) {
 }
 
 TEST(SystemCallTest, TestForkParentChild) {
-    auto pid = fork();
+    auto pid = syscall(SYS_fork);
     EXPECT_GE(pid, 0);
     if (pid == 0) {
         exit(EXIT_SUCCESS);
@@ -69,7 +70,7 @@ TEST(SystemCallTest, TestForkParentChild) {
 }
 
 TEST(SystemCallTest, TestThreadCloneProducerConsumerWithStat) {
-    constexpr const char *PATHNAME = "test_file.txt";
+    constexpr const char *PATHNAME = "test_clone.txt";
     sem                            = static_cast<sem_t *>(malloc(sizeof(sem_t)));
     EXPECT_EQ(sem_init(sem, 0, 0), 0);
     FILE *fp = fopen(PATHNAME, "w+");

--- a/capio/tests/unit/syscall/src/main.cpp
+++ b/capio/tests/unit/syscall/src/main.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <linux/limits.h>
 
-#include "capio/syscall.hpp"
+#include "common/syscall.hpp"
 
 char **build_args() {
     char **args = (char **) malloc(4 * sizeof(uintptr_t));

--- a/capio/tests/unit/syscall/src/main.cpp
+++ b/capio/tests/unit/syscall/src/main.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <linux/limits.h>
 
+#include "capio/syscall.hpp"
+
 char **build_args() {
     char **args = (char **) malloc(4 * sizeof(uintptr_t));
 
@@ -66,7 +68,7 @@ class CapioServerEnvironment : public testing::Environment {
     void SetUp() override {
         if (server_pid < 0) {
             ASSERT_NE(std::getenv("CAPIO_DIR"), nullptr);
-            ASSERT_GE(server_pid = fork(), 0);
+            ASSERT_GE(server_pid = capio_syscall(SYS_fork), 0);
             if (server_pid == 0) {
                 execvpe(args[0], args, envp);
                 _exit(127);


### PR DESCRIPTION
This commit moves the  `syscall_intercept` dependency from Intel PMem (archived and no longer maintained) to a [new version](https://github.com/alpha-unito/syscall_intercept) actively maintained by the Alpha Parallel Computing Group at the University of Turin, which also includes support for the RISC-V architecture.