### PR TITLE
Updated syscalls and uniform CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 option(CAPIO_BUILD_TESTS "Build CAPIO test suite" FALSE)
 option(CAPIO_LOG "Enable capio debug logging" FALSE)
 option(ENABLE_COVERAGE "Enable code coverage collection" FALSE)
+option(CAPIO_BUILD_SERVER "Build CAPIO server component" TRUE)
+option(CAPIO_BUILD_POSIX  "Build CAPIO posix component" TRUE)
 
 #####################################
 # CMake module imports
@@ -82,8 +84,16 @@ FetchContent_Declare(
 #####################################
 # Targets
 #####################################
-add_subdirectory(capio/posix)
-add_subdirectory(capio/server)
+
+IF(CAPIO_BUILD_POSIX)
+	message(STATUS "Adding CAPIO posix component")
+	add_subdirectory(capio/posix)
+ENDIF()
+
+IF(CAPIO_BUILD_SERVER)
+	message(STATUS "Adding CAPIO server component")
+	add_subdirectory(capio/server)
+ENDIF()
 
 IF (CAPIO_BUILD_TESTS)
     message(STATUS "Building CAPIO test suite")

--- a/capio/common/logger.hpp
+++ b/capio/common/logger.hpp
@@ -210,21 +210,13 @@ class Logger {
             setup_posix_log_filename();
             current_log_level =
                 0; // reset log level after clone, avoiding propagation to child threads
-#if defined(SYS_mkdir)
-            capio_syscall(SYS_mkdir, get_log_dir(), 0755);
-            capio_syscall(SYS_mkdir, get_posix_log_dir(), 0755);
-            capio_syscall(SYS_mkdir, get_host_log_dir(), 0755);
-#elif defined(SYS_mkdirat)
+
             capio_syscall(SYS_mkdirat, AT_FDCWD, get_log_dir(), 0755);
             capio_syscall(SYS_mkdirat, AT_FDCWD, get_posix_log_dir(), 0755);
             capio_syscall(SYS_mkdirat, AT_FDCWD, get_host_log_dir(), 0755);
-#endif
-#if defined(SYS_open)
-            logfileFD = capio_syscall(SYS_open, logfile_path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
-#elif defined(SYS_openat)
+
             logfileFD = capio_syscall(SYS_openat, AT_FDCWD, logfile_path,
                                       O_CREAT | O_WRONLY | O_TRUNC, 0644);
-#endif
 
             if (logfileFD == -1) {
                 capio_syscall(SYS_write, fileno(stdout),

--- a/capio/common/logger.hpp
+++ b/capio/common/logger.hpp
@@ -256,7 +256,7 @@ class Logger {
 
             auto buf1 = reinterpret_cast<char *>(capio_syscall(
                 SYS_mmap, nullptr, 50, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-            sprintf(buf1, CAPIO_LOG_POSIX_SYSCALL_START, sys_num_to_string(syscallNumber),
+            sprintf(buf1, CAPIO_LOG_POSIX_SYSCALL_START, sys_num_to_string(syscallNumber).c_str(),
                     syscallNumber);
             log_write_to(buf1, strlen(buf1));
             capio_syscall(SYS_munmap, buf1, 50);

--- a/capio/posix/handlers/dup.hpp
+++ b/capio/posix/handlers/dup.hpp
@@ -27,23 +27,16 @@ int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
+#ifdef SYS_dup2
 int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     long tid = syscall_no_intercept(SYS_gettid);
     int fd   = static_cast<int>(arg0);
     int fd2  = static_cast<int>(arg1);
 
-    // int res = capio_dup2(fd, fd2, tid);
-
     START_LOG(tid, "call(fd=%d, fd2=%d)", fd, fd2);
 
     if (exists_capio_fd(fd)) {
-        int res = static_cast<int>(syscall_no_intercept(
-#ifdef SYS_dup2
-            SYS_dup2, fd, fd2
-#else
-            SYS_dup3, fd, fd2, 0
-#endif
-        ));
+        int res = static_cast<int>(syscall_no_intercept(SYS_dup2, fd, fd2));
         if (res == -1) {
             *result = -errno;
             return CAPIO_POSIX_SYSCALL_SUCCESS;
@@ -57,6 +50,7 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     }
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
+#endif
 
 int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     long tid  = syscall_no_intercept(SYS_gettid);

--- a/capio/posix/handlers/dup.hpp
+++ b/capio/posix/handlers/dup.hpp
@@ -37,7 +37,13 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
     START_LOG(tid, "call(fd=%d, fd2=%d)", fd, fd2);
 
     if (exists_capio_fd(fd)) {
-        int res = static_cast<int>(syscall_no_intercept(SYS_dup2, fd, fd2));
+        int res = static_cast<int>(syscall_no_intercept(
+#ifded SYS_dup2
+            SYS_dup2, fd, fd2
+#else
+            SYS_dup3, fd, fd2, 0
+#endif
+        ));
         if (res == -1) {
             *result = -errno;
             return CAPIO_POSIX_SYSCALL_SUCCESS;

--- a/capio/posix/handlers/dup.hpp
+++ b/capio/posix/handlers/dup.hpp
@@ -38,7 +38,7 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
 
     if (exists_capio_fd(fd)) {
         int res = static_cast<int>(syscall_no_intercept(
-#ifded SYS_dup2
+#ifdef SYS_dup2
             SYS_dup2, fd, fd2
 #else
             SYS_dup3, fd, fd2, 0

--- a/capio/posix/handlers/fchmod.hpp
+++ b/capio/posix/handlers/fchmod.hpp
@@ -1,7 +1,7 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 #define CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 
-#if defined(SYS_chmod)
+#if defined(SYS_fchmod)
 
 int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int fd = static_cast<int>(arg0);
@@ -20,5 +20,5 @@ int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
-#endif // SYS_chmod
+#endif // SYS_fchmod
 #endif // CAPIO_POSIX_HANDLERS_FCHMOD_HPP

--- a/capio/posix/handlers/fchmod.hpp
+++ b/capio/posix/handlers/fchmod.hpp
@@ -1,11 +1,11 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 #define CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 
-#if defined(SYS_fchmod)
-
 int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int fd = static_cast<int>(arg0);
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
+
+    // TODO: Handle mode provided bt arg1
 
     if (!exists_capio_fd(fd)) {
         LOG("Syscall refers to file not handled by capio. Skipping it!");
@@ -20,5 +20,4 @@ int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
-#endif // SYS_fchmod
 #endif // CAPIO_POSIX_HANDLERS_FCHMOD_HPP

--- a/capio/posix/handlers/fchown.hpp
+++ b/capio/posix/handlers/fchown.hpp
@@ -1,8 +1,6 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCHOWN_HPP
 #define CAPIO_POSIX_HANDLERS_FCHOWN_HPP
 
-#if defined(SYS_chown)
-
 int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
     int fd = static_cast<int>(arg0);
     START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
@@ -18,8 +16,5 @@ int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long a
     *result = 0;
     LOG("File is present in capio. Ignoring fchmod operation");
     return CAPIO_POSIX_SYSCALL_SUCCESS;
-    return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
-
-#endif // SYS_chown
 #endif // CAPIO_POSIX_HANDLERS_FCHOWN_HPP

--- a/capio/posix/handlers/open.hpp
+++ b/capio/posix/handlers/open.hpp
@@ -37,7 +37,7 @@ inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, 
 
     if (is_capio_path(path)) {
         int fd = static_cast<int>(syscall_no_intercept(
-#ifded SYS_open
+#ifdef SYS_open
         SYS_open, "/dev/null", O_RDONLY
 #else
         SYS_openat, AT_FDCWD, "/dev/null", O_RDONLY

--- a/capio/posix/handlers/open.hpp
+++ b/capio/posix/handlers/open.hpp
@@ -36,7 +36,13 @@ inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, 
     }
 
     if (is_capio_path(path)) {
-        int fd = static_cast<int>(syscall_no_intercept(SYS_open, "/dev/null", O_RDONLY));
+        int fd = static_cast<int>(syscall_no_intercept(
+#ifded SYS_open
+        SYS_open, "/dev/null", O_RDONLY
+#else
+        SYS_openat, AT_FDCWD, "/dev/null", O_RDONLY
+#endif
+        ));
         if (fd == -1) {
             ERR_EXIT("capio_open, /dev/null opening");
         }

--- a/capio/posix/handlers/open.hpp
+++ b/capio/posix/handlers/open.hpp
@@ -36,13 +36,8 @@ inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, 
     }
 
     if (is_capio_path(path)) {
-        int fd = static_cast<int>(syscall_no_intercept(
-#ifdef SYS_open
-        SYS_open, "/dev/null", O_RDONLY
-#else
-        SYS_openat, AT_FDCWD, "/dev/null", O_RDONLY
-#endif
-        ));
+        int fd =
+            static_cast<int>(syscall_no_intercept(SYS_openat, AT_FDCWD, "/dev/null", O_RDONLY));
         if (fd == -1) {
             ERR_EXIT("capio_open, /dev/null opening");
         }

--- a/capio/posix/utils/filesystem.hpp
+++ b/capio/posix/utils/filesystem.hpp
@@ -237,13 +237,7 @@ std::filesystem::path get_dir_path(int dirfd) {
         char proclnk[128];
         char dir_pathname[PATH_MAX];
         sprintf(proclnk, "/proc/self/fd/%d", dirfd);
-        if (syscall_no_intercept(
-#ifdef SYS_readlink
-        SYS_readlink, proclnk, dir_pathname, PATH_MAX
-#else
-        SYS_readlinkat, AT_FDCWD, proclnk, dir_pathname, PATH_MAX
-#endif
-        ) < 0) {
+        if (syscall_no_intercept(SYS_readlinkat, AT_FDCWD, proclnk, dir_pathname, PATH_MAX) < 0) {
             LOG("failed to readlink\n");
             return {};
         }

--- a/capio/posix/utils/filesystem.hpp
+++ b/capio/posix/utils/filesystem.hpp
@@ -237,7 +237,13 @@ std::filesystem::path get_dir_path(int dirfd) {
         char proclnk[128];
         char dir_pathname[PATH_MAX];
         sprintf(proclnk, "/proc/self/fd/%d", dirfd);
-        if (syscall_no_intercept(SYS_readlink, proclnk, dir_pathname, PATH_MAX) < 0) {
+        if (syscall_no_intercept(
+#ifdef SYS_readlink
+        SYS_readlink, proclnk, dir_pathname, PATH_MAX
+#else
+        SYS_readlinkat, AT_FDCWD, proclnk, dir_pathname, PATH_MAX
+#endif
+        ) < 0) {
             LOG("failed to readlink\n");
             return {};
         }


### PR DESCRIPTION
This commit updates the internal syscalls used by the CAPIO to use more generic and modern system calls. It also uniforms the CMakeLists.txt file by ensuring that all different components have flags to enable/disable the compilation