### PR TITLE
Trickle down thread ID instead of executing syscall

### DIFF
--- a/capio/posix/handlers/access.hpp
+++ b/capio/posix/handlers/access.hpp
@@ -19,7 +19,7 @@ inline off64_t capio_faccessat(int dirfd, const std::string_view &pathname, mode
     std::filesystem::path path(pathname);
     if (path.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            path = capio_posix_realpath(pathname);
+            path = capio_posix_realpath(tid, pathname);
             if (path.empty()) {
                 errno = ENONET;
                 return CAPIO_POSIX_SYSCALL_ERRNO;
@@ -29,7 +29,7 @@ inline off64_t capio_faccessat(int dirfd, const std::string_view &pathname, mode
                 LOG("dirfd does not point to a directory");
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
-            const std::filesystem::path dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(tid, dirfd);
             if (dir_path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -45,23 +45,22 @@ inline off64_t capio_faccessat(int dirfd, const std::string_view &pathname, mode
     }
 }
 
-int access_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int access_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     auto mode = static_cast<mode_t>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_faccessat(AT_FDCWD, pathname, mode, 0, tid), result);
+    return posix_return_value(tid, capio_faccessat(AT_FDCWD, pathname, mode, 0, tid), result);
 }
 
-int faccessat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int faccessat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                       long *result) {
     auto dirfd = static_cast<int>(arg0);
     const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     auto mode  = static_cast<mode_t>(arg2);
     auto flags = static_cast<int>(arg3);
-    long tid   = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_faccessat(dirfd, pathname, mode, flags, tid), result);
+    return posix_return_value(tid, capio_faccessat(dirfd, pathname, mode, flags, tid), result);
 }
 
 #endif // SYS_access || SYS_faccessat || SYS_faccessat2

--- a/capio/posix/handlers/chdir.hpp
+++ b/capio/posix/handlers/chdir.hpp
@@ -11,9 +11,9 @@
  * to the kernel.
  */
 
-int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int chdir_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
-    long tid = syscall_no_intercept(SYS_gettid);
 
     START_LOG(tid, "call(path=%s)", pathname.data());
 
@@ -24,7 +24,7 @@ int chdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long ar
 
     std::filesystem::path path(pathname);
     if (path.is_relative()) {
-        path = capio_posix_realpath(path);
+        path = capio_posix_realpath(tid, path);
         if (path.empty()) {
             *result = -errno;
             return CAPIO_POSIX_SYSCALL_SUCCESS;

--- a/capio/posix/handlers/close.hpp
+++ b/capio/posix/handlers/close.hpp
@@ -5,13 +5,13 @@
 
 #include "utils/requests.hpp"
 
-int close_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    int fd   = static_cast<int>(arg0);
-    long tid = syscall_no_intercept(SYS_gettid);
+int close_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
+    int fd = static_cast<int>(arg0);
     START_LOG(tid, "call(fd=%ld)", fd);
 
-    if (exists_capio_fd(fd)) {
-        write_cache->flush();
+    if (exists_capio_fd(tid, fd)) {
+        write_cache->flush(tid);
         close_request(fd, tid);
         delete_capio_fd(fd);
         *result = 0;

--- a/capio/posix/handlers/dup.hpp
+++ b/capio/posix/handlers/dup.hpp
@@ -6,13 +6,13 @@
 #include "common/syscall.hpp"
 #include "utils/requests.hpp"
 
-int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    long tid = syscall_no_intercept(SYS_gettid);
-    int fd   = static_cast<int>(arg0);
+int dup_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                long *result) {
+    int fd = static_cast<int>(arg0);
 
     START_LOG(tid, "call(fd=%d)", fd);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         int res = open("/dev/null", O_WRONLY);
         if (res == -1) {
             *result = -errno;
@@ -28,14 +28,14 @@ int dup_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5
 }
 
 #ifdef SYS_dup2
-int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    long tid = syscall_no_intercept(SYS_gettid);
-    int fd   = static_cast<int>(arg0);
-    int fd2  = static_cast<int>(arg1);
+int dup2_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                 long *result) {
+    int fd  = static_cast<int>(arg0);
+    int fd2 = static_cast<int>(arg1);
 
     START_LOG(tid, "call(fd=%d, fd2=%d)", fd, fd2);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         int res = static_cast<int>(syscall_no_intercept(SYS_dup2, fd, fd2));
         if (res == -1) {
             *result = -errno;
@@ -52,8 +52,8 @@ int dup2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
 }
 #endif
 
-int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    long tid  = syscall_no_intercept(SYS_gettid);
+int dup3_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                 long *result) {
     int fd    = static_cast<int>(arg0);
     int fd2   = static_cast<int>(arg1);
     int flags = static_cast<int>(arg2);
@@ -62,7 +62,7 @@ int dup3_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg
 
     START_LOG(tid, "call(fd=%d, fd2=%d)", fd, fd2);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         if (fd == fd2) {
             errno   = EINVAL;
             *result = -errno;

--- a/capio/posix/handlers/execve.hpp
+++ b/capio/posix/handlers/execve.hpp
@@ -5,8 +5,8 @@
 
 #include "utils/snapshot.hpp"
 
-int execve_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    long tid = syscall_no_intercept(SYS_gettid);
+int execve_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     START_LOG(tid, "call()");
 
     create_snapshot(tid);

--- a/capio/posix/handlers/exit_group.hpp
+++ b/capio/posix/handlers/exit_group.hpp
@@ -14,13 +14,13 @@
  * with CAPIO
  */
 
-int exit_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
-    long tid = syscall_no_intercept(SYS_gettid);
+int exit_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                 long *result) {
     START_LOG(tid, "call()");
 
     LOG("Thread %d is a CAPIO thread: clean up", tid);
-    read_cache->flush();
-    write_cache->flush();
+    read_cache->flush(tid);
+    write_cache->flush(tid);
     exit_group_request(tid);
 
     return CAPIO_POSIX_SYSCALL_SKIP;

--- a/capio/posix/handlers/fchmod.hpp
+++ b/capio/posix/handlers/fchmod.hpp
@@ -1,13 +1,14 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 #define CAPIO_POSIX_HANDLERS_FCHMOD_HPP
 
-int fchmod_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int fchmod_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     int fd = static_cast<int>(arg0);
-    START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
+    START_LOG(tid, "call(fd=%d)", fd);
 
     // TODO: Handle mode provided bt arg1
 
-    if (!exists_capio_fd(fd)) {
+    if (!exists_capio_fd(tid, fd)) {
         LOG("Syscall refers to file not handled by capio. Skipping it!");
         return CAPIO_POSIX_SYSCALL_SKIP;
     }

--- a/capio/posix/handlers/fchown.hpp
+++ b/capio/posix/handlers/fchown.hpp
@@ -1,11 +1,12 @@
 #ifndef CAPIO_POSIX_HANDLERS_FCHOWN_HPP
 #define CAPIO_POSIX_HANDLERS_FCHOWN_HPP
 
-int fchown_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int fchown_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     int fd = static_cast<int>(arg0);
-    START_LOG(syscall_no_intercept(SYS_gettid), "call(fd=%d)", fd);
+    START_LOG(tid, "call(fd=%d)", fd);
 
-    if (!exists_capio_fd(fd)) {
+    if (!exists_capio_fd(tid, fd)) {
         LOG("Syscall refers to file not handled by capio. Skipping it!");
         return CAPIO_POSIX_SYSCALL_SKIP;
     }

--- a/capio/posix/handlers/fcntl.hpp
+++ b/capio/posix/handlers/fcntl.hpp
@@ -5,17 +5,17 @@
 
 #include "utils/requests.hpp"
 
-int fcntl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int fcntl_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     auto fd  = static_cast<int>(arg0);
     auto cmd = static_cast<int>(arg1);
     auto arg = static_cast<int>(arg2);
-    long tid = syscall_no_intercept(SYS_gettid);
 
     // int res = capio_fcntl(fd, cmd, arg, tid);
 
     START_LOG(tid, "call(fd=%d, cmd=%d, arg=%d)", fd, cmd, arg);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         switch (cmd) {
         case F_GETFD: {
             *result = get_capio_fd_cloexec(fd);

--- a/capio/posix/handlers/fgetxattr.hpp
+++ b/capio/posix/handlers/fgetxattr.hpp
@@ -3,16 +3,15 @@
 
 #if defined(SYS_fgetxattr)
 
-int fgetxattr_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int fgetxattr_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                       long *result) {
     std::string name(reinterpret_cast<const char *>(arg1));
     auto *value = reinterpret_cast<void *>(arg2);
     auto size   = static_cast<size_t>(arg3);
-    long tid    = syscall_no_intercept(SYS_gettid);
     auto fd     = static_cast<int>(arg0);
     START_LOG(tid, "call(name=%s, value=0x%08x, size=%ld)", name.c_str(), value, size);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         if (std::equal(name.begin(), name.end(), "system.posix_acl_access")) {
             errno   = ENODATA;
             *result = -errno;

--- a/capio/posix/handlers/fork.hpp
+++ b/capio/posix/handlers/fork.hpp
@@ -6,7 +6,8 @@
 #include "utils/clone.hpp"
 #include "utils/requests.hpp"
 
-int fork_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int fork_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                 long *result) {
     auto pid = static_cast<pid_t>(syscall_no_intercept(SYS_fork));
     START_LOG(syscall_no_intercept(SYS_gettid), "call(pid=%ld)", pid);
 

--- a/capio/posix/handlers/getcwd.hpp
+++ b/capio/posix/handlers/getcwd.hpp
@@ -3,10 +3,10 @@
 
 #if defined(SYS_getcwd)
 
-int getcwd_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int getcwd_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     auto buf  = reinterpret_cast<char *>(arg0);
     auto size = static_cast<size_t>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
     START_LOG(tid, "call(buf=0x%08x, size=%ld)", buf, size);
 

--- a/capio/posix/handlers/getdents.hpp
+++ b/capio/posix/handlers/getdents.hpp
@@ -8,26 +8,26 @@
 #include "utils/data.hpp"
 
 // TODO: too similar to capio_read, refactoring needed
-inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, bool is64bit) {
+inline int getdents_handler_impl(pid_t tid, long arg0, long arg1, long arg2, long *result,
+                                 bool is64bit) {
     auto fd      = static_cast<int>(arg0);
     auto *buffer = reinterpret_cast<struct linux_dirent64 *>(arg1);
     auto count   = static_cast<off64_t>(arg2);
-    long tid     = syscall_no_intercept(SYS_gettid);
 
     START_LOG(tid, "call(fd=%d, dirp=0x%08x, count=%ld, is64bit=%s)", fd, buffer, count,
               is64bit ? "true" : "false");
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         LOG("fd=%d, is a capio file descriptor", fd);
 
         if (count >= SSIZE_MAX) {
             ERR_EXIT("src does not support read bigger than SSIZE_MAX yet");
         }
-        write_cache->flush();
-        *result = read_cache->read(fd, buffer, count, true, is64bit);
+        write_cache->flush(tid);
+        *result = read_cache->read(tid, fd, buffer, count, true, is64bit);
 
-        DBG(tid, [](char *buf, off64_t count) {
-            START_LOG(syscall_no_intercept(SYS_gettid), "call (count=%ld)", count);
+        DBG(tid, [](pid_t tid, char *buf, off64_t count) {
+            START_LOG(tid, "call (count=%ld)", count);
             struct linux_dirent64 *d;
             LOG("%25s %12s %13s %15s   %s", "INODE", "TYPE", "RECORD_LENGTH", "OFFSET", "NAME");
             for (off64_t bpos = 0, i = 0; bpos < count && i < 10; i++) {
@@ -44,7 +44,7 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
                     d->d_reclen, d->d_off, d->d_name);
                 bpos += d->d_reclen;
             }
-        }(reinterpret_cast<char *>(buffer), *result));
+        }(tid, reinterpret_cast<char *>(buffer), *result));
 
         return CAPIO_POSIX_SYSCALL_SUCCESS;
     } else {
@@ -53,14 +53,14 @@ inline int getdents_handler_impl(long arg0, long arg1, long arg2, long *result, 
     return CAPIO_POSIX_SYSCALL_SKIP;
 }
 
-inline int getdents_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
-                            long *result) {
-    return getdents_handler_impl(arg0, arg1, arg2, result, false);
+inline int getdents_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4,
+                            long arg5, long *result) {
+    return getdents_handler_impl(tid, arg0, arg1, arg2, result, false);
 }
 
-inline int getdents64_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
-                              long *result) {
-    return getdents_handler_impl(arg0, arg1, arg2, result, true);
+inline int getdents64_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4,
+                              long arg5, long *result) {
+    return getdents_handler_impl(tid, arg0, arg1, arg2, result, true);
 }
 
 #endif // SYS_getdents || SYS_getdents64

--- a/capio/posix/handlers/ioctl.hpp
+++ b/capio/posix/handlers/ioctl.hpp
@@ -3,13 +3,13 @@
 
 #if defined(SYS_ioctl)
 
-int ioctl_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int ioctl_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     auto fd      = static_cast<int>(arg0);
     auto request = static_cast<unsigned long>(arg1);
-    long tid     = syscall_no_intercept(SYS_gettid);
     START_LOG(tid, "call(fd=%d, request=%ld)", fd, request, tid);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         errno   = ENOTTY;
         *result = -errno;
         return CAPIO_POSIX_SYSCALL_SUCCESS;

--- a/capio/posix/handlers/lseek.hpp
+++ b/capio/posix/handlers/lseek.hpp
@@ -6,12 +6,12 @@
 #include "utils/common.hpp"
 
 // TODO: EOVERFLOW is not addressed
-inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
+inline off64_t capio_lseek(int fd, off64_t offset, int whence, pid_t tid) {
     START_LOG(tid, "call(fd=%d, offset=%ld, whence=%d)", fd, offset, whence);
 
-    if (exists_capio_fd(fd)) {
-        read_cache->flush();
-        write_cache->flush();
+    if (exists_capio_fd(tid, fd)) {
+        read_cache->flush(tid);
+        write_cache->flush(tid);
         off64_t file_offset = get_capio_fd_offset(fd);
         if (whence == SEEK_SET) {
             LOG("whence %d is SEEK_SET", whence);
@@ -65,13 +65,13 @@ inline off64_t capio_lseek(int fd, off64_t offset, int whence, long tid) {
     }
 }
 
-int lseek_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int lseek_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     int fd      = static_cast<int>(arg0);
     auto offset = static_cast<off64_t>(arg1);
     int whence  = static_cast<int>(arg2);
-    long tid    = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_lseek(fd, offset, whence, tid), result);
+    return posix_return_value(tid, capio_lseek(fd, offset, whence, tid), result);
 }
 
 #endif // SYS_lseek

--- a/capio/posix/handlers/mkdir.hpp
+++ b/capio/posix/handlers/mkdir.hpp
@@ -6,7 +6,7 @@
 #include "utils/common.hpp"
 #include "utils/filesystem.hpp"
 
-inline off64_t capio_mkdirat(int dirfd, const std::string_view &pathname, mode_t mode, long tid) {
+inline off64_t capio_mkdirat(int dirfd, const std::string_view &pathname, mode_t mode, pid_t tid) {
     START_LOG(tid, "call(dirfd=%d, pathname=%s, mode=%o)", dirfd, pathname.data(), mode);
 
     if (is_forbidden_path(pathname)) {
@@ -17,7 +17,7 @@ inline off64_t capio_mkdirat(int dirfd, const std::string_view &pathname, mode_t
     std::filesystem::path path(pathname);
     if (path.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            path = capio_posix_realpath(path);
+            path = capio_posix_realpath(tid, path);
             if (path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -25,7 +25,7 @@ inline off64_t capio_mkdirat(int dirfd, const std::string_view &pathname, mode_t
             if (!is_directory(dirfd)) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
-            const std::filesystem::path dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(tid, dirfd);
             if (dir_path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -61,7 +61,7 @@ inline off64_t capio_rmdir(const std::string_view &pathname, long tid) {
 
     std::filesystem::path path(pathname);
     if (path.is_relative()) {
-        path = capio_posix_realpath(path);
+        path = capio_posix_realpath(tid, path);
         if (path.empty()) {
             LOG("path_to_check.len = 0!");
             return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
@@ -89,29 +89,28 @@ inline off64_t capio_rmdir(const std::string_view &pathname, long tid) {
     }
 }
 
-int mkdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int mkdir_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     auto mode = static_cast<mode_t>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_mkdirat(AT_FDCWD, pathname, mode, tid), result);
+    return posix_return_value(tid, capio_mkdirat(AT_FDCWD, pathname, mode, tid), result);
 }
 
-int mkdirat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int mkdirat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                     long *result) {
     int dirfd = static_cast<int>(arg0);
     const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     auto mode = static_cast<mode_t>(arg2);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_mkdirat(dirfd, pathname, mode, tid), result);
+    return posix_return_value(tid, capio_mkdirat(dirfd, pathname, mode, tid), result);
 }
 
-int rmdir_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int rmdir_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
-    long tid = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_rmdir(pathname, tid), result);
+    return posix_return_value(tid, capio_rmdir(pathname, tid), result);
 }
 
 #endif // SYS_mkdir || SYS_mkdirat || SYS_rmdir

--- a/capio/posix/handlers/open.hpp
+++ b/capio/posix/handlers/open.hpp
@@ -17,7 +17,7 @@ inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, 
     std::filesystem::path path(pathname);
     if (path.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            path = capio_posix_realpath(path);
+            path = capio_posix_realpath(tid, path);
             if (path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -26,7 +26,7 @@ inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, 
                 LOG("dirfd does not point to a directory");
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
-            const std::filesystem::path dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(tid, dirfd);
             if (dir_path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -80,29 +80,29 @@ inline int capio_openat(int dirfd, const std::string_view &pathname, int flags, 
     }
 }
 
-int creat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int creat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
-    long tid = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_openat(AT_FDCWD, pathname, O_CREAT | O_WRONLY | O_TRUNC, tid),
-                              result);
+    return posix_return_value(
+        tid, capio_openat(AT_FDCWD, pathname, O_CREAT | O_WRONLY | O_TRUNC, tid), result);
 }
 
-int open_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int open_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                 long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     int flags = static_cast<int>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_openat(AT_FDCWD, pathname, flags, tid), result);
+    return posix_return_value(tid, capio_openat(AT_FDCWD, pathname, flags, tid), result);
 }
 
-int openat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int openat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     int dirfd = static_cast<int>(arg0);
     const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     int flags = static_cast<int>(arg2);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_openat(dirfd, pathname, flags, tid), result);
+    return posix_return_value(tid, capio_openat(dirfd, pathname, flags, tid), result);
 }
 
 #endif // SYS_creat || SYS_open || SYS_openat

--- a/capio/posix/handlers/read.hpp
+++ b/capio/posix/handlers/read.hpp
@@ -5,16 +5,16 @@
 
 #include "utils/data.hpp"
 
-inline off64_t capio_read(int fd, void *buffer, off64_t count, long tid) {
+inline off64_t capio_read(int fd, void *buffer, off64_t count, pid_t tid) {
     START_LOG(tid, "call(fd=%d, buf=0x%08x, count=%ld)", fd, buffer, count);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         if (count >= SSIZE_MAX) {
             ERR_EXIT("CAPIO does not support read bigger than SSIZE_MAX yet");
         }
 
-        write_cache->flush();
-        return read_cache->read(fd, buffer, count, false, false);
+        write_cache->flush(tid);
+        return read_cache->read(tid, fd, buffer, count, false, false);
     } else {
         return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
@@ -24,7 +24,7 @@ inline ssize_t capio_readv(int fd, const struct iovec *iov, int iovcnt, long tid
     START_LOG(tid, "call(fd=%d, iov.iov_base=0x%08x, iov.iov_len=%ld, iovcnt=%d)", fd,
               iov->iov_base, iov->iov_len, iovcnt);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         LOG("fd %d exists and is a capio fd", fd);
         ssize_t tot_bytes = 0;
         ssize_t res       = 0;
@@ -48,22 +48,22 @@ inline ssize_t capio_readv(int fd, const struct iovec *iov, int iovcnt, long tid
     }
 }
 
-int read_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int read_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                 long *result) {
     int fd       = static_cast<int>(arg0);
     void *buffer = reinterpret_cast<void *>(arg1);
     auto count   = static_cast<off64_t>(arg2);
-    long tid     = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_read(fd, buffer, count, tid), result);
+    return posix_return_value(tid, capio_read(fd, buffer, count, tid), result);
 }
 
-int readv_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int readv_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     auto fd         = static_cast<int>(arg0);
     const auto *iov = reinterpret_cast<const struct iovec *>(arg1);
     auto iovcnt     = static_cast<int>(arg2);
-    long tid        = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_readv(fd, iov, iovcnt, tid), result);
+    return posix_return_value(tid, capio_readv(fd, iov, iovcnt, tid), result);
 }
 
 #endif // SYS_read || SYS_readv

--- a/capio/posix/handlers/rename.hpp
+++ b/capio/posix/handlers/rename.hpp
@@ -3,14 +3,13 @@
 
 #include "utils/filesystem.hpp"
 
-int renameat2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int renameat2_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                       long *result) {
     const auto flags                            = arg4;
-    const std::filesystem::path old_dir_fd_path = get_dir_path(static_cast<int>(arg0));
+    const std::filesystem::path old_dir_fd_path = get_dir_path(tid, static_cast<int>(arg0));
     const std::filesystem::path old_path(reinterpret_cast<const char *>(arg1));
-    const std::filesystem::path new_dir_fd_path = get_dir_path(static_cast<int>(arg2));
+    const std::filesystem::path new_dir_fd_path = get_dir_path(tid, static_cast<int>(arg2));
     const std::filesystem::path new_path(reinterpret_cast<const char *>(arg3));
-    const long tid = syscall_no_intercept(SYS_gettid);
 
     // TODO: implement handling of FLAGS
 
@@ -21,10 +20,10 @@ int renameat2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
 
     // Resolve paths relative to path of dir_fd ONLY if input path is not absolute
     const auto old_path_abs =
-        old_path.is_absolute() ? old_path : capio_absolute(old_dir_fd_path / old_path);
+        old_path.is_absolute() ? old_path : capio_absolute(tid, old_dir_fd_path / old_path);
 
     const auto new_path_abs =
-        new_path.is_absolute() ? new_path : capio_absolute(new_dir_fd_path / new_path);
+        new_path.is_absolute() ? new_path : capio_absolute(tid, new_dir_fd_path / new_path);
 
     if (is_prefix(old_path_abs, new_path_abs)) { // TODO: The check is more complex
         errno   = EINVAL;
@@ -48,15 +47,16 @@ int renameat2_handler(long arg0, long arg1, long arg2, long arg3, long arg4, lon
     }
 }
 
-int rename_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int rename_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     // Force flags to zero to ensure that spurious data is being passed to handler
-    return renameat2_handler(AT_FDCWD, arg0, AT_FDCWD, arg1, 0, 0, result);
+    return renameat2_handler(tid, AT_FDCWD, arg0, AT_FDCWD, arg1, 0, 0, result);
 }
 
-int renameat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int renameat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                      long *result) {
     // Force flags to zero to ensure that spurious data is being passed to handler
-    return renameat2_handler(arg0, arg1, arg2, arg3, 0, arg5, result);
+    return renameat2_handler(tid, arg0, arg1, arg2, arg3, 0, arg5, result);
 }
 
 #endif // CAPIO_POSIX_HANDLERS_RENAME_HPP

--- a/capio/posix/handlers/stat.hpp
+++ b/capio/posix/handlers/stat.hpp
@@ -15,9 +15,9 @@ inline blkcnt_t get_nblocks(off64_t file_size) {
     return (file_size % 4096 == 0) ? (file_size / 512) : (file_size / 512 + 8);
 }
 
-inline void fill_statbuf(struct stat *statbuf, off_t file_size, bool is_dir, ino_t inode) {
-    START_LOG(syscall_no_intercept(SYS_gettid),
-              "call(statbuf=0x%08x, file_size=%ld, is_dir=%s, inode=%ul)", statbuf, file_size,
+inline void fill_statbuf(pid_t tid, struct stat *statbuf, off_t file_size, bool is_dir,
+                         ino_t inode) {
+    START_LOG(tid, "call(statbuf=0x%08x, file_size=%ld, is_dir=%s, inode=%ul)", statbuf, file_size,
               is_dir ? "true" : "false", inode);
 
     timespec time{1, 1};
@@ -41,24 +41,25 @@ inline void fill_statbuf(struct stat *statbuf, off_t file_size, bool is_dir, ino
     statbuf->st_ctim    = time;
 }
 
-inline int capio_fstat(int fd, struct stat *statbuf, long tid) {
+inline int capio_fstat(int fd, struct stat *statbuf, pid_t tid) {
     START_LOG(tid, "call(fd=%d, statbuf=0x%08x)", fd, statbuf);
 
-    if (exists_capio_fd(fd)) {
-        write_cache->flush();
+    if (exists_capio_fd(tid, fd)) {
+        write_cache->flush(tid);
         auto [file_size, is_dir] = fstat_request(fd, tid);
         if (file_size == -1) {
             errno = ENOENT;
             return CAPIO_POSIX_SYSCALL_ERRNO;
         }
-        fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(get_capio_fd_path(fd)));
+        fill_statbuf(tid, statbuf, file_size, is_dir,
+                     std::hash<std::string>{}(get_capio_fd_path(fd)));
         return CAPIO_POSIX_SYSCALL_SUCCESS;
     } else {
         return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 }
 
-inline int capio_lstat(const std::string_view &pathname, struct stat *statbuf, long tid) {
+inline int capio_lstat(const std::string_view &pathname, struct stat *statbuf, pid_t tid) {
     START_LOG(tid, "call(absolute_path=%s, statbuf=0x%08x)", pathname.data(), statbuf);
 
     if (is_forbidden_path(pathname)) {
@@ -68,7 +69,7 @@ inline int capio_lstat(const std::string_view &pathname, struct stat *statbuf, l
 
     const std::filesystem::path absolute_path(pathname);
     if (is_capio_path(absolute_path)) {
-        write_cache->flush();
+        write_cache->flush(tid);
         auto [file_size, is_dir] = stat_request(absolute_path, tid);
         if (file_size == -1) {
             errno = ENOENT;
@@ -80,7 +81,7 @@ inline int capio_lstat(const std::string_view &pathname, struct stat *statbuf, l
             return file_size;
         }
 
-        fill_statbuf(statbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path));
+        fill_statbuf(tid, statbuf, file_size, is_dir, std::hash<std::string>{}(absolute_path));
         return CAPIO_POSIX_SYSCALL_SUCCESS;
     }
     return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
@@ -94,7 +95,7 @@ inline int capio_lstat_wrapper(const std::string_view &pathname, struct stat *st
         return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
 
-    const std::filesystem::path absolute_path = capio_posix_realpath(pathname);
+    const std::filesystem::path absolute_path = capio_posix_realpath(tid, pathname);
     if (absolute_path.empty()) {
         errno = ENOENT;
         return CAPIO_POSIX_SYSCALL_ERRNO;
@@ -128,7 +129,7 @@ inline int capio_fstatat(int dirfd, const std::string_view &pathname, struct sta
                 errno = ENOTDIR;
                 return CAPIO_POSIX_SYSCALL_ERRNO;
             }
-            const std::filesystem::path dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(tid, dirfd);
             if (dir_path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -140,39 +141,38 @@ inline int capio_fstatat(int dirfd, const std::string_view &pathname, struct sta
     }
 }
 
-int fstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int fstat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     auto fd   = static_cast<int>(arg0);
     auto *buf = reinterpret_cast<struct stat *>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_fstat(fd, buf, tid), result);
+    return posix_return_value(tid, capio_fstat(fd, buf, tid), result);
 }
 
-int fstatat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int fstatat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                     long *result) {
     auto dirfd = static_cast<int>(arg0);
     const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     auto *statbuf = reinterpret_cast<struct stat *>(arg2);
     auto flags    = static_cast<int>(arg3);
-    long tid      = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_fstatat(dirfd, pathname, statbuf, flags, tid), result);
+    return posix_return_value(tid, capio_fstatat(dirfd, pathname, statbuf, flags, tid), result);
 }
 
-int lstat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int lstat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     auto *buf = reinterpret_cast<struct stat *>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_lstat_wrapper(pathname, buf, tid), result);
+    return posix_return_value(tid, capio_lstat_wrapper(pathname, buf, tid), result);
 }
 
-int stat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int stat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                 long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
     auto *buf = reinterpret_cast<struct stat *>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_lstat_wrapper(pathname, buf, tid), result);
+    return posix_return_value(tid, capio_lstat_wrapper(pathname, buf, tid), result);
 }
 
 #endif // SYS_fstat || SYS_lstat || SYS_newfstatat || SYS_stat

--- a/capio/posix/handlers/statfs.hpp
+++ b/capio/posix/handlers/statfs.hpp
@@ -3,15 +3,14 @@
 
 #if defined(SYS_fstatfs)
 
-int fstatfs_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int fstatfs_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                     long *result) {
     auto fd   = static_cast<int>(arg0);
     auto *buf = reinterpret_cast<struct statfs *>(arg1);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
     START_LOG(tid, "call(fd=%d, buf=0x%08x)", fd, buf);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         const std::filesystem::path path(get_capio_fd_path(fd));
 
         *result = static_cast<int>(syscall_no_intercept(SYS_statfs, get_capio_dir().c_str(), buf));

--- a/capio/posix/handlers/statx.hpp
+++ b/capio/posix/handlers/statx.hpp
@@ -5,10 +5,10 @@
 
 #include "utils/common.hpp"
 
-inline void fill_statxbuf(struct statx *statxbuf, off_t file_size, bool is_dir, ino_t inode,
-                          int mask) {
-    START_LOG(syscall_no_intercept(SYS_gettid), "call(filesize=%ld, is_dir=%s, inode=%d, mask=%d)",
-              file_size, is_dir ? "true" : "false", mask);
+inline void fill_statxbuf(pid_t tid, struct statx *statxbuf, off_t file_size, bool is_dir,
+                          ino_t inode, int mask) {
+    START_LOG(tid, "call(filesize=%ld, is_dir=%s, inode=%d, mask=%d)", file_size,
+              is_dir ? "true" : "false", mask);
 
     statx_timestamp time{1, 1};
     if (is_dir == 1) {
@@ -51,7 +51,7 @@ inline int capio_statx(int dirfd, const std::string_view &pathname, int flags, i
             LOG("dirfd is AT_FDCWD");
             path = get_current_dir();
         } else { // operate on dirfd. in this case dirfd can refer to any type of file
-            if (exists_capio_fd(dirfd)) {
+            if (exists_capio_fd(tid, dirfd)) {
                 path = get_capio_fd_path(dirfd);
             } else {
                 LOG("returning -2 due to !exists_capio_fd");
@@ -62,7 +62,7 @@ inline int capio_statx(int dirfd, const std::string_view &pathname, int flags, i
         if (path.is_relative()) {
             if (dirfd == AT_FDCWD) {
                 LOG("dirfd is AT_FDCWD");
-                path = capio_posix_realpath(path);
+                path = capio_posix_realpath(tid, path);
                 if (path.empty()) {
                     LOG("returning -1 due to pathname empty");
                     errno = ENOENT;
@@ -74,7 +74,7 @@ inline int capio_statx(int dirfd, const std::string_view &pathname, int flags, i
                     errno = ENOTDIR;
                     return CAPIO_POSIX_SYSCALL_ERRNO;
                 }
-                const std::filesystem::path dir_path = get_dir_path(dirfd);
+                const std::filesystem::path dir_path = get_dir_path(tid, dirfd);
                 if (dir_path.empty()) {
                     LOG("returning -2 due to dir path empty");
                     return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
@@ -88,7 +88,7 @@ inline int capio_statx(int dirfd, const std::string_view &pathname, int flags, i
         }
     }
 
-    write_cache->flush();
+    write_cache->flush(tid);
     auto [file_size, is_dir] = stat_request(path, tid);
     if (file_size == -1) {
         errno = ENOENT;
@@ -97,19 +97,19 @@ inline int capio_statx(int dirfd, const std::string_view &pathname, int flags, i
     if (file_size == CAPIO_POSIX_SYSCALL_REQUEST_SKIP) {
         return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
     }
-    fill_statxbuf(statxbuf, file_size, is_dir, std::hash<std::string>{}(path), mask);
+    fill_statxbuf(tid, statxbuf, file_size, is_dir, std::hash<std::string>{}(path), mask);
     return CAPIO_POSIX_SYSCALL_SUCCESS;
 }
 
-int statx_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int statx_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     auto dirfd = static_cast<int>(arg0);
     const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     auto flags = static_cast<int>(arg2);
     auto mask  = static_cast<int>(arg3);
     auto *buf  = reinterpret_cast<struct statx *>(arg4);
-    long tid   = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_statx(dirfd, pathname, flags, mask, buf, tid), result);
+    return posix_return_value(tid, capio_statx(dirfd, pathname, flags, mask, buf, tid), result);
 }
 
 #endif // SYS_statx

--- a/capio/posix/handlers/unlink.hpp
+++ b/capio/posix/handlers/unlink.hpp
@@ -39,7 +39,7 @@ inline off64_t capio_unlinkat(int dirfd, const std::string_view &pathname, int f
     std::filesystem::path path(pathname);
     if (path.is_relative()) {
         if (dirfd == AT_FDCWD) {
-            path = capio_posix_realpath(path);
+            path = capio_posix_realpath(tid, path);
             if (path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -48,7 +48,7 @@ inline off64_t capio_unlinkat(int dirfd, const std::string_view &pathname, int f
             if (!is_directory(dirfd)) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
-            const std::filesystem::path dir_path = get_dir_path(dirfd);
+            const std::filesystem::path dir_path = get_dir_path(tid, dirfd);
             if (dir_path.empty()) {
                 return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
             }
@@ -62,21 +62,20 @@ inline off64_t capio_unlinkat(int dirfd, const std::string_view &pathname, int f
     return res;
 }
 
-int unlink_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int unlink_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     const std::string_view pathname(reinterpret_cast<const char *>(arg0));
-    long tid = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_unlinkat(AT_FDCWD, pathname, 0, tid), result);
+    return posix_return_value(tid, capio_unlinkat(AT_FDCWD, pathname, 0, tid), result);
 }
 
-int unlinkat_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+int unlinkat_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
                      long *result) {
     int dirfd = static_cast<int>(arg0);
     const std::string_view pathname(reinterpret_cast<const char *>(arg1));
     int flags = static_cast<int>(arg2);
-    long tid  = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_unlinkat(dirfd, pathname, flags, tid), result);
+    return posix_return_value(tid, capio_unlinkat(dirfd, pathname, flags, tid), result);
 }
 
 #endif // SYS_unlink || SYS_unlinkat

--- a/capio/posix/handlers/write.hpp
+++ b/capio/posix/handlers/write.hpp
@@ -9,14 +9,14 @@
 inline off64_t capio_write(int fd, const void *buffer, off64_t count, long tid) {
     START_LOG(tid, "call(fd=%d, buf=0x%08x, count=%ld)", fd, buffer, count);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         if (count > SSIZE_MAX) {
             ERR_EXIT("Capio does not support writes bigger than "
                      "SSIZE_MAX yet");
         }
 
-        read_cache->flush();
-        write_cache->write(fd, buffer, count);
+        read_cache->flush(tid);
+        write_cache->write(tid, fd, buffer, count);
 
         return count;
     } else {
@@ -24,11 +24,11 @@ inline off64_t capio_write(int fd, const void *buffer, off64_t count, long tid) 
     }
 }
 
-inline off64_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long tid) {
+inline off64_t capio_writev(int fd, const iovec *iov, int iovcnt, long tid) {
     START_LOG(tid, "call(fd=%d, iov.iov_base=0x%08x, iov.iov_len=%ld, iovcnt=%d)", fd,
               iov->iov_base, iov->iov_len, iovcnt);
 
-    if (exists_capio_fd(fd)) {
+    if (exists_capio_fd(tid, fd)) {
         LOG("fd %d exists and is a capio fd", fd);
         off64_t tot_bytes = 0;
         off64_t res       = 0;
@@ -52,22 +52,22 @@ inline off64_t capio_writev(int fd, const struct iovec *iov, int iovcnt, long ti
     }
 }
 
-int write_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int write_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                  long *result) {
     auto fd         = static_cast<int>(arg0);
     const auto *buf = reinterpret_cast<const void *>(arg1);
     auto count      = static_cast<off64_t>(arg2);
-    long tid        = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_write(fd, buf, count, tid), result);
+    return posix_return_value(tid, capio_write(fd, buf, count, tid), result);
 }
 
-int writev_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5, long *result) {
+int writev_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
+                   long *result) {
     auto fd         = static_cast<int>(arg0);
     const auto *iov = reinterpret_cast<const struct iovec *>(arg1);
     auto iovcnt     = static_cast<int>(arg2);
-    long tid        = syscall_no_intercept(SYS_gettid);
 
-    return posix_return_value(capio_writev(fd, iov, iovcnt, tid), result);
+    return posix_return_value(tid, capio_writev(fd, iov, iovcnt, tid), result);
 }
 
 #endif // SYS_write || SYS_writev

--- a/capio/posix/libcapio_posix.cpp
+++ b/capio/posix/libcapio_posix.cpp
@@ -3,6 +3,8 @@
  * if -1, and capio logging is enable everything is logged, otherwise, only
  * logs up to CAPIO_MAX_LOG_LEVEL function calls
  */
+#include <unistd.h>
+static thread_local pid_t current_tid = -1;
 
 #include <array>
 #include <string>
@@ -15,11 +17,13 @@
 
 #include "handlers.hpp"
 
+#include <thread>
+
 /**
  * Handler for syscall not handled and interrupt syscall_intercept
  */
-static int not_handled_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
-                               long *result) {
+static int not_handled_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4,
+                               long arg5, long *result) {
     return 1;
 }
 
@@ -27,8 +31,8 @@ static int not_handled_handler(long arg0, long arg1, long arg2, long arg3, long 
  * Handler for syscall handled, but not yet implemented and interrupt
  * syscall_intercept
  */
-static int not_implemented_handler(long arg0, long arg1, long arg2, long arg3, long arg4, long arg5,
-                                   long *result) {
+static int not_implemented_handler(pid_t tid, long arg0, long arg1, long arg2, long arg3, long arg4,
+                                   long arg5, long *result) {
     errno   = ENOTSUP;
     *result = -errno;
     return 0;
@@ -330,6 +334,10 @@ static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3,
         build_syscall_table();
     static const char *capio_dir = std::getenv("CAPIO_DIR");
 
+    if (current_tid == -1) {
+        current_tid = static_cast<pid_t>(syscall_no_intercept(SYS_gettid));
+    }
+
 #ifdef SYS_futex
     /**
      * Old glibc versions call the SYS_futex syscall when accessing a thread_local
@@ -351,7 +359,7 @@ static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3,
     CAPIO_LOG_LEVEL = get_capio_log_level();
 #endif
 
-    START_LOG(syscall_no_intercept(SYS_gettid), "call(syscall_number=%ld)", syscall_number);
+    START_LOG(current_tid, "call(syscall_number=%ld)", syscall_number);
 
     // If the syscall_number is higher than the maximum
     // syscall captured by CAPIO, simply return
@@ -367,7 +375,8 @@ static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3,
     }
 
     try {
-        return syscallTable[syscall_number](arg0, arg1, arg2, arg3, arg4, arg5, result);
+        return syscallTable[syscall_number](current_tid, arg0, arg1, arg2, arg3, arg4, arg5,
+                                            result);
     } catch (const std::exception &exception) {
         syscall_no_intercept_flag = true;
 
@@ -395,14 +404,14 @@ static int hook(long syscall_number, long arg0, long arg1, long arg2, long arg3,
 
 static __attribute__((constructor)) void init() {
 
-    const long tid = syscall_no_intercept(SYS_gettid);
+    current_tid = static_cast<pid_t>(syscall_no_intercept(SYS_gettid));
 
-    init_client(tid);
+    init_client(current_tid);
     init_filesystem();
     initialize_new_thread();
 
-    if (const int *fd_shm = get_fd_snapshot(tid); fd_shm != nullptr) {
-        initialize_from_snapshot(fd_shm, tid);
+    if (const int *fd_shm = get_fd_snapshot(current_tid); fd_shm != nullptr) {
+        initialize_from_snapshot(fd_shm, current_tid);
     }
 
     intercept_hook_point_clone_child  = hook_clone_child;

--- a/capio/posix/utils/cache.hpp
+++ b/capio/posix/utils/cache.hpp
@@ -14,8 +14,8 @@ class ReadCache {
     off64_t _max_line_size, _actual_size, _cache_offset;
     SPSCQueue _queue;
 
-    inline void _read(void *buffer, off64_t count) {
-        START_LOG(capio_syscall(SYS_gettid), "call(count=%ld)", count);
+    inline void _read(pid_t tid, void *buffer, off64_t count) {
+        START_LOG(tid, "call(count=%ld)", count);
 
         if (count > 0) {
             memcpy(buffer, _cache + _cache_offset, count);
@@ -30,8 +30,8 @@ class ReadCache {
           _cache_offset(0),
           _queue(SHM_SPSC_PREFIX_READ + std::to_string(tid), lines, line_size, workflow_name) {}
 
-    inline void flush() {
-        START_LOG(capio_syscall(SYS_gettid), "call()");
+    inline void flush(pid_t tid) {
+        START_LOG(tid, "call()");
 
         if (_cache_offset != _actual_size) {
             _actual_size = _cache_offset = 0;
@@ -39,13 +39,14 @@ class ReadCache {
         }
     }
 
-    inline off64_t read(int fd, void *buffer, off64_t count, bool is_getdents, bool is64bit) {
-        START_LOG(capio_syscall(SYS_gettid), "call(fd=%d, count=%ld, is_getdents=%s, is64bit=%s)",
-                  fd, count, is_getdents ? "true" : "false", is64bit ? "true" : "false");
+    inline off64_t read(pid_t tid, int fd, void *buffer, off64_t count, bool is_getdents,
+                        bool is64bit) {
+        START_LOG(tid, "call(fd=%d, count=%ld, is_getdents=%s, is64bit=%s)", fd, count,
+                  is_getdents ? "true" : "false", is64bit ? "true" : "false");
 
         if (_last_fd != fd) {
             LOG("changed fd from %d to %d: flushing", _last_fd, fd);
-            flush();
+            flush(tid);
             _last_fd = fd;
         }
 
@@ -63,11 +64,11 @@ class ReadCache {
 
         if (count <= remaining_bytes) {
             LOG("count %ld <= remaining_bytes %ld", count, remaining_bytes);
-            _read(buffer, count);
+            _read(tid, buffer, count);
             bytes_read = count;
         } else {
             LOG("count %ld > remaining_bytes %ld", count, remaining_bytes);
-            _read(buffer, remaining_bytes);
+            _read(tid, buffer, remaining_bytes);
             buffer = reinterpret_cast<char *>(buffer) + remaining_bytes;
 
             // NOTE: if getdents send a request for exactly the correct amount of data.
@@ -94,11 +95,11 @@ class ReadCache {
                 }
                 if (read_size < _actual_size) {
                     LOG("count - remaining_bytes %ld < _actual_size %ld", read_size, _actual_size);
-                    _read(buffer, read_size);
+                    _read(tid, buffer, read_size);
                     bytes_read = count;
                 } else {
                     LOG("count - remaining_bytes %ld >= _actual_size %ld", read_size, _actual_size);
-                    _read(buffer, _actual_size);
+                    _read(tid, buffer, _actual_size);
                     bytes_read = remaining_bytes + _actual_size;
                 }
             }
@@ -118,8 +119,8 @@ class WriteCache {
     off64_t _max_line_size, _actual_size;
     SPSCQueue _queue;
 
-    inline void _write(off64_t count, const void *buffer) {
-        START_LOG(capio_syscall(SYS_gettid), "call(count=%ld)", count);
+    inline void _write(pid_t tid, off64_t count, const void *buffer) {
+        START_LOG(tid, "call(count=%ld)", count);
 
         if (count > 0) {
             if (_cache == nullptr) {
@@ -128,7 +129,7 @@ class WriteCache {
             memcpy(_cache + _actual_size, buffer, count);
             _actual_size += count;
             if (_actual_size == _max_line_size) {
-                flush();
+                flush(tid);
             }
         }
     }
@@ -138,8 +139,8 @@ class WriteCache {
         : _cache(nullptr), _tid(tid), _fd(-1), _max_line_size(line_size), _actual_size(0),
           _queue(SHM_SPSC_PREFIX_WRITE + std::to_string(tid), lines, line_size, workflow_name) {}
 
-    inline void flush() {
-        START_LOG(capio_syscall(SYS_gettid), "call()");
+    inline void flush(pid_t tid) {
+        START_LOG(tid, "call()");
 
         if (_actual_size != 0) {
             write_request(_fd, _actual_size, _tid);
@@ -148,24 +149,23 @@ class WriteCache {
         }
     }
 
-    inline void write(int fd, const void *buffer, off64_t count) {
-        START_LOG(capio_syscall(SYS_gettid), "call(fd=%d, buffer=0x%08x, count=%ld)", fd, buffer,
-                  count);
+    inline void write(pid_t tid, int fd, const void *buffer, off64_t count) {
+        START_LOG(tid, "call(fd=%d, buffer=0x%08x, count=%ld)", fd, buffer, count);
 
         if (_fd != fd) {
             LOG("changed fd from %d to %d: flushing", _fd, fd);
-            flush();
+            flush(tid);
             _fd = fd;
         }
 
         if (count <= _max_line_size - _actual_size) {
             LOG("count %ld <= _max_line_size - _actual_size %ld", count,
                 _max_line_size - _actual_size);
-            _write(count, buffer);
+            _write(tid, count, buffer);
         } else {
             LOG("count %ld > _max_line_size - _actual_size %ld", count,
                 _max_line_size - _actual_size);
-            flush();
+            flush(tid);
             if (count - _actual_size > _max_line_size) {
                 LOG("count - _actual_size %ld > _max_line_size %ld", count - _actual_size,
                     _max_line_size);
@@ -174,7 +174,7 @@ class WriteCache {
             } else {
                 LOG("count - _actual_size %ld <= _max_line_size %ld", count - _actual_size,
                     _max_line_size);
-                _write(count, buffer);
+                _write(tid, count, buffer);
             }
         }
 

--- a/capio/posix/utils/clone.hpp
+++ b/capio/posix/utils/clone.hpp
@@ -13,20 +13,20 @@
  * is called after a SYS_clone is issued.
  */
 inline void initialize_new_thread(const bool wait = false) {
-    const long tid = syscall_no_intercept(SYS_gettid);
+    current_tid    = static_cast<pid_t>(syscall_no_intercept(SYS_gettid));
     const long pid = syscall_no_intercept(SYS_getpid);
 
     syscall_no_intercept_flag = true;
     const auto capio_app_name = get_capio_app_name();
     syscall_no_intercept_flag = false;
 
-    START_LOG(tid, "call(tid=%d, pid=%d, app_name=%s)", tid, pid, capio_app_name);
+    START_LOG(current_tid, "call(tid=%d, pid=%d, app_name=%s)", current_tid, pid, capio_app_name);
 
-    initialize_data_queues(tid);
-    init_client(tid);
+    initialize_data_queues(current_tid);
+    init_client(current_tid);
 
-    handshake_named_request(tid, pid, capio_app_name, wait);
-    LOG("Starting child thread %d", tid);
+    handshake_named_request(current_tid, pid, capio_app_name, wait);
+    LOG("Starting child thread %d", current_tid);
 }
 
 inline void hook_clone_parent(long child_tid) {

--- a/capio/posix/utils/common.hpp
+++ b/capio/posix/utils/common.hpp
@@ -3,8 +3,8 @@
 #ifndef CAPIO_FUNCTIONS_H
 #define CAPIO_FUNCTIONS_H
 
-int posix_return_value(long res, long *result) {
-    START_LOG(capio_syscall(SYS_gettid), "cal(res=%ld)", res);
+int posix_return_value(pid_t tid, long res, long *result) {
+    START_LOG(tid, "cal(res=%ld)", res);
     if (res != CAPIO_POSIX_SYSCALL_REQUEST_SKIP) {
         *result = (res < 0 ? -errno : res);
         LOG("SYSCALL handled by capio. errno is: %s", res < 0 ? strerror(-errno) : "none");

--- a/capio/posix/utils/filesystem.hpp
+++ b/capio/posix/utils/filesystem.hpp
@@ -66,8 +66,8 @@ inline void add_capio_fd(long tid, const std::string &path, int fd, off64_t offs
  * @param pathname
  * @return
  */
-std::filesystem::path capio_posix_realpath(const std::filesystem::path &pathname) {
-    START_LOG(syscall_no_intercept(SYS_gettid), "call(path=%s)", pathname.c_str());
+std::filesystem::path capio_posix_realpath(pid_t tid, const std::filesystem::path &pathname) {
+    START_LOG(tid, "call(path=%s)", pathname.c_str());
     char *posix_real_path = capio_realpath((char *) pathname.c_str(), nullptr);
 
     // if capio_realpath fails, then it should be a capio_file
@@ -100,8 +100,8 @@ std::filesystem::path capio_posix_realpath(const std::filesystem::path &pathname
  * @param path
  * @return
  */
-inline std::filesystem::path capio_absolute(const std::filesystem::path &path) {
-    return path.is_absolute() ? path : capio_posix_realpath(path);
+inline std::filesystem::path capio_absolute(pid_t tid, const std::filesystem::path &path) {
+    return path.is_absolute() ? path : capio_posix_realpath(tid, path);
 }
 
 /**
@@ -159,8 +159,8 @@ inline void dup_capio_fd(long tid, int oldfd, int newfd, bool is_cloexec) {
  * @param fd
  * @return if the file descriptor exists
  */
-inline bool exists_capio_fd(int fd) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%d)", fd);
+inline bool exists_capio_fd(pid_t tid, int fd) {
+    START_LOG(tid, "call(fd=%d)", fd);
     return files->find(fd) != files->end();
 }
 
@@ -226,8 +226,8 @@ inline std::vector<int> get_capio_fds() {
  * @param dirfd
  * @return the corresponding path
  */
-std::filesystem::path get_dir_path(int dirfd) {
-    START_LOG(syscall_no_intercept(SYS_gettid), "call(dirfd=%d)", dirfd);
+std::filesystem::path get_dir_path(pid_t tid, int dirfd) {
+    START_LOG(tid, "call(dirfd=%d)", dirfd);
 
     if (dirfd == AT_FDCWD) {
         LOG("Returning current CWD");

--- a/capio/posix/utils/requests.hpp
+++ b/capio/posix/utils/requests.hpp
@@ -22,7 +22,7 @@ inline void init_client(const long tid) {
 }
 
 inline off64_t access_request(const std::filesystem::path &path, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
+    START_LOG(tid, "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_ACCESS, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -32,15 +32,14 @@ inline off64_t access_request(const std::filesystem::path &path, const long tid)
 }
 
 inline void clone_request(const long parent_tid, const long child_tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(parent_tid=%ld, child_tid=%ld)", parent_tid,
-              child_tid);
+    START_LOG(parent_tid, "call(parent_tid=%ld, child_tid=%ld)", parent_tid, child_tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d  %ld %ld", CAPIO_REQUEST_CLONE, parent_tid, child_tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void close_request(const int fd, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, tid=%ld)", fd, tid);
+    START_LOG(tid, "call(fd=%ld, tid=%ld)", fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_CLOSE, tid, fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -48,8 +47,8 @@ inline void close_request(const int fd, const long tid) {
 
 inline off64_t rename_request(const long tid, const std::filesystem::path &old_path,
                               const std::filesystem::path &newpath) {
-    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld, old_path=%s, new_path=%s)", tid,
-              old_path.c_str(), newpath.c_str());
+    START_LOG(tid, "call(tid=%ld, old_path=%s, new_path=%s)", tid, old_path.c_str(),
+              newpath.c_str());
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %s %s %ld", CAPIO_REQUEST_RENAME, old_path.c_str(), newpath.c_str(), tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -59,7 +58,7 @@ inline off64_t rename_request(const long tid, const std::filesystem::path &old_p
 }
 
 inline off64_t create_request(const int fd, const std::filesystem::path &path, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
+    START_LOG(tid, "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -70,7 +69,7 @@ inline off64_t create_request(const int fd, const std::filesystem::path &path, c
 
 inline off64_t create_exclusive_request(const int fd, const std::filesystem::path &path,
                                         const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
+    START_LOG(tid, "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_CREATE_EXCLUSIVE, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -80,22 +79,22 @@ inline off64_t create_exclusive_request(const int fd, const std::filesystem::pat
 }
 
 inline void dup_request(const int old_fd, const int new_fd, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(old_fd=%ld, new_fd=%ld, tid)", old_fd, new_fd, tid);
+    START_LOG(tid, "call(old_fd=%ld, new_fd=%ld, tid)", old_fd, new_fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %d", CAPIO_REQUEST_DUP, tid, old_fd, new_fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline void exit_group_request(const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld)", tid);
+    START_LOG(tid, "call(tid=%ld)", tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld", CAPIO_REQUEST_EXIT_GROUP, tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
 }
 
 inline off64_t getdents_request(const int fd, const off64_t count, bool is64bit, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, count=%ld, is_64_bit=%s, tid=%ld)", fd,
-              count, is64bit ? "true" : "false", tid);
+    START_LOG(tid, "call(fd=%ld, count=%ld, is_64_bit=%s, tid=%ld)", fd, count,
+              is64bit ? "true" : "false", tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", is64bit ? CAPIO_REQUEST_GETDENTS64 : CAPIO_REQUEST_GETDENTS,
             tid, fd, count);
@@ -106,7 +105,7 @@ inline off64_t getdents_request(const int fd, const off64_t count, bool is64bit,
 }
 
 inline void handshake_anonymous_request(const long tid, const long pid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld, pid=%ld)", tid, pid);
+    START_LOG(tid, "call(tid=%ld, pid=%ld)", tid, pid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %ld", CAPIO_REQUEST_HANDSHAKE_ANONYMOUS, tid, pid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -114,8 +113,7 @@ inline void handshake_anonymous_request(const long tid, const long pid) {
 
 inline void handshake_named_request(const long tid, const long pid, const std::string &app_name,
                                     const bool wait = false) {
-    START_LOG(capio_syscall(SYS_gettid), "call(tid=%ld, pid=%ld, app_name=%s)", tid, pid,
-              app_name.c_str());
+    START_LOG(tid, "call(tid=%ld, pid=%ld, app_name=%s)", tid, pid, app_name.c_str());
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %ld %s %d", CAPIO_REQUEST_HANDSHAKE_NAMED, tid, pid, app_name.c_str(),
             wait ? 1 : 0);
@@ -128,7 +126,7 @@ inline void handshake_named_request(const long tid, const long pid, const std::s
 }
 
 inline CPStatResponse_t fstat_request(const int fd, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, tid=%ld)", fd, tid);
+    START_LOG(tid, "call(fd=%ld, tid=%ld)", fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_FSTAT, tid, fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -141,7 +139,7 @@ inline CPStatResponse_t fstat_request(const int fd, const long tid) {
 }
 
 inline off64_t mkdir_request(const std::filesystem::path &path, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
+    START_LOG(tid, "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_MKDIR, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -151,7 +149,7 @@ inline off64_t mkdir_request(const std::filesystem::path &path, const long tid) 
 }
 
 inline off64_t open_request(const int fd, const std::filesystem::path &path, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
+    START_LOG(tid, "call(fd=%ld, path=%s, tid=%ld)", fd, path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %s", CAPIO_REQUEST_OPEN, tid, fd, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -161,7 +159,7 @@ inline off64_t open_request(const int fd, const std::filesystem::path &path, con
 }
 
 inline off64_t read_request(const int fd, const off64_t count, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, count=%ld, tid=%ld)", fd, count, tid);
+    START_LOG(tid, "call(fd=%ld, count=%ld, tid=%ld)", fd, count, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", CAPIO_REQUEST_READ, tid, fd, count);
     LOG("Sending read request %s", req);
@@ -173,7 +171,7 @@ inline off64_t read_request(const int fd, const off64_t count, const long tid) {
 }
 
 inline off64_t seek_data_request(const int fd, const off64_t offset, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
+    START_LOG(tid, "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK_DATA, tid, fd, offset);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -183,7 +181,7 @@ inline off64_t seek_data_request(const int fd, const off64_t offset, const long 
 }
 
 inline off64_t seek_end_request(const int fd, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, tid=%ld)", fd, tid);
+    START_LOG(tid, "call(fd=%ld, tid=%ld)", fd, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d", CAPIO_REQUEST_SEEK_END, tid, fd);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -194,7 +192,7 @@ inline off64_t seek_end_request(const int fd, const long tid) {
 }
 
 inline off64_t seek_hole_request(const int fd, const off64_t offset, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
+    START_LOG(tid, "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK_HOLE, tid, fd, offset);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -204,7 +202,7 @@ inline off64_t seek_hole_request(const int fd, const off64_t offset, const long 
 }
 
 inline off64_t seek_request(const int fd, const off64_t offset, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
+    START_LOG(tid, "call(fd=%ld, offset=%ld, tid=%ld)", fd, offset, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %zu", CAPIO_REQUEST_SEEK, tid, fd, offset);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -214,7 +212,7 @@ inline off64_t seek_request(const int fd, const off64_t offset, const long tid) 
 }
 
 inline CPStatResponse_t stat_request(const std::filesystem::path &path, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
+    START_LOG(tid, "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_STAT, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -231,7 +229,7 @@ inline CPStatResponse_t stat_request(const std::filesystem::path &path, const lo
 }
 
 inline off64_t unlink_request(const std::filesystem::path &path, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(path=%s, tid=%ld)", path.c_str(), tid);
+    START_LOG(tid, "call(path=%s, tid=%ld)", path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %s", CAPIO_REQUEST_UNLINK, tid, path.c_str());
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -241,7 +239,7 @@ inline off64_t unlink_request(const std::filesystem::path &path, const long tid)
 }
 
 inline off64_t rmdir_request(const std::filesystem::path &dir_path, long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(dir_path=%s, tid=%ld)", dir_path.c_str(), tid);
+    START_LOG(tid, "call(dir_path=%s, tid=%ld)", dir_path.c_str(), tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %s %ld", CAPIO_REQUEST_RMDIR, dir_path.c_str(), tid);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);
@@ -251,7 +249,7 @@ inline off64_t rmdir_request(const std::filesystem::path &dir_path, long tid) {
 }
 
 inline void write_request(const int fd, const off64_t count, const long tid) {
-    START_LOG(capio_syscall(SYS_gettid), "call(fd=%ld, count=%ld, tid=%ld)", fd, count, tid);
+    START_LOG(tid, "call(fd=%ld, count=%ld, tid=%ld)", fd, count, tid);
     char req[CAPIO_REQ_MAX_SIZE];
     sprintf(req, "%04d %ld %d %ld", CAPIO_REQUEST_WRITE, tid, fd, count);
     buf_requests->write(req, CAPIO_REQ_MAX_SIZE);

--- a/capio/posix/utils/types.hpp
+++ b/capio/posix/utils/types.hpp
@@ -11,6 +11,6 @@ typedef std::pair<off64_t, off64_t> CPStatResponse_t;
 typedef std::unordered_map<int, std::string> CPFileDescriptors_t;
 typedef std::unordered_map<std::string, std::unordered_set<int>> CPFilesPaths_t;
 
-typedef int (*CPHandler_t)(long, long, long, long, long, long, long *);
+typedef int (*CPHandler_t)(pid_t, long, long, long, long, long, long, long *);
 
 #endif // CAPIO_POSIX_UTILS_TYPES_HPP

--- a/capio/tests/unit/posix/src/realpath.cpp
+++ b/capio/tests/unit/posix/src/realpath.cpp
@@ -17,28 +17,28 @@ TEST_F(RealpathPosixTest, TestAbsolutePathsInCapioDirWhenPathExists) {
     const std::filesystem::path PATHNAME = get_capio_dir() / "test";
     EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
     EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
-    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(gettid(), PATHNAME), PATHNAME);
     EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
     EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
 
 TEST_F(RealpathPosixTest, TestAbsolutePathsInCapioDirWhenPathDoesNotExist) {
     const std::filesystem::path PATHNAME = get_capio_dir() / "test";
-    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(gettid(), PATHNAME), PATHNAME);
 }
 
 TEST_F(RealpathPosixTest, TestAbsolutePathsOutsideCapioDirWhenPathExists) {
     const std::filesystem::path PATHNAME = "/tmp/test";
     EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
     EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
-    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(gettid(), PATHNAME), PATHNAME);
     EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
     EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
 
 TEST_F(RealpathPosixTest, TestAbsolutePathOutsideCapioDirWhenPathDoesNotExist) {
     const std::filesystem::path PATHNAME = "/tmp/test";
-    EXPECT_EQ(capio_posix_realpath(PATHNAME), PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(gettid(), PATHNAME), PATHNAME);
 }
 
 TEST_F(RealpathPosixTest, TestRelativePathsInCapioDirWhenCwdIsCapioDir) {
@@ -47,7 +47,7 @@ TEST_F(RealpathPosixTest, TestRelativePathsInCapioDirWhenCwdIsCapioDir) {
     set_current_dir(capio_dir);
     EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
     EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
-    EXPECT_EQ(capio_posix_realpath("test"), PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(gettid(), "test"), PATHNAME);
     EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
     EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }
@@ -58,7 +58,7 @@ TEST_F(RealpathPosixTest, TestRelativePathsInCapioDirWhenCwdIsParentOfCapioDir) 
     set_current_dir(capio_dir.parent_path());
     EXPECT_NE(mkdir(PATHNAME.c_str(), S_IRWXU), -1);
     EXPECT_EQ(access(PATHNAME.c_str(), F_OK), 0);
-    EXPECT_EQ(capio_posix_realpath(capio_dir.filename() / "test"), PATHNAME);
+    EXPECT_EQ(capio_posix_realpath(gettid(), capio_dir.filename() / "test"), PATHNAME);
     EXPECT_NE(rmdir(PATHNAME.c_str()), -1);
     EXPECT_NE(access(PATHNAME.c_str(), F_OK), 0);
 }


### PR DESCRIPTION
This commit refactors the CAPIO posix component, by redicing the amount of ```syscall_no_intercept(SYS_gettid)``` by passing the current thread id from the ```hook()``` function