### PR TITLE
Treat warning as errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ capio_logs
 debug
 build
 
+cmake_test_discovery*.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # Set compiler flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -pedantic -O0")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -pedantic -O0 -Werror")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Werror")
 
 #####################################
 # Options

--- a/capio/common/constants.hpp
+++ b/capio/common/constants.hpp
@@ -10,8 +10,6 @@
 // CAPIO files constants
 constexpr size_t CAPIO_DEFAULT_DIR_INITIAL_SIZE   = 1024L * 1024 * 1024;
 constexpr off64_t CAPIO_DEFAULT_FILE_INITIAL_SIZE = 1024L * 1024 * 1024 * 4;
-constexpr std::array CAPIO_DIR_FORBIDDEN_PATHS    = {std::string_view{"/proc/"},
-                                                     std::string_view{"/sys/"}};
 
 // CAPIO default values for shared memory
 constexpr char CAPIO_DEFAULT_WORKFLOW_NAME[] = "CAPIO";

--- a/capio/common/env.hpp
+++ b/capio/common/env.hpp
@@ -12,6 +12,9 @@
 #include "common/syscall.hpp"
 #include "logger.hpp"
 
+// TODO: remove forward declaration of function by splitting into header and impl. capio/common
+inline bool is_forbidden_path(const std::string_view &path);
+
 inline const std::filesystem::path &get_capio_dir() {
     static std::filesystem::path capio_dir{};
     START_LOG(capio_syscall(SYS_gettid), "call()");
@@ -42,10 +45,9 @@ inline const std::filesystem::path &get_capio_dir() {
             }
         }
         capio_dir = std::filesystem::path(buf.get());
-        for (auto &forbidden_path : CAPIO_DIR_FORBIDDEN_PATHS) {
-            if (capio_dir.native().rfind(forbidden_path, 0) == 0) {
-                ERR_EXIT("CAPIO_DIR inside %s file system is not supported", forbidden_path.data());
-            }
+
+        if (is_forbidden_path(capio_dir.c_str())) {
+            ERR_EXIT("CAPIO_DIR %s is in forbidden path", capio_dir.string().c_str());
         }
     }
     LOG("CAPIO_DIR=%s", capio_dir.c_str());

--- a/capio/common/filesystem.hpp
+++ b/capio/common/filesystem.hpp
@@ -14,6 +14,9 @@
 #include "common/syscall.hpp"
 #include "env.hpp"
 
+constexpr std::array CAPIO_DIR_FORBIDDEN_PATHS = {std::string_view{"/proc/"},
+                                                  std::string_view{"/sys/"}};
+
 inline std::filesystem::path get_parent_dir_path(const std::filesystem::path &file_path) {
     START_LOG(capio_syscall(SYS_gettid), "call(file_path=%s)", file_path.c_str());
     if (file_path == file_path.root_path()) {
@@ -34,8 +37,8 @@ inline bool in_dir(const std::string &path, const std::string &glob) {
 inline bool is_directory(int dirfd) {
     START_LOG(capio_syscall(SYS_gettid), "call(dirfd=%d)", dirfd);
 
-    struct stat path_stat {};
-    int tmp = fstat(dirfd, &path_stat);
+    struct stat path_stat = {};
+    int tmp               = fstat(dirfd, &path_stat);
     if (tmp != 0) {
         LOG("Error at is_directory(dirfd=%d) -> %d: %d (%s)", dirfd, tmp, errno,
             std::strerror(errno));

--- a/capio/common/filesystem.hpp
+++ b/capio/common/filesystem.hpp
@@ -37,8 +37,8 @@ inline bool in_dir(const std::string &path, const std::string &glob) {
 inline bool is_directory(int dirfd) {
     START_LOG(capio_syscall(SYS_gettid), "call(dirfd=%d)", dirfd);
 
-    struct stat path_stat = {};
-    int tmp               = fstat(dirfd, &path_stat);
+    struct stat path_stat {};
+    int tmp = fstat(dirfd, &path_stat);
     if (tmp != 0) {
         LOG("Error at is_directory(dirfd=%d) -> %d: %d (%s)", dirfd, tmp, errno,
             std::strerror(errno));

--- a/capio/common/logger.hpp
+++ b/capio/common/logger.hpp
@@ -25,6 +25,14 @@ template <typename T> std::string demangled_name(const T &obj) {
 
 inline bool continue_on_error = false; // if set to true, CAPIO does not terminate on ERR_EXIT
 
+inline void raise_termination(const bool raise_exception, const std::string &message) {
+    if (raise_exception) {
+        throw std::runtime_error(message);
+    }
+    capio_syscall(SYS_write, stderr, message.c_str(), message.size());
+    exit(EXIT_FAILURE);
+}
+
 #if defined(CAPIO_LOG) && defined(__CAPIO_POSIX)
 #include "syscallnames.h"
 #endif
@@ -328,15 +336,18 @@ class Logger {
 };
 
 #ifdef CAPIO_LOG
-#define ERR_EXIT(message, ...)                                                                     \
+
+#define ERR_EXIT_EXCEPT_CHOICE(raise_exception, message, ...)                                      \
     log.log(message, ##__VA_ARGS__);                                                               \
     if (!continue_on_error) {                                                                      \
         if (!continue_on_error) {                                                                  \
             char err_msg[CAPIO_LOG_MAX_MSG_LEN];                                                   \
             snprintf(err_msg, CAPIO_LOG_MAX_MSG_LEN, message, ##__VA_ARGS__);                      \
-            throw std::runtime_error(err_msg);                                                     \
+            raise_termination(raise_exception, err_msg);                                           \
         }                                                                                          \
     }
+#define ERR_EXIT(message, ...) ERR_EXIT_EXCEPT_CHOICE(true, message, ##__VA_ARGS__)
+
 #define LOG(message, ...) log.log(message, ##__VA_ARGS__)
 #define START_LOG(tid, message, ...)                                                               \
     Logger log(__func__, __FILE__, __LINE__, tid, message, ##__VA_ARGS__)
@@ -371,12 +382,13 @@ class Logger {
 
 #else
 
-#define ERR_EXIT(message, ...)                                                                     \
+#define ERR_EXIT_EXCEPT_CHOICE(raise_exception, message, ...)                                      \
     if (!continue_on_error) {                                                                      \
         char err_msg[CAPIO_LOG_MAX_MSG_LEN];                                                       \
         snprintf(err_msg, sizeof(err_msg), message, ##__VA_ARGS__);                                \
-        throw std::runtime_error(err_msg);                                                         \
+        raise_termination(raise_exception, err_msg);                                               \
     }
+#define ERR_EXIT(message, ...) ERR_EXIT_EXCEPT_CHOICE(true, message, ##__VA_ARGS__)
 #define LOG(message, ...)
 #define START_LOG(tid, message, ...)
 #define START_SYSCALL_LOGGING()

--- a/capio/common/queue.hpp
+++ b/capio/common/queue.hpp
@@ -10,6 +10,7 @@
 #include "common/logger.hpp"
 #include "common/semaphore.hpp"
 #include "common/shm.hpp"
+#include "filesystem.hpp"
 
 template <class T, class Mutex> class Queue {
   private:

--- a/capio/common/semaphore.hpp
+++ b/capio/common/semaphore.hpp
@@ -44,11 +44,11 @@ class NamedSemaphore {
     ~NamedSemaphore() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
         if (sem_destroy(_sem) != 0) {
-            ERR_EXIT(" destruction of semaphore %s failed", _name.c_str());
+            ERR_EXIT_EXCEPT_CHOICE(false, " destruction of semaphore %s failed", _name.c_str());
         }
         LOG(" Destroyed shared semaphore %s", _name.c_str());
         if (sem_unlink(_name.c_str()) != 0) {
-            ERR_EXIT(" destruction of semaphore %s failed", _name.c_str());
+            ERR_EXIT_EXCEPT_CHOICE(false, " destruction of semaphore %s failed", _name.c_str());
         }
         LOG(" Unlinked shared semaphore %s", _name.c_str());
     }
@@ -88,7 +88,7 @@ class Semaphore {
     ~Semaphore() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
         if (sem_destroy(&_sem) != 0) {
-            ERR_EXIT("destruction of unnamed semaphore failed");
+            ERR_EXIT_EXCEPT_CHOICE(false, "destruction of unnamed semaphore failed");
         }
     }
 

--- a/capio/common/shm.hpp
+++ b/capio/common/shm.hpp
@@ -15,7 +15,7 @@
 
 #define SHM_DESTROY_CHECK(source_name)                                                             \
     if (shm_unlink(source_name) == -1) {                                                           \
-        ERR_EXIT("Unable to destroy shared mem:  ", source_name);                                  \
+        ERR_EXIT_EXCEPT_CHOICE(false, "Unable to destroy shared mem: %s", source_name);                   \
     };
 
 #define SHM_CREATE_CHECK(condition, source)                                                        \
@@ -105,7 +105,7 @@ inline void *get_shm(const std::string &shm_name) {
 
     // if we are not creating a new object, mode is equals to 0
     int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
-    struct stat sb {};
+    struct stat sb{};
     if (fd == -1) {
         ERR_EXIT("get_shm shm_open %s", shm_name.c_str());
     }
@@ -130,7 +130,7 @@ inline void *get_shm_if_exist(const std::string &shm_name) {
 
     // if we are not creating a new object, mode is equals to 0
     int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
-    struct stat sb {};
+    struct stat sb{};
     if (fd == -1) {
         if (errno == ENOENT) {
             return nullptr;

--- a/capio/common/shm.hpp
+++ b/capio/common/shm.hpp
@@ -104,8 +104,8 @@ inline void *get_shm(const std::string &shm_name) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s)", shm_name.c_str());
 
     // if we are not creating a new object, mode is equals to 0
-    int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
-    struct stat sb{};
+    int fd         = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
+    struct stat sb = {};
     if (fd == -1) {
         ERR_EXIT("get_shm shm_open %s", shm_name.c_str());
     }
@@ -129,8 +129,8 @@ inline void *get_shm_if_exist(const std::string &shm_name) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s)", shm_name.c_str());
 
     // if we are not creating a new object, mode is equals to 0
-    int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
-    struct stat sb{};
+    int fd         = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
+    struct stat sb = {};
     if (fd == -1) {
         if (errno == ENOENT) {
             return nullptr;

--- a/capio/common/shm.hpp
+++ b/capio/common/shm.hpp
@@ -15,7 +15,7 @@
 
 #define SHM_DESTROY_CHECK(source_name)                                                             \
     if (shm_unlink(source_name) == -1) {                                                           \
-        ERR_EXIT_EXCEPT_CHOICE(false, "Unable to destroy shared mem: %s", source_name);                   \
+        ERR_EXIT_EXCEPT_CHOICE(false, "Unable to destroy shared mem: %s", source_name);            \
     };
 
 #define SHM_CREATE_CHECK(condition, source)                                                        \

--- a/capio/common/shm.hpp
+++ b/capio/common/shm.hpp
@@ -104,8 +104,8 @@ inline void *get_shm(const std::string &shm_name) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s)", shm_name.c_str());
 
     // if we are not creating a new object, mode is equals to 0
-    int fd         = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
-    struct stat sb = {};
+    int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
+    struct stat sb {};
     if (fd == -1) {
         ERR_EXIT("get_shm shm_open %s", shm_name.c_str());
     }
@@ -129,8 +129,8 @@ inline void *get_shm_if_exist(const std::string &shm_name) {
     START_LOG(capio_syscall(SYS_gettid), "call(shm_name=%s)", shm_name.c_str());
 
     // if we are not creating a new object, mode is equals to 0
-    int fd         = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
-    struct stat sb = {};
+    int fd = shm_open(shm_name.c_str(), O_RDWR, 0); // to be closed
+    struct stat sb {};
     if (fd == -1) {
         if (errno == ENOENT) {
             return nullptr;

--- a/capio/posix/handlers/unlink.hpp
+++ b/capio/posix/handlers/unlink.hpp
@@ -11,19 +11,18 @@ off64_t capio_unlink_abs(const std::filesystem::path &abs_path, long tid, bool i
     if (is_capio_path(abs_path)) {
         if (is_capio_dir(abs_path)) {
             ERR_EXIT("ERROR: unlink to the capio_dir %s", abs_path.c_str());
-        } else {
-            off64_t res = is_dir ? rmdir_request(abs_path, tid) : unlink_request(abs_path, tid);
-            if (res == -1) {
-                errno = ENOENT;
-            } else {
-                LOG("Removing %s from capio_files_path", abs_path.c_str());
-                delete_capio_path(abs_path);
-            }
-            return res;
+            return -1; // note: this point should never be reached
         }
-    } else {
-        return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
+        off64_t res = is_dir ? rmdir_request(abs_path, tid) : unlink_request(abs_path, tid);
+        if (res == -1) {
+            errno = ENOENT;
+        } else {
+            LOG("Removing %s from capio_files_path", abs_path.c_str());
+            delete_capio_path(abs_path);
+        }
+        return res;
     }
+    return CAPIO_POSIX_SYSCALL_REQUEST_SKIP;
 }
 
 inline off64_t capio_unlinkat(int dirfd, const std::string_view &pathname, int flags, long tid) {

--- a/capio/server/include/storage/capio_file.hpp
+++ b/capio/server/include/storage/capio_file.hpp
@@ -225,7 +225,7 @@ class CapioFile {
     [[nodiscard]] off64_t getStoredSize() const;
 
     /** @return Count of files currently indexed in this directory. */
-    [[nodiscard]] int getCurrentDirectoryFileCount() const;
+    [[nodiscard]] unsigned int getCurrentDirectoryFileCount() const;
 
     /** @return Expected total files in this directory. */
     [[nodiscard]] unsigned int getDirectoryExpectedFileCount() const;

--- a/capio/server/include/utils/location.hpp
+++ b/capio/server/include/utils/location.hpp
@@ -110,12 +110,11 @@ inline std::pair<const char *const, long int> &
 get_file_location(const std::filesystem::path &path) {
     START_LOG(gettid(), "path=%s", path.c_str());
 
-    auto file_location_opt = get_file_location_opt(path);
-    if (file_location_opt) {
-        return file_location_opt->get();
-    } else {
+    const auto file_location_opt = get_file_location_opt(path);
+    if (!file_location_opt) {
         ERR_EXIT("error file location %s not present in CAPIO", path.c_str());
     }
+    return file_location_opt->get();
 }
 
 inline void add_file_location(const std::filesystem::path &path, const char *const p_node_str,

--- a/capio/server/src/capio_file.cpp
+++ b/capio/server/src/capio_file.cpp
@@ -233,7 +233,9 @@ void CapioFile::insertSector(off64_t new_start, off64_t new_end) {
     _sectors.emplace(new_start, new_end);
 }
 
-bool CapioFile::closed() const { return _n_close_expected <= 0 || _n_close == _n_close_expected; }
+bool CapioFile::closed() const {
+    return _n_close_expected <= 0 || static_cast<unsigned int>(_n_close) == _n_close_expected;
+}
 
 bool CapioFile::deletable() const { return _n_opens <= 0; }
 
@@ -341,6 +343,6 @@ void CapioFile::incrementDirectoryFileCount(const int count) {
     this->_data_avail_cv.notify_all();
 }
 
-int CapioFile::getCurrentDirectoryFileCount() const { return this->_n_files; }
+unsigned int CapioFile::getCurrentDirectoryFileCount() const { return this->_n_files; }
 
 unsigned int CapioFile::getDirectoryExpectedFileCount() const { return this->_n_files_expected; }

--- a/capio/server/src/capio_file.cpp
+++ b/capio/server/src/capio_file.cpp
@@ -234,7 +234,7 @@ void CapioFile::insertSector(off64_t new_start, off64_t new_end) {
 }
 
 bool CapioFile::closed() const {
-    return _n_close_expected <= 0 || static_cast<unsigned int>(_n_close) == _n_close_expected;
+    return _n_close_expected == 0 || _n_close == static_cast<int>(_n_close_expected);
 }
 
 bool CapioFile::deletable() const { return _n_opens <= 0; }

--- a/capio/server/src/storage_manager.cpp
+++ b/capio/server/src/storage_manager.cpp
@@ -40,11 +40,11 @@ void StorageManager::addDirectoryEntry(const pid_t tid, const std::filesystem::p
 
     CapioFile &c_file = get(dir);
     c_file.createBuffer(dir, true);
-    void *file_shm             = c_file.getBuffer();
-    const off64_t file_size    = c_file.getStoredSize();
-    const off64_t data_size    = file_size + ld.d_reclen;
-    const size_t file_shm_size = c_file.getBufSize();
-    ld.d_off                   = data_size;
+    void *file_shm              = c_file.getBuffer();
+    const off64_t file_size     = c_file.getStoredSize();
+    const off64_t data_size     = file_size + ld.d_reclen;
+    const off64_t file_shm_size = c_file.getBufSize();
+    ld.d_off                    = data_size;
 
     if (data_size > file_shm_size) {
         file_shm = c_file.expandBuffer(data_size);

--- a/capio/tests/integration/src/main.cpp
+++ b/capio/tests/integration/src/main.cpp
@@ -28,7 +28,7 @@ char **build_env(char **envp) {
     }
 
     char **cleaned_env = (char **) malloc((vars.size() + 2) * sizeof(uintptr_t));
-    for (int i = 0; i < vars.size(); i++) {
+    for (size_t i = 0; i < vars.size(); i++) {
         cleaned_env[i] = strdup(envp[i]);
     }
     cleaned_env[vars.size()]     = strdup("LD_PRELOAD=");
@@ -45,7 +45,7 @@ class CapioServerEnvironment : public testing::Environment {
 
   public:
     explicit CapioServerEnvironment(char **envp)
-        : args(build_args()), envp(build_env(envp)), server_pid(-1){};
+        : args(build_args()), envp(build_env(envp)), server_pid(-1) {};
 
     ~CapioServerEnvironment() override {
         for (int i = 0; args[i] != nullptr; i++) {

--- a/capio/tests/integration/src/main.cpp
+++ b/capio/tests/integration/src/main.cpp
@@ -45,7 +45,7 @@ class CapioServerEnvironment : public testing::Environment {
 
   public:
     explicit CapioServerEnvironment(char **envp)
-        : args(build_args()), envp(build_env(envp)), server_pid(-1) {};
+        : args(build_args()), envp(build_env(envp)), server_pid(-1){};
 
     ~CapioServerEnvironment() override {
         for (int i = 0; args[i] != nullptr; i++) {

--- a/capio/tests/integration/src/mapreduce.cpp
+++ b/capio/tests/integration/src/mapreduce.cpp
@@ -113,7 +113,7 @@ static int writedata(char *dataptr, size_t datalen, float percent, char *destdir
         perror("malloc");
         return -1;
     }
-    char filepath[strlen(destdir) + maxfilename];
+    auto filepath = new char[strlen(destdir) + maxfilename];
 
     // opening (truncating) all files
     for (int j = 0, i = 0 + dstart; i < (dfiles + dstart); ++i, ++j) {
@@ -125,6 +125,7 @@ static int writedata(char *dataptr, size_t datalen, float percent, char *destdir
             error = -1;
         }
     }
+    delete[] filepath;
 
     if (!error) {
         size_t nbytes = datalen * percent;
@@ -207,7 +208,7 @@ int mergeFunction(ssize_t nfiles, char *sourcedir, char *destdir) {
     EXPECT_NE(stat(destdir, &statbuf), -1);
     EXPECT_TRUE(S_ISDIR(statbuf.st_mode));
 
-    char filepath[strlen(sourcedir) + maxfilename];
+    auto filepath = new char[strlen(sourcedir) + maxfilename];
     for (int i = 0; i < nfiles; ++i) {
         sprintf(filepath, fmtout, sourcedir, i);
         FILE *fp = fopen(filepath, "r");
@@ -219,11 +220,13 @@ int mergeFunction(ssize_t nfiles, char *sourcedir, char *destdir) {
         dataptr = ptr;
         fclose(fp);
     }
+    delete[] filepath;
 
-    char resultpath[strlen(destdir) + strlen("/result.dat")];
+    auto resultpath = new char[strlen(destdir) + strlen("/result.dat")];
     sprintf(resultpath, "%s/result.dat", destdir);
     FILE *fp = fopen(resultpath, "w");
     EXPECT_TRUE(fp);
+    delete[] resultpath;
 
     EXPECT_EQ(fwrite(dataptr, 1, datalen, fp), datalen);
 
@@ -255,8 +258,8 @@ int splitFunction(ssize_t nlines, ssize_t nfiles, char *dirname) {
     char **buffer = (char **) calloc(IO_BUFFER, nfiles);
     EXPECT_TRUE(buffer);
 
-    int error = 0;
-    char filepath[strlen(dirname) + maxfilename];
+    int error     = 0;
+    auto filepath = new char[strlen(dirname) + maxfilename];
     // opening (truncating) all files
     for (int i = 0; i < nfiles; ++i) {
         sprintf(filepath, fmtin, dirname, i);
@@ -265,6 +268,8 @@ int splitFunction(ssize_t nlines, ssize_t nfiles, char *dirname) {
         EXPECT_TRUE(fp[i]);
         EXPECT_EQ(setvbuf(fp[i], buffer[i], _IOFBF, IO_BUFFER), 0);
     }
+    delete[] filepath;
+
     if (!error) {
         char *buffer = (char *) calloc(maxphraselen, 1);
         if (!buffer) {
@@ -321,7 +326,7 @@ int mapReduceFunction(char *sourcedirname, ssize_t sstart, ssize_t sfiles, char 
     EXPECT_GT(percent, 0);
     EXPECT_LE(percent, 1);
 
-    char filepath[strlen(sourcedirname) + maxfilename];
+    auto filepath = new char[strlen(sourcedirname) + maxfilename];
     // concatenating all files in memory (dataptr)
     for (int i = 0 + sstart; i < (sfiles + sstart); ++i) {
         sprintf(filepath, fmtin, sourcedirname, i);
@@ -335,6 +340,7 @@ int mapReduceFunction(char *sourcedirname, ssize_t sstart, ssize_t sfiles, char 
         dataptr = ptr;
         fclose(fp);
     }
+    delete[] filepath;
 
     int r = writedata(dataptr, datalen, percent, destdirname, dstart, dfiles);
     free(dataptr);

--- a/capio/tests/unit/server/src/capio_file.cpp
+++ b/capio/tests/unit/server/src/capio_file.cpp
@@ -328,7 +328,7 @@ class MockBackend : public Backend {
     MockBackend() : Backend(HOST_NAME_MAX) {}
 
     void recv_file(char *shm, const std::string &source, const long int bytes_expected) override {
-        for (std::size_t i = 0; i < bytes_expected; ++i) {
+        for (long int i = 0; i < bytes_expected; ++i) {
             shm[i] = 33 + (i % 93);
         }
     }

--- a/capio/tests/unit/syscall/src/dirent.cpp
+++ b/capio/tests/unit/syscall/src/dirent.cpp
@@ -71,7 +71,7 @@ TEST(SystemCallTest, TestDirentsOnCapioDir) {
             break;
         }
 
-        for (size_t bpos = 0, i = 0; bpos < nread && i < 10; i++) {
+        for (long bpos = 0, i = 0; bpos < nread && i < 10; i++) {
             auto d = (struct linux_dirent64 *) (buf + bpos);
 
             EXPECT_NE(std::find(expectedNames.begin(), expectedNames.end(), d->d_name),

--- a/capio/tests/unit/syscall/src/main.cpp
+++ b/capio/tests/unit/syscall/src/main.cpp
@@ -35,7 +35,7 @@ char **build_env(char **envp) {
     }
 
     char **cleaned_env = (char **) malloc((vars.size() + 2) * sizeof(uintptr_t));
-    for (int i = 0; i < vars.size(); i++) {
+    for (size_t i = 0; i < vars.size(); i++) {
         cleaned_env[i] = strdup(envp[i]);
     }
     cleaned_env[vars.size()]     = strdup("LD_PRELOAD=");

--- a/capio/tests/unit/syscall/src/write.cpp
+++ b/capio/tests/unit/syscall/src/write.cpp
@@ -12,16 +12,17 @@ TEST(SystemCallTest, TestFileCreateWriteClose) {
     constexpr const char *PATHNAME = "test_file.txt";
     constexpr const char *BUFFER =
         "QWERTYUIOPASDFGHJKLZXCVBNM1234567890qwertyuiopasdfghjklzxcvbnm\0";
-    int fd = open(PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+    const auto buf_size = strlen(BUFFER);
+    int fd              = open(PATHNAME, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
     EXPECT_NE(fd, -1);
     EXPECT_EQ(access(PATHNAME, F_OK), 0);
-    EXPECT_EQ(write(fd, BUFFER, strlen(BUFFER)), strlen(BUFFER));
+    EXPECT_EQ(write(fd, BUFFER, buf_size), buf_size);
     EXPECT_NE(close(fd), -1);
     fd = open(PATHNAME, O_RDONLY, S_IRUSR | S_IWUSR);
     EXPECT_NE(fd, -1);
-    std::unique_ptr<char[]> buf(new char[strlen(BUFFER)]);
-    EXPECT_EQ(read(fd, buf.get(), strlen(BUFFER)), strlen(BUFFER));
-    buf[strlen(BUFFER)] = '\0';
+    std::unique_ptr<char[]> buf(new char[buf_size + 1]);
+    EXPECT_EQ(read(fd, buf.get(), buf_size), buf_size);
+    buf[buf_size] = '\0';
     EXPECT_EQ(std::string_view(BUFFER), std::string_view(buf.get()));
     EXPECT_NE(close(fd), -1);
     EXPECT_NE(unlink(PATHNAME), -1);


### PR DESCRIPTION
This commit updates the CMake configuration to treat warnings as errors. It also resolves existing warnings related to:
- Destructor exceptions: Introduced a mechanism to explicitly choose between throwing an exception or terminating.
- Signedness comparisons: Fixed mismatches between signed and unsigned integers.
- ISO C++ compliance: Replaced variable-length arrays (VLAs) on the stack with heap allocated arrays