### PR TITLE
Update `Taywee/args` server dependency

### DIFF
--- a/capio/server/CMakeLists.txt
+++ b/capio/server/CMakeLists.txt
@@ -13,7 +13,7 @@ set(TARGET_SOURCES
 FetchContent_Declare(
         args
         GIT_REPOSITORY https://github.com/Taywee/args.git
-        GIT_TAG 6.4.6
+        GIT_TAG 6.4.7
 )
 FetchContent_Declare(
         simdjson


### PR DESCRIPTION
This commit bumps the `Taywee/args` dependency for the Capio server component to  V6.4.7. This ensures compatibility with newer versions of CMake.