### PR TITLE
Fix compilation flags for CAPIO dependencies

### DIFF
--- a/capio/posix/syscall_intercept/CMakeLists.txt
+++ b/capio/posix/syscall_intercept/CMakeLists.txt
@@ -22,4 +22,5 @@ ExternalProject_Add(syscall_intercept
         -DBUILD_EXAMPLES=OFF
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 )

--- a/capio/server/CMakeLists.txt
+++ b/capio/server/CMakeLists.txt
@@ -24,7 +24,7 @@ FetchContent_Declare(
 
 set(ARGS_BUILD_EXAMPLE OFF CACHE INTERNAL "")
 set(ARGS_BUILD_UNITTESTS OFF CACHE INTERNAL "")
-
+set(SIMDJSON_IMPLEMENTATION fallback CACHE STRING "" FORCE)
 
 FetchContent_MakeAvailable(args simdjson)
 


### PR DESCRIPTION
This commit adds CMake configuration flags to ensure that the dependencies are still able to be compiled even with newer releases of C++ compilers:
- `syscall_intercept`: enabled compatibility with outdated releases of CMake. This will be removed once the [new version](https://github.com/alpha-unito/syscall_intercept) of the syscall_intercept library is ready to be integrated
- `simdjson/simdjson`: selected C++ backend as CMake erroneously tried to compile SIMD instructions even when targeting unsupported architecture, making it impossible to compile the dependency.