### PR TITLE
Uniformed server side stdout prints and `parseCLI`

### DIFF
--- a/capio/common/constants.hpp
+++ b/capio/common/constants.hpp
@@ -73,23 +73,23 @@ constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]             = "~~~~~~~~~  END SYSCA
 
 // CAPIO logger - server
 constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_PREFIX[] = "server_thread_\0";
-constexpr char CAPIO_LOG_SERVER_BANNER[16][70]        = {
+// Note: Ensure CAPIO_VERSION is defined as a string literal, e.g., #define CAPIO_VERSION "1.0.0"
+constexpr char CAPIO_LOG_SERVER_BANNER[14][80]        = {
     "",
-    "",
-    "\033[1;34m /$$$$$$   /$$$$$$  /$$$$$$$\033[0;96m  /$$$$$$  /$$$$$$ ",
-    "\033[1;34m /$$__  $$ /$$__  $$| $$__  $$\033[0;96m|_  $$_/ /$$__  $$",
+    "\033[1;34m  /$$$$$$   /$$$$$$  /$$$$$$$  \033[0;96m /$$$$$$  /$$$$$$ ",
+    "\033[1;34m /$$__  $$ /$$__  $$| $$__  $$ \033[0;96m|_ $$_/ /$$__  $$",
     "\033[1;34m| $$  \\__/| $$  \\ $$| $$  \\ $$ \033[0;96m | $$  | $$  \\ $$",
     "\033[1;34m| $$      | $$$$$$$$| $$$$$$$/  \033[0;96m| $$  | $$  | $$",
     "\033[1;34m| $$      | $$__  $$| $$____/   \033[0;96m| $$  | $$  | $$",
     "\033[1;34m| $$    $$| $$  | $$| $$        \033[0;96m| $$  | $$  | $$",
-    "\033[1;34m|  $$$$$$/| $$  | $$| $$       \033[0;96m/$$$$$$|  $$$$$$/",
-    "\033[1;34m \\______/ |__/  |__/|__/      \033[0;96m|______/ \\______/",
+    "\033[1;34m|  $$$$$$/| $$  | $$| $$        \033[0;96m/$$$$$$|  $$$$$$/",
+    "\033[1;34m \\______/ |__/  |__/|__/       \033[0;96m|______/ \\______/",
     "",
     "\033[0m   CAPIO - Cross Application Programmable IO         ",
     "",
-    "                    V. " CAPIO_VERSION,
+    "                     V. " CAPIO_VERSION,
     "",
-    ""};
+};
 
 constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE[] =
     "CAPIO_LOG set but log support was not compiled into CAPIO!";
@@ -147,9 +147,10 @@ constexpr char CAPIO_SERVER_ARG_PARSER_CONFIG_BACKEND_HELP[] =
     "\n\t> mpi \n\t> mpisync \n\t> none (default)";
 
 // Cli pre messages
-constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_STATUS[]  = "[\033[1;34mCAPIO-SERVER\033[0m ";
-constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_INFO[]    = "[\033[1;32mCAPIO-SERVER\033[0m ";
-constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_WARNING[] = "[\033[1;33mCAPIO-SERVER\033[0m ";
-constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_ERROR[]   = "[\033[1;31mCAPIO-SERVER\033[0m ";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_RESET[]   = "\033[0m";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_STATUS[]  = "\033[1;34m";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_INFO[]    = "\033[1;32m";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_WARNING[] = "\033[1;33m";
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_ERROR[]   = "\033[1;31m";
 
 #endif // CAPIO_COMMON_CONSTANTS_HPP

--- a/capio/common/constants.hpp
+++ b/capio/common/constants.hpp
@@ -73,36 +73,45 @@ constexpr char CAPIO_LOG_POSIX_SYSCALL_END[]             = "~~~~~~~~~  END SYSCA
 
 // CAPIO logger - server
 constexpr char CAPIO_SERVER_DEFAULT_LOG_FILE_PREFIX[] = "server_thread_\0";
-constexpr char CAPIO_LOG_SERVER_BANNER[] =
-    "\n\n "
-    "\033[1;34m /$$$$$$   /$$$$$$  /$$$$$$$\033[0;96m  /$$$$$$  /$$$$$$ \n"
-    "\033[1;34m /$$__  $$ /$$__  $$| $$__  $$\033[0;96m|_  $$_/ /$$__  $$\n"
-    "\033[1;34m| $$  \\__/| $$  \\ $$| $$  \\ $$ \033[0;96m | $$  | $$  \\ "
-    "$$\n"
-    "\033[1;34m| $$      | $$$$$$$$| $$$$$$$/  \033[0;96m| $$  | $$  | $$\n"
-    "\033[1;34m| $$      | $$__  $$| $$____/   \033[0;96m| $$  | $$  | $$\n"
-    "\033[1;34m| $$    $$| $$  | $$| $$        \033[0;96m| $$  | $$  | $$\n"
-    "\033[1;34m|  $$$$$$/| $$  | $$| $$       \033[0;96m/$$$$$$|  $$$$$$/\n"
-    "\033[1;34m \\______/ |__/  |__/|__/      \033[0;96m|______/ "
-    "\\______/\n\n"
-    "\033[0m   CAPIO - Cross Application Programmable IO         \n"
-    "                    V. " CAPIO_VERSION "\n\n";
+constexpr char CAPIO_LOG_SERVER_BANNER[16][70]        = {
+    "",
+    "",
+    "\033[1;34m /$$$$$$   /$$$$$$  /$$$$$$$\033[0;96m  /$$$$$$  /$$$$$$ ",
+    "\033[1;34m /$$__  $$ /$$__  $$| $$__  $$\033[0;96m|_  $$_/ /$$__  $$",
+    "\033[1;34m| $$  \\__/| $$  \\ $$| $$  \\ $$ \033[0;96m | $$  | $$  \\ $$",
+    "\033[1;34m| $$      | $$$$$$$$| $$$$$$$/  \033[0;96m| $$  | $$  | $$",
+    "\033[1;34m| $$      | $$__  $$| $$____/   \033[0;96m| $$  | $$  | $$",
+    "\033[1;34m| $$    $$| $$  | $$| $$        \033[0;96m| $$  | $$  | $$",
+    "\033[1;34m|  $$$$$$/| $$  | $$| $$       \033[0;96m/$$$$$$|  $$$$$$/",
+    "\033[1;34m \\______/ |__/  |__/|__/      \033[0;96m|______/ \\______/",
+    "",
+    "\033[0m   CAPIO - Cross Application Programmable IO         ",
+    "",
+    "                    V. " CAPIO_VERSION,
+    "",
+    ""};
 
-constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING[] =
-    "[\033[1;33mCAPIO-SERVER \033[0m ] "
-    "|==================================================================|\n"
-    "[\033[1;33mCAPIO-SERVER \033[0m ] | you are running a build of CAPIO with "
-    "logging enabled.           |\n"
-    "[\033[1;33mCAPIO-SERVER \033[0m ] | this will have impact on performance. "
-    "you should recompile CAPIO |\n"
-    "[\033[1;33mCAPIO-SERVER \033[0m ] | with -DCAPIO_LOG=FALSE                 "
-    "                          |\n"
-    "[\033[1;33mCAPIO-SERVER \033[0m ] "
-    "|==================================================================|\n";
 constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE[] =
     "CAPIO_LOG set but log support was not compiled into CAPIO!";
 constexpr char CAPIO_LOG_SERVER_REQUEST_START[] = "\n+++++++++++ REQUEST +++++++++++";
 constexpr char CAPIO_LOG_SERVER_REQUEST_END[]   = "~~~~~~~~~ END REQUEST ~~~~~~~~~\n";
+
+// Server - Warning banners
+constexpr char CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING[5][80] = {
+    "\033[1;33m|==================================================================|\033[0m",
+    "\033[1;33m| you are running a build of CAPIO with logging enabled.           |\033[0m",
+    "\033[1;33m| this will have impact on performance. you should recompile CAPIO |\033[0m",
+    "\033[1;33m| with -DCAPIO_LOG=FALSE                                           |\033[0m",
+    "\033[1;33m|==================================================================|\033[0m"};
+
+constexpr char CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING[7][80] = {
+    "\033[1;31m|==================================================================|\033[0m",
+    "\033[1;31m|           you are running CAPIO with --continue-on-error         |\033[0m",
+    "\033[1;31m|       This is extremely dangerous as CAPIO server will continue  |\033[0m",
+    "\033[1;31m|              its execution even if it should terminate.          |\033[0m",
+    "\033[1;31m|                                                                  |\033[0m",
+    "\033[1;31m|                     USE IT AT YOUR OWN RISK                      |\033[0m",
+    "\033[1;31m|==================================================================|\033[0m"};
 
 // CAPIO server argument parser
 constexpr char CAPIO_SERVER_ARG_PARSER_PRE[] =
@@ -113,7 +122,6 @@ constexpr char CAPIO_SERVER_ARG_PARSER_EPILOGUE[] =
     "For further help, a full list of the available ENVIRONMENT VARIABLES,"
     " and a guide on config JSON file structure, please visit "
     "https://github.com/High-Performance-IO/capio";
-constexpr char CAPIO_SERVER_ARG_PARSER_PRE_COMMAND[] = "{ENVIRONMENT_VARS}  mpirun -n 1";
 constexpr char CAPIO_SERVER_ARG_PARSER_LOGILE_DIR_OPT_HELP[] =
     "Name of the folder to which CAPIO server will put log files into";
 constexpr char CAPIO_SERVER_ARG_PARSER_LOGILE_OPT_HELP[] =
@@ -134,29 +142,12 @@ constexpr char CAPIO_SERVER_ARG_PARSER_STORE_ALL_IN_MEMORY_OPT_HELP[] =
     "Flag to set CAPIO and CAPIO-CL to store all files in memory, independently of the "
     "information provided by the CAPIO-CL configuration file";
 
-constexpr char CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING[] =
-    "[ \033[1;33m SERVER \033[0m ]\033[1;31m "
-    "|==================================================================|\033[0m\n"
-    "[ \033[1;33mCAPIO-SERVER \033[0m ]\033[1;31m |           you are running CAPIO with "
-    "--continue-on-error         |\033[0m\n"
-    "[ \033[1;33mCAPIO-SERVER \033[0m ]\033[1;31m |       This is extremely dangerous as CAPIO "
-    "server will continue  |\033[0m\n"
-    "[ \033[1;33mCAPIO-SERVER \033[0m ]\033[1;31m |              its execution even if it should "
-    "terminate.          |\033[0m\n"
-    "[ \033[1;33mCAPIO-SERVER \033[0m ]\033[1;31m |                                                "
-    "                  |\033[0m\n"
-    "[ \033[1;33mCAPIO-SERVER \033[0m ]\033[1;31m |                     USE IT AT YOUR OWN RISK    "
-    "                  |\033[0m\n"
-    "[ \033[1;33mCAPIO-SERVER \033[0m ]\033[1;31m |                                                "
-    "                  |\033[0m\n"
-    "[ \033[1;33mCAPIO-SERVER \033[0m ]\033[1;31m "
-    "|==================================================================|\033[0m\n";
-
 constexpr char CAPIO_SERVER_ARG_PARSER_CONFIG_BACKEND_HELP[] =
     "Backend used in CAPIO. The value [backend] can be one of the following implemented backends: "
     "\n\t> mpi \n\t> mpisync \n\t> none (default)";
 
 // Cli pre messages
+constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_STATUS[]  = "[\033[1;34mCAPIO-SERVER\033[0m ";
 constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_INFO[]    = "[\033[1;32mCAPIO-SERVER\033[0m ";
 constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_WARNING[] = "[\033[1;33mCAPIO-SERVER\033[0m ";
 constexpr char CAPIO_LOG_SERVER_CLI_LEVEL_ERROR[]   = "[\033[1;31mCAPIO-SERVER\033[0m ";

--- a/capio/common/shm.hpp
+++ b/capio/common/shm.hpp
@@ -11,6 +11,7 @@
 
 #include "common/logger.hpp"
 
+
 #ifdef __CAPIO_POSIX
 
 #define SHM_DESTROY_CHECK(source_name)                                                             \
@@ -24,6 +25,8 @@
     };
 
 #else
+
+#include "utils/server_println.hpp"
 
 #define SHM_DESTROY_CHECK(source_name)                                                             \
     if (shm_unlink(source_name) == -1) {                                                           \
@@ -55,20 +58,22 @@ class CapioShmCanary {
         if (_shm_id == -1) {
             LOG(CAPIO_SHM_CANARY_ERROR, _canary_name.data());
 #ifndef __CAPIO_POSIX
-            auto message = new char[strlen(CAPIO_SHM_CANARY_ERROR)];
+            const auto message = new char[strlen(CAPIO_SHM_CANARY_ERROR)];
             sprintf(message, CAPIO_SHM_CANARY_ERROR, _canary_name.data());
-            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << message << std::endl;
+            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "CapioShmCanary", message);
             delete[] message;
 #endif
             ERR_EXIT("ERR: shm canary flag already exists");
         }
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "CapioShmCanary",
+                       "Created Capio SHM canary: " + _canary_name);
     };
 
     ~CapioShmCanary() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
 #ifndef __CAPIO_POSIx
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "Removing shared memory canary flag"
-                  << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioShmCanary",
+                       "Removing shared memory canary flag");
 #endif
         close(_shm_id);
         SHM_DESTROY_CHECK(_canary_name.c_str());

--- a/capio/common/shm.hpp
+++ b/capio/common/shm.hpp
@@ -11,7 +11,6 @@
 
 #include "common/logger.hpp"
 
-
 #ifdef __CAPIO_POSIX
 
 #define SHM_DESTROY_CHECK(source_name)                                                             \
@@ -60,20 +59,23 @@ class CapioShmCanary {
 #ifndef __CAPIO_POSIX
             const auto message = new char[strlen(CAPIO_SHM_CANARY_ERROR)];
             sprintf(message, CAPIO_SHM_CANARY_ERROR, _canary_name.data());
-            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "CapioShmCanary", message);
+            server_println(capio_workflow_name, CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "CapioShmCanary",
+                           message);
             delete[] message;
 #endif
             ERR_EXIT("ERR: shm canary flag already exists");
         }
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "CapioShmCanary",
+#ifndef __CAPIO_POSIX
+        server_println(capio_workflow_name, CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "CapioShmCanary",
                        "Created Capio SHM canary: " + _canary_name);
+#endif
     };
 
     ~CapioShmCanary() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
-#ifndef __CAPIO_POSIx
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioShmCanary",
-                       "Removing shared memory canary flag");
+#ifndef __CAPIO_POSIX
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                       "CapioShmCanary", "Removing shared memory canary flag");
 #endif
         close(_shm_id);
         SHM_DESTROY_CHECK(_canary_name.c_str());

--- a/capio/common/shm.hpp
+++ b/capio/common/shm.hpp
@@ -59,23 +59,23 @@ class CapioShmCanary {
 #ifndef __CAPIO_POSIX
             const auto message = new char[strlen(CAPIO_SHM_CANARY_ERROR)];
             sprintf(message, CAPIO_SHM_CANARY_ERROR, _canary_name.data());
-            server_println(capio_workflow_name, CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "CapioShmCanary",
-                           message);
+            server_println(message, capio_workflow_name, CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                           "CapioShmCanary");
             delete[] message;
 #endif
             ERR_EXIT("ERR: shm canary flag already exists");
         }
 #ifndef __CAPIO_POSIX
-        server_println(capio_workflow_name, CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "CapioShmCanary",
-                       "Created Capio SHM canary: " + _canary_name);
+        server_println("Created Capio SHM canary: " + _canary_name, capio_workflow_name,
+                       CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "CapioShmCanary");
 #endif
     };
 
     ~CapioShmCanary() {
         START_LOG(capio_syscall(SYS_gettid), "call()");
 #ifndef __CAPIO_POSIX
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
-                       "CapioShmCanary", "Removing shared memory canary flag");
+        server_println("Removing shared memory canary flag", get_capio_workflow_name(),
+                       CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioShmCanary");
 #endif
         close(_shm_id);
         SHM_DESTROY_CHECK(_canary_name.c_str());

--- a/capio/server/CMakeLists.txt
+++ b/capio/server/CMakeLists.txt
@@ -37,7 +37,6 @@ target_sources(${TARGET_NAME} PRIVATE
 target_include_directories(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${MPI_INCLUDE_PATH}
-        ${args_SOURCE_DIR}
         ${capio_cl_SOURCE_DIR}
 )
 
@@ -55,7 +54,7 @@ ENDIF (MPI_LINK_FLAGS)
 #####################################
 # Link libraries
 #####################################
-target_link_libraries(${TARGET_NAME} PRIVATE ${MPI_LIBRARIES} pthread rt stdc++fs libcapio_cl)
+target_link_libraries(${TARGET_NAME} PRIVATE ${MPI_LIBRARIES} pthread rt stdc++fs libcapio_cl args)
 
 #####################################
 # Install rules

--- a/capio/server/capio_server.cpp
+++ b/capio/server/capio_server.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <args.hxx>
 #include <array>
 #include <cstdio>
 #include <cstring>
@@ -39,6 +38,7 @@ StorageManager *storage_manager;
 Backend *backend;
 
 #include "handlers.hpp"
+#include "utils/cli_parser.hpp"
 #include "utils/location.hpp"
 #include "utils/signals.hpp"
 
@@ -109,171 +109,6 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
         request_handlers[code](str.get());
         LOG(CAPIO_LOG_SERVER_REQUEST_END);
     }
-}
-
-struct CapioParsedConfig {
-    std::string backend_name;
-    std::string capio_cl_config_path;
-    std::string capio_cl_resolve_path;
-    bool capio_cl_dynamic_config = false;
-    bool store_all_in_memory     = false;
-};
-
-CapioParsedConfig parseCLI(int argc, char **argv) {
-    CapioParsedConfig capio_config;
-    Logger *log;
-
-    args::ArgumentParser parser(CAPIO_SERVER_ARG_PARSER_PRE, CAPIO_SERVER_ARG_PARSER_EPILOGUE);
-    parser.LongSeparator(" ");
-    parser.LongPrefix("--");
-    parser.ShortPrefix("-");
-
-    args::Group arguments(parser, "Arguments");
-    args::HelpFlag help(arguments, "help", "Display this help menu", {'h', "help"});
-    args::ValueFlag<std::string> logfile_src(arguments, "filename",
-                                             CAPIO_SERVER_ARG_PARSER_LOGILE_OPT_HELP, {'l', "log"});
-    args::ValueFlag<std::string> logfile_folder(
-        arguments, "filename", CAPIO_SERVER_ARG_PARSER_LOGILE_DIR_OPT_HELP, {'d', "log-dir"});
-    args::ValueFlag<std::string> resolve_prefix(arguments, "resolve-prefix",
-                                                CAPIO_SERVER_ARG_PARSER_RESOLVE_PREFIX_OPT_HELP,
-                                                {'r', "resolve-prefix"});
-
-    args::ValueFlag<std::string> config(arguments, "filename",
-                                        CAPIO_SERVER_ARG_PARSER_CONFIG_OPT_HELP, {'c', "config"});
-    args::Flag noConfigFile(arguments, "no-config",
-                            CAPIO_SERVER_ARG_PARSER_CONFIG_NO_CONF_FILE_HELP, {"no-config"});
-    args::ValueFlag<std::string> backend_flag(
-        arguments, "backend", CAPIO_SERVER_ARG_PARSER_CONFIG_BACKEND_HELP, {'b', "backend"});
-
-    args::Flag continueOnErrorFlag(arguments, "continue-on-error",
-                                   CAPIO_SERVER_ARG_PARSER_CONFIG_NCONTINUE_ON_ERROR_HELP,
-                                   {"continue-on-error"});
-    args::Flag mem_only_flag(arguments, "mem-only",
-                             CAPIO_SERVER_ARG_PARSER_STORE_ALL_IN_MEMORY_OPT_HELP, {"mem-only"});
-
-    try {
-        parser.ParseCLI(argc, argv);
-    } catch (args::Help &) {
-        std::cout << parser;
-        exit(EXIT_SUCCESS);
-    } catch (args::ParseError &e) {
-        std::cerr << e.what() << std::endl;
-        std::cerr << parser;
-        exit(EXIT_FAILURE);
-    } catch (args::ValidationError &e) {
-        std::cerr << e.what() << std::endl;
-        std::cerr << parser;
-        exit(EXIT_FAILURE);
-    }
-
-    if (continueOnErrorFlag) {
-#ifdef CAPIO_LOG
-        continue_on_error = true;
-        for (const auto line : CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING) {
-            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI", line);
-        }
-
-#else
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "--continue-on-error flag given, but logger is not compiled into CAPIO. "
-                       "Flag is ignored.");
-#endif
-    }
-
-    if (logfile_folder) {
-#ifdef CAPIO_LOG
-        log_master_dir_name = args::get(logfile_folder);
-#else
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "Capio logfile folder, but logging capabilities not compiled into capio!");
-#endif
-    }
-
-    if (logfile_src) {
-#ifdef CAPIO_LOG
-        // log file was given
-        std::string token = args::get(logfile_src);
-        if (token.find(".log") != std::string::npos) {
-            token.erase(token.length() - 4); // delete .log if for some reason
-            // is given as parameter
-        }
-        logfile_prefix = token;
-#else
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "Capio logfile provided, but logging capabilities not compiled into capio!");
-#endif
-    }
-#ifdef CAPIO_LOG
-    auto logname = open_server_logfile();
-    log          = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                   "started logging to logfile " + logname.string());
-#endif
-
-    if (mem_only_flag) {
-        capio_config.store_all_in_memory = args::get(mem_only_flag);
-    }
-
-    if (config) {
-
-        capio_config.capio_cl_config_path = args::get(config);
-
-        if (std::string token = args::get(config); token == "dynamic") {
-            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                           "Starting CAPIO-CL engine with dynamic configuration");
-            capio_config.capio_cl_dynamic_config = true;
-
-        } else {
-            std::filesystem::path resolve_path = "";
-
-            if (resolve_prefix) {
-                capio_config.capio_cl_resolve_path = args::get(resolve_prefix);
-            }
-        }
-
-    } else if (noConfigFile) {
-
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "skipping config file parsing.");
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "Obtained from environment variable current workflow name: " +
-                           get_capio_workflow_name());
-    } else {
-        server_println(
-            CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
-            "Error: no config file provided. To skip config file use --no-config option!");
-#ifdef CAPIO_LOG
-        log->log("no config file provided, and  --no-config not provided");
-#endif
-        exit(EXIT_FAILURE);
-    }
-
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                   "CAPIO_DIR=" + get_capio_dir().string());
-
-#ifdef CAPIO_LOG
-    CAPIO_LOG_LEVEL = get_capio_log_level();
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                   "LOG_LEVEL set to: " + std::to_string(CAPIO_LOG_LEVEL));
-    for (const auto &msg : CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING) {
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "Logger", msg);
-    }
-
-    log->log("LOG_LEVEL set to: %d", CAPIO_LOG_LEVEL);
-    delete log;
-#else
-    if (std::getenv("CAPIO_LOG_LEVEL") != nullptr) {
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE);
-    }
-#endif
-
-    // Backend selection phase
-    if (backend_flag) {
-        capio_config.backend_name = args::get(backend_flag);
-    }
-
-    return capio_config;
 }
 
 int main(int argc, char **argv) {

--- a/capio/server/capio_server.cpp
+++ b/capio/server/capio_server.cpp
@@ -101,8 +101,8 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
         LOG(CAPIO_LOG_SERVER_REQUEST_START);
         int code = client_manager->readNextRequest(str.get());
         if (code < 0 || code > CAPIO_NR_REQUESTS) {
-            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "capio_server",
-                           "Received invalid code: " + std::to_string(code));
+            server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                           "capio_server", "Received invalid code: " + std::to_string(code));
 
             ERR_EXIT("Error: received invalid request code");
         }
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
     Semaphore internal_server_sem(0);
 
     for (const auto line : CAPIO_LOG_SERVER_BANNER) {
-        server_println("", "", line);
+        server_println("", "", "", line);
     }
 
     const auto configuration = parseCLI(argc, argv);
@@ -153,8 +153,8 @@ int main(int argc, char **argv) {
     LOG("capio_server thread started");
     std::thread remote_listener_thread(capio_remote_listener, std::ref(internal_server_sem));
     LOG("capio_remote_listener thread started.");
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "main",
-                   "Server instance successfully started!");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
+                   "main", "Server instance successfully started!");
     server_thread.join();
     remote_listener_thread.join();
 

--- a/capio/server/capio_server.cpp
+++ b/capio/server/capio_server.cpp
@@ -1,5 +1,3 @@
-
-
 #include <algorithm>
 #include <args.hxx>
 #include <array>
@@ -103,8 +101,8 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
         LOG(CAPIO_LOG_SERVER_REQUEST_START);
         int code = client_manager->readNextRequest(str.get());
         if (code < 0 || code > CAPIO_NR_REQUESTS) {
-            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Received invalid code: " << code
-                      << std::endl;
+            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "capio_server",
+                           "Received invalid code: " + std::to_string(code));
 
             ERR_EXIT("Error: received invalid request code");
         }
@@ -113,7 +111,16 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
     }
 }
 
-int parseCLI(int argc, char **argv) {
+struct CapioParsedConfig {
+    std::string backend_name;
+    std::string capio_cl_config_path;
+    std::string capio_cl_resolve_path;
+    bool capio_cl_dynamic_config = false;
+    bool store_all_in_memory     = false;
+};
+
+CapioParsedConfig parseCLI(int argc, char **argv) {
+    CapioParsedConfig capio_config;
     Logger *log;
 
     args::ArgumentParser parser(CAPIO_SERVER_ARG_PARSER_PRE, CAPIO_SERVER_ARG_PARSER_EPILOGUE);
@@ -147,7 +154,7 @@ int parseCLI(int argc, char **argv) {
     try {
         parser.ParseCLI(argc, argv);
     } catch (args::Help &) {
-        std::cout << CAPIO_SERVER_ARG_PARSER_PRE_COMMAND << parser;
+        std::cout << parser;
         exit(EXIT_SUCCESS);
     } catch (args::ParseError &e) {
         std::cerr << e.what() << std::endl;
@@ -162,12 +169,14 @@ int parseCLI(int argc, char **argv) {
     if (continueOnErrorFlag) {
 #ifdef CAPIO_LOG
         continue_on_error = true;
-        std::cout << CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING << std::endl;
+        for (const auto line : CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING) {
+            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI", line);
+        }
+
 #else
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
-                  << "--continue-on-error flag given, but logger is not compiled into CAPIO. Flag "
-                     "is ignored."
-                  << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "--continue-on-error flag given, but logger is not compiled into CAPIO. "
+                       "Flag is ignored.");
 #endif
     }
 
@@ -175,9 +184,8 @@ int parseCLI(int argc, char **argv) {
 #ifdef CAPIO_LOG
         log_master_dir_name = args::get(logfile_folder);
 #else
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
-                  << "Capio logfile folder, but logging capabilities not compiled into capio!"
-                  << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "Capio logfile folder, but logging capabilities not compiled into capio!");
 #endif
     }
 
@@ -191,105 +199,112 @@ int parseCLI(int argc, char **argv) {
         }
         logfile_prefix = token;
 #else
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
-                  << "Capio logfile provided, but logging capabilities not compiled into capio!"
-                  << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "Capio logfile provided, but logging capabilities not compiled into capio!");
 #endif
     }
 #ifdef CAPIO_LOG
     auto logname = open_server_logfile();
     log          = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "started logging to logfile " << logname
-              << std::endl;
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                   "started logging to logfile " + logname.string());
 #endif
-    bool store_all_in_memory = false;
 
     if (mem_only_flag) {
-        store_all_in_memory = args::get(mem_only_flag);
+        capio_config.store_all_in_memory = args::get(mem_only_flag);
     }
 
     if (config) {
 
-        if (std::string token = args::get(config); token == "dynamic") {
-            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
-                      << "Starting CAPIO-CL engine with dynamic configuration" << std::endl;
+        capio_config.capio_cl_config_path = args::get(config);
 
-            capio_cl_engine = new capiocl::engine::Engine();
-            capio_cl_engine->startApiServer();
+        if (std::string token = args::get(config); token == "dynamic") {
+            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                           "Starting CAPIO-CL engine with dynamic configuration");
+            capio_config.capio_cl_dynamic_config = true;
+
         } else {
             std::filesystem::path resolve_path = "";
 
             if (resolve_prefix) {
-                resolve_path = args::get(resolve_prefix);
+                capio_config.capio_cl_resolve_path = args::get(resolve_prefix);
             }
-
-            std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "parsing config file: " << token
-                      << std::endl;
-
-            capio_cl_engine =
-                capiocl::parser::Parser::parse(token, resolve_path, store_all_in_memory);
         }
 
     } else if (noConfigFile) {
-        capio_cl_engine = new capiocl::engine::Engine();
-        capio_cl_engine->setWorkflowName(get_capio_workflow_name());
-        if (store_all_in_memory) {
-            capio_cl_engine->setAllStoreInMemory();
-        }
 
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "skipping config file parsing."
-                  << std::endl
-                  << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
-                  << "Obtained from environment variable current workflow name: "
-                  << capio_cl_engine->getWorkflowName() << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "skipping config file parsing.");
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "Obtained from environment variable current workflow name: " +
+                           get_capio_workflow_name());
     } else {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR
-                  << "Error: no config file provided. To skip config file use --no-config option!"
-                  << std::endl;
+        server_println(
+            CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
+            "Error: no config file provided. To skip config file use --no-config option!");
 #ifdef CAPIO_LOG
         log->log("no config file provided, and  --no-config not provided");
 #endif
         exit(EXIT_FAILURE);
     }
 
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "CAPIO_DIR=" << get_capio_dir().c_str()
-              << std::endl;
-
-    capio_cl_engine->print();
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                   "CAPIO_DIR=" + get_capio_dir().string());
 
 #ifdef CAPIO_LOG
     CAPIO_LOG_LEVEL = get_capio_log_level();
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "LOG_LEVEL set to: " << CAPIO_LOG_LEVEL
-              << std::endl;
-    std::cout << CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING;
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                   "LOG_LEVEL set to: " + std::to_string(CAPIO_LOG_LEVEL));
+    for (const auto &msg : CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING) {
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "Logger", msg);
+    }
+
     log->log("LOG_LEVEL set to: %d", CAPIO_LOG_LEVEL);
     delete log;
 #else
     if (std::getenv("CAPIO_LOG_LEVEL") != nullptr) {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING
-                  << CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE);
     }
 #endif
 
     // Backend selection phase
-    std::string backend_name_str;
     if (backend_flag) {
-        backend_name_str = args::get(backend_flag);
+        capio_config.backend_name = args::get(backend_flag);
     }
-    backend = select_backend(backend_name_str, argc, argv);
 
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "server initialization completed!" << std::endl
-              << std::flush;
-    return 0;
+    return capio_config;
 }
 
 int main(int argc, char **argv) {
 
     Semaphore internal_server_sem(0);
 
-    std::cout << CAPIO_LOG_SERVER_BANNER;
+    for (const auto line : CAPIO_LOG_SERVER_BANNER) {
+        server_println("", "", line);
+    }
 
-    parseCLI(argc, argv);
+    const auto configuration = parseCLI(argc, argv);
+
+    if (configuration.capio_cl_dynamic_config) {
+        capio_cl_engine = new capiocl::engine::Engine();
+        capio_cl_engine->startApiServer();
+    } else if (!configuration.capio_cl_config_path.empty()) {
+        capio_cl_engine = capiocl::parser::Parser::parse(configuration.capio_cl_config_path,
+                                                         configuration.capio_cl_resolve_path,
+                                                         configuration.store_all_in_memory);
+    } else {
+        capio_cl_engine = new capiocl::engine::Engine();
+        capio_cl_engine->setWorkflowName(get_capio_workflow_name());
+    }
+
+    if (configuration.store_all_in_memory) {
+        capio_cl_engine->setAllStoreInMemory();
+    }
+
+    capio_cl_engine->print();
+
+    backend = select_backend(configuration.backend_name, argc, argv);
 
     START_LOG(gettid(), "call()");
 
@@ -303,6 +318,8 @@ int main(int argc, char **argv) {
     LOG("capio_server thread started");
     std::thread remote_listener_thread(capio_remote_listener, std::ref(internal_server_sem));
     LOG("capio_remote_listener thread started.");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "main",
+                   "Server instance successfully started!");
     server_thread.join();
     remote_listener_thread.join();
 

--- a/capio/server/capio_server.cpp
+++ b/capio/server/capio_server.cpp
@@ -102,7 +102,7 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
         int code = client_manager->readNextRequest(str.get());
         if (code < 0 || code > CAPIO_NR_REQUESTS) {
             server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
-                           "capio_server", "Received invalid code: " + std::to_string(code));
+                           __func__, "Received invalid code: " + std::to_string(code));
 
             ERR_EXIT("Error: received invalid request code");
         }

--- a/capio/server/capio_server.cpp
+++ b/capio/server/capio_server.cpp
@@ -101,8 +101,9 @@ static constexpr std::array<CSHandler_t, CAPIO_NR_REQUESTS> build_request_handle
         LOG(CAPIO_LOG_SERVER_REQUEST_START);
         int code = client_manager->readNextRequest(str.get());
         if (code < 0 || code > CAPIO_NR_REQUESTS) {
-            server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
-                           __func__, "Received invalid code: " + std::to_string(code));
+            server_println("Received invalid code: " + std::to_string(code),
+                           CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                           __func__);
 
             ERR_EXIT("Error: received invalid request code");
         }
@@ -116,7 +117,7 @@ int main(int argc, char **argv) {
     Semaphore internal_server_sem(0);
 
     for (const auto line : CAPIO_LOG_SERVER_BANNER) {
-        server_println("", "", "", line);
+        server_println(line, "", "", "");
     }
 
     const auto configuration = parseCLI(argc, argv);
@@ -153,8 +154,8 @@ int main(int argc, char **argv) {
     LOG("capio_server thread started");
     std::thread remote_listener_thread(capio_remote_listener, std::ref(internal_server_sem));
     LOG("capio_remote_listener thread started.");
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
-                   "main", "Server instance successfully started!");
+    server_println("Server instance successfully started!", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "main");
     server_thread.join();
     remote_listener_thread.join();
 

--- a/capio/server/include/remote/listener.hpp
+++ b/capio/server/include/remote/listener.hpp
@@ -50,7 +50,7 @@ inline Backend *select_backend(const std::string &backend_name, int argc, char *
     LOG("Backend %s does not exist in CAPIO. Reverting back to the default backend (none)",
         backend_name.c_str());
     server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "select_backend",
-                   " Backend " + backend_name +
+                   "Backend " + backend_name +
                        " does not exist. Reverting to the default backend (none)");
     return new NoneBackend(argc, argv);
 }

--- a/capio/server/include/remote/listener.hpp
+++ b/capio/server/include/remote/listener.hpp
@@ -28,28 +28,30 @@ inline Backend *select_backend(const std::string &backend_name, int argc, char *
     if (backend_name.empty() || backend_name == "none") {
         LOG("backend selected: none");
         server_println(
-            CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "select_backend",
+            CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+            "select_backend",
             "Starting CAPIO with default backend (none) as no preferred backend was chosen");
         return new NoneBackend(argc, argv);
     }
 
     if (backend_name == "mpi") {
         LOG("backend selected: mpi");
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "select_backend",
-                       "Starting CAPIO with MPI backend");
+        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                       "select_backend", "Starting CAPIO with MPI backend");
         return new MPIBackend(argc, argv);
     }
 
     if (backend_name == "mpisync") {
         LOG("backend selected: mpisync");
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "select_backend",
-                       "Starting CAPIO with MPI (SYNC) backend");
+        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                       "select_backend", "Starting CAPIO with MPI (SYNC) backend");
         return new MPISYNCBackend(argc, argv);
     }
 
     LOG("Backend %s does not exist in CAPIO. Reverting back to the default backend (none)",
         backend_name.c_str());
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "select_backend",
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                   "select_backend",
                    "Backend " + backend_name +
                        " does not exist. Reverting to the default backend (none)");
     return new NoneBackend(argc, argv);
@@ -63,7 +65,8 @@ inline void capio_remote_listener(Semaphore &internal_server_sem) {
 
     if (typeid(*backend) == typeid(NoneBackend)) {
         server_println(
-            CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "capio_remote_listener",
+            CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+            "capio_remote_listener",
             "backend is of type NoneBackend. Stopping capio_remote_listener() execution.");
         return;
     }

--- a/capio/server/include/remote/listener.hpp
+++ b/capio/server/include/remote/listener.hpp
@@ -27,30 +27,31 @@ inline Backend *select_backend(const std::string &backend_name, int argc, char *
 
     if (backend_name.empty() || backend_name == "none") {
         LOG("backend selected: none");
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
-                  << "Starting CAPIO with default backend (none) as no preferred backend was chosen"
-                  << std::endl;
+        server_println(
+            CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "select_backend",
+            "Starting CAPIO with default backend (none) as no preferred backend was chosen");
         return new NoneBackend(argc, argv);
     }
 
     if (backend_name == "mpi") {
         LOG("backend selected: mpi");
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Starting CAPIO with MPI backend"
-                  << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "select_backend",
+                       "Starting CAPIO with MPI backend");
         return new MPIBackend(argc, argv);
     }
 
     if (backend_name == "mpisync") {
         LOG("backend selected: mpisync");
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "Starting CAPIO with MPI (SYNC) backend"
-                  << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "select_backend",
+                       "Starting CAPIO with MPI (SYNC) backend");
         return new MPISYNCBackend(argc, argv);
     }
 
     LOG("Backend %s does not exist in CAPIO. Reverting back to the default backend (none)",
         backend_name.c_str());
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << " Backend " << backend_name
-              << " does not exist. Reverting to the default backend (none)" << std::endl;
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "select_backend",
+                   " Backend " + backend_name +
+                       " does not exist. Reverting to the default backend (none)");
     return new NoneBackend(argc, argv);
 }
 
@@ -61,10 +62,9 @@ inline void capio_remote_listener(Semaphore &internal_server_sem) {
     internal_server_sem.lock();
 
     if (typeid(*backend) == typeid(NoneBackend)) {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO
-                  << " RemoteListener] backend is of type NoneBackend. Stopping "
-                     "capio_remote_listener() execution."
-                  << std::endl;
+        server_println(
+            CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "capio_remote_listener",
+            "backend is of type NoneBackend. Stopping capio_remote_listener() execution.");
         return;
     }
 

--- a/capio/server/include/remote/listener.hpp
+++ b/capio/server/include/remote/listener.hpp
@@ -28,32 +28,33 @@ inline Backend *select_backend(const std::string &backend_name, int argc, char *
     if (backend_name.empty() || backend_name == "none") {
         LOG("backend selected: none");
         server_println(
+            "Starting CAPIO with default backend (none) as no preferred backend was chosen",
             CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-            "select_backend",
-            "Starting CAPIO with default backend (none) as no preferred backend was chosen");
+            "select_backend");
         return new NoneBackend(argc, argv);
     }
 
     if (backend_name == "mpi") {
         LOG("backend selected: mpi");
-        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                       "select_backend", "Starting CAPIO with MPI backend");
+        server_println("Starting CAPIO with MPI backend", CapioCLEngine::get().getWorkflowName(),
+                       CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "select_backend");
         return new MPIBackend(argc, argv);
     }
 
     if (backend_name == "mpisync") {
         LOG("backend selected: mpisync");
-        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                       "select_backend", "Starting CAPIO with MPI (SYNC) backend");
+        server_println("Starting CAPIO with MPI (SYNC) backend",
+                       CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                       "select_backend");
         return new MPISYNCBackend(argc, argv);
     }
 
     LOG("Backend %s does not exist in CAPIO. Reverting back to the default backend (none)",
         backend_name.c_str());
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
-                   "select_backend",
-                   "Backend " + backend_name +
-                       " does not exist. Reverting to the default backend (none)");
+    server_println("Backend " + backend_name +
+                       " does not exist. Reverting to the default backend (none)",
+                   CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                   "select_backend");
     return new NoneBackend(argc, argv);
 }
 
@@ -65,9 +66,9 @@ inline void capio_remote_listener(Semaphore &internal_server_sem) {
 
     if (typeid(*backend) == typeid(NoneBackend)) {
         server_println(
+            "backend is of type NoneBackend. Stopping capio_remote_listener() execution.",
             CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-            "capio_remote_listener",
-            "backend is of type NoneBackend. Stopping capio_remote_listener() execution.");
+            "capio_remote_listener");
         return;
     }
 

--- a/capio/server/include/utils/cli_parser.hpp
+++ b/capio/server/include/utils/cli_parser.hpp
@@ -1,0 +1,15 @@
+#ifndef CAPIO_CLI_PARSER_HPP
+#define CAPIO_CLI_PARSER_HPP
+#include <string>
+
+struct CapioParsedConfig {
+    std::string backend_name;
+    std::string capio_cl_config_path;
+    std::string capio_cl_resolve_path;
+    bool capio_cl_dynamic_config = false;
+    bool store_all_in_memory     = false;
+};
+
+CapioParsedConfig parseCLI(int argc, char **argv);
+
+#endif // CAPIO_CLI_PARSER_HPP

--- a/capio/server/include/utils/common.hpp
+++ b/capio/server/include/utils/common.hpp
@@ -83,13 +83,20 @@ inline bool is_int(const std::string &s) {
     return res;
 }
 
-inline void server_println(const std::string &message_type = "",
-                           const std::string &message_line = "") {
+inline void server_println(const std::string &message_type   = "",
+                           const std::string &component_name = "CAPIO",
+                           const std::string &message_line   = "") {
+    static char *node_name = nullptr;
+    if (node_name == nullptr) {
+        node_name = new char[HOST_NAME_MAX]{0};
+        gethostname(node_name, HOST_NAME_MAX);
+    }
+
     if (message_type.empty()) {
-        std::cout << std::endl;
+        std::cout << message_line << std::endl;
     } else {
-        std::cout << message_type << " " << get_capio_workflow_name() << "] " << message_line
-                  << std::endl
+        std::cout << message_type << " " << node_name << "][" << component_name << "] "
+                  << message_line << std::endl
                   << std::flush;
     }
 }

--- a/capio/server/include/utils/common.hpp
+++ b/capio/server/include/utils/common.hpp
@@ -84,32 +84,4 @@ inline bool is_int(const std::string &s) {
     return res;
 }
 
-inline void server_println(const std::string_view message_color  = "",
-                           const std::string_view component_name = "CAPIO",
-                           const std::string_view message_line   = "") {
-
-    static char node_name[HOST_NAME_MAX];
-    // static init once the nodename
-    [[maybe_unused]] static bool host_init = []() {
-        if (gethostname(node_name, HOST_NAME_MAX) != 0) {
-            snprintf(node_name, HOST_NAME_MAX, "unknown");
-        }
-        return true;
-    }();
-
-    if (message_color.empty()) {
-        std::cout << message_line << "\n";
-        return;
-    }
-
-    // Get current time
-    const auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-
-    std::cout << message_color << "[CAPIO-SERVER ~ " << get_capio_workflow_name() << "]"
-              << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " ["
-              << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] " << " "
-              << node_name << "@" << std::left << std::setw(20) << component_name.substr(0, 20)
-              << " | " << message_line << "\n"
-              << std::flush;
-}
 #endif // CAPIO_SERVER_UTILS_COMMON_HPP

--- a/capio/server/include/utils/common.hpp
+++ b/capio/server/include/utils/common.hpp
@@ -1,6 +1,7 @@
 #ifndef CAPIO_SERVER_UTILS_COMMON_HPP
 #define CAPIO_SERVER_UTILS_COMMON_HPP
 
+#include <iomanip>
 #include <string>
 #include <thread>
 
@@ -83,22 +84,32 @@ inline bool is_int(const std::string &s) {
     return res;
 }
 
-inline void server_println(const std::string &message_type   = "",
-                           const std::string &component_name = "CAPIO",
-                           const std::string &message_line   = "") {
-    static char *node_name = nullptr;
-    if (node_name == nullptr) {
-        node_name = new char[HOST_NAME_MAX]{0};
-        gethostname(node_name, HOST_NAME_MAX);
+inline void server_println(const std::string_view message_color  = "",
+                           const std::string_view component_name = "CAPIO",
+                           const std::string_view message_line   = "") {
+
+    static char node_name[HOST_NAME_MAX];
+    // static init once the nodename
+    [[maybe_unused]] static bool host_init = []() {
+        if (gethostname(node_name, HOST_NAME_MAX) != 0) {
+            snprintf(node_name, HOST_NAME_MAX, "unknown");
+        }
+        return true;
+    }();
+
+    if (message_color.empty()) {
+        std::cout << message_line << "\n";
+        return;
     }
 
-    if (message_type.empty()) {
-        std::cout << message_line << std::endl;
-    } else {
-        std::cout << message_type << " " << node_name << "][" << component_name << "] "
-                  << message_line << std::endl
-                  << std::flush;
-    }
+    // Get current time
+    const auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+
+    std::cout << message_color << "[CAPIO-SERVER ~ " << get_capio_workflow_name() << "]"
+              << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " ["
+              << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] " << " "
+              << node_name << "@" << std::left << std::setw(20) << component_name.substr(0, 20)
+              << " | " << message_line << "\n"
+              << std::flush;
 }
-
 #endif // CAPIO_SERVER_UTILS_COMMON_HPP

--- a/capio/server/include/utils/server_println.hpp
+++ b/capio/server/include/utils/server_println.hpp
@@ -5,9 +5,9 @@
 #include <string_view>
 
 #include "common/constants.hpp"
-#include "common/env.hpp"
 
-inline void server_println(const std::string_view message_color  = "",
+inline void server_println(const std::string_view workflow_name  = CAPIO_DEFAULT_WORKFLOW_NAME,
+                           const std::string_view message_color  = CAPIO_LOG_SERVER_CLI_LEVEL_RESET,
                            const std::string_view component_name = "CAPIO",
                            const std::string_view message_line   = "") {
 
@@ -28,11 +28,11 @@ inline void server_println(const std::string_view message_color  = "",
     // Get current time
     const auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
-    std::cout << message_color << "[CAPIO-SERVER > " << get_capio_workflow_name() << "]"
-              << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " ["
-              << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] " << " "
-              << node_name << "@" << std::left << std::setw(20) << component_name.substr(0, 20)
-              << " | " << message_line << "\n"
-              << std::flush;
+    std::cout << message_color << "[CAPIO-SERVER > " << workflow_name << "]";
+    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " [";
+    std::cout << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] ";
+    std::cout << " " << node_name << "@" << std::left << std::setw(20);
+    std::cout << component_name.substr(0, 20) << " | " << message_line << "\n";
+    std::cout << std::flush;
 }
 #endif // CAPIO_PRINT_TEXT_HPP

--- a/capio/server/include/utils/server_println.hpp
+++ b/capio/server/include/utils/server_println.hpp
@@ -28,7 +28,7 @@ inline void server_println(const std::string_view message_color  = "",
     // Get current time
     const auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
-    std::cout << message_color << "[CAPIO-SERVER ~ " << get_capio_workflow_name() << "]"
+    std::cout << message_color << "[CAPIO-SERVER > " << get_capio_workflow_name() << "]"
               << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " ["
               << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] " << " "
               << node_name << "@" << std::left << std::setw(20) << component_name.substr(0, 20)

--- a/capio/server/include/utils/server_println.hpp
+++ b/capio/server/include/utils/server_println.hpp
@@ -1,0 +1,38 @@
+#ifndef CAPIO_PRINT_TEXT_HPP
+#define CAPIO_PRINT_TEXT_HPP
+#include <chrono>
+#include <iostream>
+#include <string_view>
+
+#include "common/constants.hpp"
+#include "common/env.hpp"
+
+inline void server_println(const std::string_view message_color  = "",
+                           const std::string_view component_name = "CAPIO",
+                           const std::string_view message_line   = "") {
+
+    static char node_name[HOST_NAME_MAX];
+    // static init once the nodename
+    [[maybe_unused]] static bool host_init = []() {
+        if (gethostname(node_name, HOST_NAME_MAX) != 0) {
+            snprintf(node_name, HOST_NAME_MAX, "unknown");
+        }
+        return true;
+    }();
+
+    if (message_color.empty()) {
+        std::cout << message_line << "\n";
+        return;
+    }
+
+    // Get current time
+    const auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+
+    std::cout << message_color << "[CAPIO-SERVER ~ " << get_capio_workflow_name() << "]"
+              << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " ["
+              << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] " << " "
+              << node_name << "@" << std::left << std::setw(20) << component_name.substr(0, 20)
+              << " | " << message_line << "\n"
+              << std::flush;
+}
+#endif // CAPIO_PRINT_TEXT_HPP

--- a/capio/server/include/utils/server_println.hpp
+++ b/capio/server/include/utils/server_println.hpp
@@ -28,10 +28,11 @@ inline void server_println(const std::string_view workflow_name  = CAPIO_DEFAULT
     // Get current time
     const auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
-    std::cout << message_color << "[CAPIO-SERVER > " << workflow_name << "]";
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " [";
-    std::cout << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] ";
-    std::cout << " " << node_name << "@" << std::left << std::setw(20);
-    std::cout << component_name.substr(0, 20) << " | " << message_line << std::endl;
+    std::cout << message_color << "[CAPIO-SERVER > " << workflow_name << "]"
+              << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " ["
+              << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] "
+              << " " << node_name << "@" << std::left << std::setw(20)
+              << component_name.substr(0, 20) << " | " << message_line << std::endl
+              << std::flush;
 }
 #endif // CAPIO_PRINT_TEXT_HPP

--- a/capio/server/include/utils/server_println.hpp
+++ b/capio/server/include/utils/server_println.hpp
@@ -32,7 +32,6 @@ inline void server_println(const std::string_view workflow_name  = CAPIO_DEFAULT
     std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_RESET << " [";
     std::cout << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S") << "] ";
     std::cout << " " << node_name << "@" << std::left << std::setw(20);
-    std::cout << component_name.substr(0, 20) << " | " << message_line << "\n";
-    std::cout << std::flush;
+    std::cout << component_name.substr(0, 20) << " | " << message_line << std::endl;
 }
 #endif // CAPIO_PRINT_TEXT_HPP

--- a/capio/server/include/utils/server_println.hpp
+++ b/capio/server/include/utils/server_println.hpp
@@ -6,10 +6,10 @@
 
 #include "common/constants.hpp"
 
-inline void server_println(const std::string_view workflow_name  = CAPIO_DEFAULT_WORKFLOW_NAME,
+inline void server_println(const std::string_view message_line,
+                           const std::string_view workflow_name  = CAPIO_DEFAULT_WORKFLOW_NAME,
                            const std::string_view message_color  = CAPIO_LOG_SERVER_CLI_LEVEL_RESET,
-                           const std::string_view component_name = "CAPIO",
-                           const std::string_view message_line   = "") {
+                           const std::string_view component_name = "CAPIO") {
 
     static char node_name[HOST_NAME_MAX];
     // static init once the nodename

--- a/capio/server/include/utils/server_println.hpp
+++ b/capio/server/include/utils/server_println.hpp
@@ -21,7 +21,7 @@ inline void server_println(const std::string_view workflow_name  = CAPIO_DEFAULT
     }();
 
     if (message_color.empty()) {
-        std::cout << message_line << "\n";
+        std::cout << message_line << std::endl;
         return;
     }
 

--- a/capio/server/include/utils/signals.hpp
+++ b/capio/server/include/utils/signals.hpp
@@ -4,6 +4,7 @@
 #include <csignal>
 
 #include "remote/backend.hpp"
+#include "server_println.hpp"
 
 #ifdef CAPIO_COVERAGE
 extern "C" void __gcov_dump(void);
@@ -13,10 +14,10 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     START_LOG(gettid(), "call(signal=[%d] (%s) from process with pid=%ld)", signum,
               strsignal(signum), info != nullptr ? info->si_pid : -1);
 
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "shutting down server");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "sig_term_handler", "shutting down server");
 
     if (signum == SIGSEGV) {
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "Segfault detected!");
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "sig_term_handler", "Segfault detected!");
     }
 
     // free all the memory used
@@ -24,7 +25,8 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     delete client_manager;
     delete storage_manager;
 
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "data_buffers cleanup completed");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "sig_term_handler",
+                   "data_buffers cleanup completed");
 
 #ifdef CAPIO_COVERAGE
     __gcov_dump();
@@ -33,7 +35,7 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     delete backend;
     delete shm_canary;
 
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "shutdown completed");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "sig_term_handler", "shutdown completed");
     exit(EXIT_SUCCESS);
 }
 
@@ -54,6 +56,8 @@ void setup_signal_handlers() {
     if (res == -1) {
         ERR_EXIT("sigaction for SIGTERM");
     }
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "setup_signal_handlers",
+                   "Installed signal handlers");
 }
 
 #endif // CAPIO_SERVER_HANDLERS_SIGNALS_HPP

--- a/capio/server/include/utils/signals.hpp
+++ b/capio/server/include/utils/signals.hpp
@@ -13,22 +13,18 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     START_LOG(gettid(), "call(signal=[%d] (%s) from process with pid=%ld)", signum,
               strsignal(signum), info != nullptr ? info->si_pid : -1);
 
-    std::cout << std::endl
-              << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "shutting down server" << std::endl;
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "shutting down server");
 
     if (signum == SIGSEGV) {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Segfault detected!" << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "Segfault detected!");
     }
 
     // free all the memory used
 
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "shm cleanup completed" << std::endl;
-
     delete client_manager;
     delete storage_manager;
 
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_WARNING << "data_buffers cleanup completed"
-              << std::endl;
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "data_buffers cleanup completed");
 
 #ifdef CAPIO_COVERAGE
     __gcov_dump();
@@ -37,7 +33,7 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     delete backend;
     delete shm_canary;
 
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << "shutdown completed" << std::endl;
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "shutdown completed");
     exit(EXIT_SUCCESS);
 }
 

--- a/capio/server/include/utils/signals.hpp
+++ b/capio/server/include/utils/signals.hpp
@@ -14,10 +14,12 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     START_LOG(gettid(), "call(signal=[%d] (%s) from process with pid=%ld)", signum,
               strsignal(signum), info != nullptr ? info->si_pid : -1);
 
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "sig_term_handler", "shutting down server");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                   "sig_term_handler", "shutting down server");
 
     if (signum == SIGSEGV) {
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "sig_term_handler", "Segfault detected!");
+        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                       "sig_term_handler", "Segfault detected!");
     }
 
     // free all the memory used
@@ -25,8 +27,8 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     delete client_manager;
     delete storage_manager;
 
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "sig_term_handler",
-                   "data_buffers cleanup completed");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                   "sig_term_handler", "data_buffers cleanup completed");
 
 #ifdef CAPIO_COVERAGE
     __gcov_dump();
@@ -35,7 +37,8 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     delete backend;
     delete shm_canary;
 
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "sig_term_handler", "shutdown completed");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                   "sig_term_handler", "shutdown completed");
     exit(EXIT_SUCCESS);
 }
 
@@ -56,8 +59,8 @@ void setup_signal_handlers() {
     if (res == -1) {
         ERR_EXIT("sigaction for SIGTERM");
     }
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "setup_signal_handlers",
-                   "Installed signal handlers");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
+                   "setup_signal_handlers", "Installed signal handlers");
 }
 
 #endif // CAPIO_SERVER_HANDLERS_SIGNALS_HPP

--- a/capio/server/include/utils/signals.hpp
+++ b/capio/server/include/utils/signals.hpp
@@ -14,12 +14,12 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     START_LOG(gettid(), "call(signal=[%d] (%s) from process with pid=%ld)", signum,
               strsignal(signum), info != nullptr ? info->si_pid : -1);
 
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
-                   "sig_term_handler", "shutting down server");
+    server_println("shutting down server", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, __func__);
 
     if (signum == SIGSEGV) {
-        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
-                       "sig_term_handler", "Segfault detected!");
+        server_println("Segfault detected!", CapioCLEngine::get().getWorkflowName(),
+                       CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, __func__);
     }
 
     // free all the memory used
@@ -27,8 +27,8 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     delete client_manager;
     delete storage_manager;
 
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
-                   "sig_term_handler", "data_buffers cleanup completed");
+    server_println("data_buffers cleanup completed", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, __func__);
 
 #ifdef CAPIO_COVERAGE
     __gcov_dump();
@@ -37,8 +37,8 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
     delete backend;
     delete shm_canary;
 
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                   "sig_term_handler", "shutdown completed");
+    server_println("shutdown completed", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_INFO, __func__);
     exit(EXIT_SUCCESS);
 }
 
@@ -59,8 +59,8 @@ void setup_signal_handlers() {
     if (res == -1) {
         ERR_EXIT("sigaction for SIGTERM");
     }
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
-                   "setup_signal_handlers", "Installed signal handlers");
+    server_println("Installed signal handlers", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, __func__);
 }
 
 #endif // CAPIO_SERVER_HANDLERS_SIGNALS_HPP

--- a/capio/server/src/backend.cpp
+++ b/capio/server/src/backend.cpp
@@ -12,9 +12,10 @@ Backend::Backend(const unsigned int node_name_max_length)
 
     gethostname(node_name.data(), node_name_max_length);
     node_name.resize(strlen(node_name.data()));
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "Backend", "Node name: " + node_name);
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "Backend",
-                   "Node count: " + std::to_string(n_servers));
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                   "Backend", "Node name: " + node_name);
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                   "Backend", "Node count: " + std::to_string(n_servers));
 }
 
 [[nodiscard]] const std::string &Backend::get_node_name() const {

--- a/capio/server/src/backend.cpp
+++ b/capio/server/src/backend.cpp
@@ -1,6 +1,7 @@
 #include "remote/backend.hpp"
 
 #include "utils/common.hpp"
+#include "utils/server_println.hpp"
 
 #include <iostream>
 

--- a/capio/server/src/backend.cpp
+++ b/capio/server/src/backend.cpp
@@ -1,5 +1,7 @@
 #include "remote/backend.hpp"
 
+#include "utils/common.hpp"
+
 #include <iostream>
 
 Backend::Backend(const unsigned int node_name_max_length)
@@ -9,11 +11,9 @@ Backend::Backend(const unsigned int node_name_max_length)
 
     gethostname(node_name.data(), node_name_max_length);
     node_name.resize(strlen(node_name.data()));
-
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << " Backend] Node name: " << node_name
-              << std::endl;
-    std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_INFO << " Backend] Node Count: " << n_servers
-              << std::endl;
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "Backend", "Node name: " + node_name);
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "Backend",
+                   "Node count: " + std::to_string(n_servers));
 }
 
 [[nodiscard]] const std::string &Backend::get_node_name() const {

--- a/capio/server/src/backend.cpp
+++ b/capio/server/src/backend.cpp
@@ -12,10 +12,11 @@ Backend::Backend(const unsigned int node_name_max_length)
 
     gethostname(node_name.data(), node_name_max_length);
     node_name.resize(strlen(node_name.data()));
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                   "Backend", "Node name: " + node_name);
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                   "Backend", "Node count: " + std::to_string(n_servers));
+    server_println("Node name: " + node_name, CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "Backend");
+    server_println("Node count: " + std::to_string(n_servers),
+                   CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                   "Backend");
 }
 
 [[nodiscard]] const std::string &Backend::get_node_name() const {

--- a/capio/server/src/capio_file.cpp
+++ b/capio/server/src/capio_file.cpp
@@ -34,7 +34,8 @@ CapioFile::~CapioFile() {
             delete[] _buf;
         } else {
             if (munmap(_buf, _buf_size) == -1) {
-                server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioFile",
+                server_println(CapioCLEngine::get().getWorkflowName(),
+                               CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioFile",
                                "WARN: unable to unmap CapioFile: " + std::string(strerror(errno)));
             }
         }

--- a/capio/server/src/capio_file.cpp
+++ b/capio/server/src/capio_file.cpp
@@ -33,7 +33,7 @@ CapioFile::~CapioFile() {
             delete[] _buf;
         } else {
             if (munmap(_buf, _buf_size) == -1) {
-                server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioFile",
                                "WARN: unable to unmap CapioFile: " + std::string(strerror(errno)));
             }
         }

--- a/capio/server/src/capio_file.cpp
+++ b/capio/server/src/capio_file.cpp
@@ -3,6 +3,7 @@
 #include "common/logger.hpp"
 #include "remote/backend.hpp"
 #include "server/include/utils/common.hpp"
+#include "server/include/utils/server_println.hpp"
 #include "utils/shared_mutex.hpp"
 
 extern Backend *backend;

--- a/capio/server/src/capio_file.cpp
+++ b/capio/server/src/capio_file.cpp
@@ -34,9 +34,9 @@ CapioFile::~CapioFile() {
             delete[] _buf;
         } else {
             if (munmap(_buf, _buf_size) == -1) {
-                server_println(CapioCLEngine::get().getWorkflowName(),
-                               CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioFile",
-                               "WARN: unable to unmap CapioFile: " + std::string(strerror(errno)));
+                server_println("WARN: unable to unmap CapioFile: " + std::string(strerror(errno)),
+                               CapioCLEngine::get().getWorkflowName(),
+                               CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "CapioFile");
             }
         }
     } else {

--- a/capio/server/src/cli_parser.cpp
+++ b/capio/server/src/cli_parser.cpp
@@ -1,0 +1,164 @@
+#include "utils/cli_parser.hpp"
+
+#include "common/constants.hpp"
+#include "common/logger.hpp"
+#include "utils/common.hpp"
+
+#include <args.hxx>
+
+CapioParsedConfig parseCLI(int argc, char **argv) {
+    CapioParsedConfig capio_config;
+    Logger *log;
+
+    args::ArgumentParser parser(CAPIO_SERVER_ARG_PARSER_PRE, CAPIO_SERVER_ARG_PARSER_EPILOGUE);
+    parser.LongSeparator(" ");
+    parser.LongPrefix("--");
+    parser.ShortPrefix("-");
+
+    args::Group arguments(parser, "Arguments");
+    args::HelpFlag help(arguments, "help", "Display this help menu", {'h', "help"});
+    args::ValueFlag<std::string> logfile_src(arguments, "filename",
+                                             CAPIO_SERVER_ARG_PARSER_LOGILE_OPT_HELP, {'l', "log"});
+    args::ValueFlag<std::string> logfile_folder(
+        arguments, "filename", CAPIO_SERVER_ARG_PARSER_LOGILE_DIR_OPT_HELP, {'d', "log-dir"});
+    args::ValueFlag<std::string> resolve_prefix(arguments, "resolve-prefix",
+                                                CAPIO_SERVER_ARG_PARSER_RESOLVE_PREFIX_OPT_HELP,
+                                                {'r', "resolve-prefix"});
+
+    args::ValueFlag<std::string> config(arguments, "filename",
+                                        CAPIO_SERVER_ARG_PARSER_CONFIG_OPT_HELP, {'c', "config"});
+    args::Flag noConfigFile(arguments, "no-config",
+                            CAPIO_SERVER_ARG_PARSER_CONFIG_NO_CONF_FILE_HELP, {"no-config"});
+    args::ValueFlag<std::string> backend_flag(
+        arguments, "backend", CAPIO_SERVER_ARG_PARSER_CONFIG_BACKEND_HELP, {'b', "backend"});
+
+    args::Flag continueOnErrorFlag(arguments, "continue-on-error",
+                                   CAPIO_SERVER_ARG_PARSER_CONFIG_NCONTINUE_ON_ERROR_HELP,
+                                   {"continue-on-error"});
+    args::Flag mem_only_flag(arguments, "mem-only",
+                             CAPIO_SERVER_ARG_PARSER_STORE_ALL_IN_MEMORY_OPT_HELP, {"mem-only"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help &) {
+        std::cout << parser;
+        exit(EXIT_SUCCESS);
+    } catch (args::ParseError &e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        exit(EXIT_FAILURE);
+    } catch (args::ValidationError &e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        exit(EXIT_FAILURE);
+    }
+
+    if (continueOnErrorFlag) {
+#ifdef CAPIO_LOG
+        continue_on_error = true;
+        for (const auto line : CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING) {
+            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI", line);
+        }
+
+#else
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "--continue-on-error flag given, but logger is not compiled into CAPIO. "
+                       "Flag is ignored.");
+#endif
+    }
+
+    if (logfile_folder) {
+#ifdef CAPIO_LOG
+        log_master_dir_name = args::get(logfile_folder);
+#else
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "Capio logfile folder, but logging capabilities not compiled into capio!");
+#endif
+    }
+
+    if (logfile_src) {
+#ifdef CAPIO_LOG
+        // log file was given
+        std::string token = args::get(logfile_src);
+        if (token.find(".log") != std::string::npos) {
+            token.erase(token.length() - 4); // delete .log if for some reason
+            // is given as parameter
+        }
+        logfile_prefix = token;
+#else
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "Capio logfile provided, but logging capabilities not compiled into capio!");
+#endif
+    }
+#ifdef CAPIO_LOG
+    auto logname = open_server_logfile();
+    log          = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                   "started logging to logfile " + logname.string());
+#endif
+
+    if (mem_only_flag) {
+        capio_config.store_all_in_memory = args::get(mem_only_flag);
+    }
+
+    if (config) {
+
+        capio_config.capio_cl_config_path = args::get(config);
+
+        if (std::string token = args::get(config); token == "dynamic") {
+            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                           "Starting CAPIO-CL engine with dynamic configuration");
+            capio_config.capio_cl_dynamic_config = true;
+
+        } else {
+            std::filesystem::path resolve_path = "";
+
+            if (resolve_prefix) {
+                capio_config.capio_cl_resolve_path = args::get(resolve_prefix);
+            }
+        }
+
+    } else if (noConfigFile) {
+
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "skipping config file parsing.");
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       "Obtained from environment variable current workflow name: " +
+                           get_capio_workflow_name());
+    } else {
+        server_println(
+            CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
+            "Error: no config file provided. To skip config file use --no-config option!");
+#ifdef CAPIO_LOG
+        log->log("no config file provided, and  --no-config not provided");
+#endif
+        exit(EXIT_FAILURE);
+    }
+
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                   "CAPIO_DIR=" + get_capio_dir().string());
+
+#ifdef CAPIO_LOG
+    CAPIO_LOG_LEVEL = get_capio_log_level();
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+                   "LOG_LEVEL set to: " + std::to_string(CAPIO_LOG_LEVEL));
+    for (const auto &msg : CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING) {
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "Logger", msg);
+    }
+
+    log->log("LOG_LEVEL set to: %d", CAPIO_LOG_LEVEL);
+    delete log;
+#else
+    if (std::getenv("CAPIO_LOG_LEVEL") != nullptr) {
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+                       CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE);
+    }
+#endif
+
+    // Backend selection phase
+    if (backend_flag) {
+        capio_config.backend_name = args::get(backend_flag);
+    }
+
+    return capio_config;
+}

--- a/capio/server/src/cli_parser.cpp
+++ b/capio/server/src/cli_parser.cpp
@@ -3,6 +3,7 @@
 #include "common/constants.hpp"
 #include "common/logger.hpp"
 #include "utils/common.hpp"
+#include "utils/server_println.hpp"
 
 #include <args.hxx>
 

--- a/capio/server/src/cli_parser.cpp
+++ b/capio/server/src/cli_parser.cpp
@@ -58,11 +58,12 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
 #ifdef CAPIO_LOG
         continue_on_error = true;
         for (const auto line : CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING) {
-            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI", line);
+            server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
+                           line);
         }
 
 #else
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
                        "--continue-on-error flag given, but logger is not compiled into CAPIO. "
                        "Flag is ignored.");
 #endif
@@ -72,7 +73,7 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
 #ifdef CAPIO_LOG
         log_master_dir_name = args::get(logfile_folder);
 #else
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
                        "Capio logfile folder, but logging capabilities not compiled into capio!");
 #endif
     }
@@ -87,14 +88,14 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
         }
         logfile_prefix = token;
 #else
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
                        "Capio logfile provided, but logging capabilities not compiled into capio!");
 #endif
     }
 #ifdef CAPIO_LOG
     auto logname = open_server_logfile();
     log          = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+    server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
                    "started logging to logfile " + logname.string());
 #endif
 
@@ -107,7 +108,7 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
         capio_config.capio_cl_config_path = args::get(config);
 
         if (std::string token = args::get(config); token == "dynamic") {
-            server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+            server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
                            "Starting CAPIO-CL engine with dynamic configuration");
             capio_config.capio_cl_dynamic_config = true;
 
@@ -121,14 +122,14 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
 
     } else if (noConfigFile) {
 
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
                        "skipping config file parsing.");
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
                        "Obtained from environment variable current workflow name: " +
                            get_capio_workflow_name());
     } else {
         server_println(
-            CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
+            get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
             "Error: no config file provided. To skip config file use --no-config option!");
 #ifdef CAPIO_LOG
         log->log("no config file provided, and  --no-config not provided");
@@ -136,22 +137,23 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
 
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+    server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
                    "CAPIO_DIR=" + get_capio_dir().string());
 
 #ifdef CAPIO_LOG
     CAPIO_LOG_LEVEL = get_capio_log_level();
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
+    server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
                    "LOG_LEVEL set to: " + std::to_string(CAPIO_LOG_LEVEL));
     for (const auto &msg : CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING) {
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "Logger", msg);
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "Logger",
+                       msg);
     }
 
     log->log("LOG_LEVEL set to: %d", CAPIO_LOG_LEVEL);
     delete log;
 #else
     if (std::getenv("CAPIO_LOG_LEVEL") != nullptr) {
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
+        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
                        CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE);
     }
 #endif

--- a/capio/server/src/cli_parser.cpp
+++ b/capio/server/src/cli_parser.cpp
@@ -58,14 +58,14 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
 #ifdef CAPIO_LOG
         continue_on_error = true;
         for (const auto line : CAPIO_LOG_SERVER_CLI_CONT_ON_ERR_WARNING) {
-            server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
-                           line);
+            server_println(line, get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                           __func__);
         }
 
 #else
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "--continue-on-error flag given, but logger is not compiled into CAPIO. "
-                       "Flag is ignored.");
+        server_println("--continue-on-error flag given, but logger is not compiled into CAPIO. "
+                       "Flag is ignored.",
+                       get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI");
 #endif
     }
 
@@ -73,8 +73,8 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
 #ifdef CAPIO_LOG
         log_master_dir_name = args::get(logfile_folder);
 #else
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "Capio logfile folder, but logging capabilities not compiled into capio!");
+        server_println("Capio logfile folder, but logging capabilities not compiled into capio!",
+                       get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI");
 #endif
     }
 
@@ -88,15 +88,15 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
         }
         logfile_prefix = token;
 #else
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "Capio logfile provided, but logging capabilities not compiled into capio!");
+        server_println("Capio logfile provided, but logging capabilities not compiled into capio!",
+                       get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI");
 #endif
     }
 #ifdef CAPIO_LOG
     auto logname = open_server_logfile();
     log          = new Logger(__func__, __FILE__, __LINE__, gettid(), "Created new log file");
-    server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                   "started logging to logfile " + logname.string());
+    server_println("started logging to logfile " + logname.string(), get_capio_workflow_name(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI");
 #endif
 
     if (mem_only_flag) {
@@ -108,8 +108,8 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
         capio_config.capio_cl_config_path = args::get(config);
 
         if (std::string token = args::get(config); token == "dynamic") {
-            server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                           "Starting CAPIO-CL engine with dynamic configuration");
+            server_println("Starting CAPIO-CL engine with dynamic configuration",
+                           get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, __func__);
             capio_config.capio_cl_dynamic_config = true;
 
         } else {
@@ -122,39 +122,39 @@ CapioParsedConfig parseCLI(int argc, char **argv) {
 
     } else if (noConfigFile) {
 
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "skipping config file parsing.");
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       "Obtained from environment variable current workflow name: " +
-                           get_capio_workflow_name());
+        server_println("skipping config file parsing.", get_capio_workflow_name(),
+                       CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, __func__);
+        server_println("Obtained from environment variable current workflow name: " +
+                           get_capio_workflow_name(),
+                       get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, __func__);
     } else {
         server_println(
-            get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "parseCLI",
-            "Error: no config file provided. To skip config file use --no-config option!");
+            "Error: no config file provided. To skip config file use --no-config option!",
+            get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, __func__);
 #ifdef CAPIO_LOG
         log->log("no config file provided, and  --no-config not provided");
 #endif
         exit(EXIT_FAILURE);
     }
 
-    server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                   "CAPIO_DIR=" + get_capio_dir().string());
+    server_println("CAPIO_DIR=" + get_capio_dir().string(), get_capio_workflow_name(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_INFO, __func__);
 
 #ifdef CAPIO_LOG
     CAPIO_LOG_LEVEL = get_capio_log_level();
-    server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "parseCLI",
-                   "LOG_LEVEL set to: " + std::to_string(CAPIO_LOG_LEVEL));
+    server_println("LOG_LEVEL set to: " + std::to_string(CAPIO_LOG_LEVEL),
+                   get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO, __func__);
     for (const auto &msg : CAPIO_LOG_SERVER_CLI_LOGGING_ENABLED_WARNING) {
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "Logger",
-                       msg);
+        server_println(msg, get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                       __func__);
     }
 
     log->log("LOG_LEVEL set to: %d", CAPIO_LOG_LEVEL);
     delete log;
 #else
     if (std::getenv("CAPIO_LOG_LEVEL") != nullptr) {
-        server_println(get_capio_workflow_name(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "parseCLI",
-                       CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE);
+        server_println(CAPIO_LOG_SERVER_CLI_LOGGING_NOT_AVAILABLE, get_capio_workflow_name(),
+                       CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, __func__);
     }
 #endif
 

--- a/capio/server/src/client_manager.cpp
+++ b/capio/server/src/client_manager.cpp
@@ -7,6 +7,7 @@
 #include "common/queue.hpp"
 #include "utils/capiocl_adapter.hpp"
 #include "utils/common.hpp"
+#include "utils/server_println.hpp"
 
 ClientManager::ClientDataBuffers::ClientDataBuffers(const std::string &clientToServerName,
                                                     const std::string &serverToClientName,

--- a/capio/server/src/client_manager.cpp
+++ b/capio/server/src/client_manager.cpp
@@ -40,6 +40,12 @@ void ClientManager::registerClient(pid_t tid, const std::string &app_name, const
     responses.try_emplace(tid, SHM_COMM_CHAN_NAME_RESP + std::to_string(tid), CAPIO_REQ_BUFF_CNT,
                           sizeof(off_t), CapioCLEngine::get().getWorkflowName());
 
+    DBG(tid, [](const int tid_app, const std::string &app_name) {
+        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                       "ClientManager",
+                       "Registered PID " + std::to_string(tid_app) + " with app name " + app_name);
+    }(tid, app_name));
+
     if (wait) {
         std::thread t([&, target_tid = tid]() {
             std::unique_lock<std::mutex> lock(mutex_thread_allowed_to_continue);
@@ -77,6 +83,12 @@ void ClientManager::removeClient(const pid_t tid) {
     if (const auto response_buffer = responses.find(tid); response_buffer != responses.end()) {
         responses.erase(response_buffer);
     }
+    DBG(tid, [](const int tid_app, const std::string &app_name) {
+        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                       "ClientManager"
+                       "Removed PID " +
+                           std::to_string(tid_app) + " with app name " + app_name);
+    }(tid, app_name));
 }
 
 void ClientManager::replyToClient(const pid_t tid, const off64_t offset) {

--- a/capio/server/src/client_manager.cpp
+++ b/capio/server/src/client_manager.cpp
@@ -18,11 +18,13 @@ ClientManager::ClientDataBuffers::ClientDataBuffers(const std::string &clientToS
 ClientManager::ClientManager()
     : requests{SHM_COMM_CHAN_NAME, CAPIO_REQ_BUFF_CNT, CAPIO_REQ_MAX_SIZE,
                CapioCLEngine::get().getWorkflowName()} {
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "ClientManager", "initialization completed.");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
+                   "ClientManager", "initialization completed.");
 }
 
 ClientManager::~ClientManager() {
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "ClientManager", "teardown completed.");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                   "ClientManager", "teardown completed.");
 }
 
 void ClientManager::registerClient(pid_t tid, const std::string &app_name, const bool wait) {
@@ -176,9 +178,10 @@ int ClientManager::readNextRequest(char *str) {
     if (ec == std::errc()) {
         strcpy(str, ptr + 1);
     } else {
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "readNextRequest",
-                       "Received invalid request: " + std::string(str));
-        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "readNextRequest",
+        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                       "readNextRequest", "Received invalid request: " + std::string(str));
+        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                       "readNextRequest",
                        "Code " + std::to_string(code) +
                            " is not mapped to a valid request handler");
 

--- a/capio/server/src/client_manager.cpp
+++ b/capio/server/src/client_manager.cpp
@@ -17,11 +17,11 @@ ClientManager::ClientDataBuffers::ClientDataBuffers(const std::string &clientToS
 ClientManager::ClientManager()
     : requests{SHM_COMM_CHAN_NAME, CAPIO_REQ_BUFF_CNT, CAPIO_REQ_MAX_SIZE,
                CapioCLEngine::get().getWorkflowName()} {
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "ClientManager initialization completed.");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "ClientManager", "initialization completed.");
 }
 
 ClientManager::~ClientManager() {
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "ClientManager teardown completed.");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "ClientManager", "teardown completed.");
 }
 
 void ClientManager::registerClient(pid_t tid, const std::string &app_name, const bool wait) {
@@ -175,10 +175,12 @@ int ClientManager::readNextRequest(char *str) {
     if (ec == std::errc()) {
         strcpy(str, ptr + 1);
     } else {
-        std::cout << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Received invalid request: " << str
-                  << std::endl
-                  << CAPIO_LOG_SERVER_CLI_LEVEL_ERROR << "Code " << code
-                  << " is not mapped to a valid request handler" << std::endl;
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "readNextRequest",
+                       "Received invalid request: " + std::string(str));
+        server_println(CAPIO_LOG_SERVER_CLI_LEVEL_ERROR, "readNextRequest",
+                       "Code " + std::to_string(code) +
+                           " is not mapped to a valid request handler");
+
         return -1;
     }
     return code;

--- a/capio/server/src/client_manager.cpp
+++ b/capio/server/src/client_manager.cpp
@@ -18,13 +18,13 @@ ClientManager::ClientDataBuffers::ClientDataBuffers(const std::string &clientToS
 ClientManager::ClientManager()
     : requests{SHM_COMM_CHAN_NAME, CAPIO_REQ_BUFF_CNT, CAPIO_REQ_MAX_SIZE,
                CapioCLEngine::get().getWorkflowName()} {
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
-                   "ClientManager", "initialization completed.");
+    server_println("initialization completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "ClientManager");
 }
 
 ClientManager::~ClientManager() {
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
-                   "ClientManager", "teardown completed.");
+    server_println("teardown completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_WARNING, "ClientManager");
 }
 
 void ClientManager::registerClient(pid_t tid, const std::string &app_name, const bool wait) {
@@ -41,9 +41,9 @@ void ClientManager::registerClient(pid_t tid, const std::string &app_name, const
                           sizeof(off_t), CapioCLEngine::get().getWorkflowName());
 
     DBG(tid, [](const int tid_app, const std::string &app_name) {
-        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                       "ClientManager",
-                       "Registered PID " + std::to_string(tid_app) + " with app name " + app_name);
+        server_println("Registered PID " + std::to_string(tid_app) + " with app name " + app_name,
+                       CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                       "ClientManager");
     }(tid, app_name));
 
     if (wait) {
@@ -84,10 +84,9 @@ void ClientManager::removeClient(const pid_t tid) {
         responses.erase(response_buffer);
     }
     DBG(tid, [](const int tid_app, const std::string &app_name) {
-        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
-                       "ClientManager"
-                       "Removed PID " +
-                           std::to_string(tid_app) + " with app name " + app_name);
+        server_println("Removed PID " + std::to_string(tid_app) + " with app name " + app_name,
+                       CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_WARNING,
+                       "ClientManager");
     }(tid, app_name));
 }
 
@@ -190,12 +189,12 @@ int ClientManager::readNextRequest(char *str) {
     if (ec == std::errc()) {
         strcpy(str, ptr + 1);
     } else {
-        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
-                       "readNextRequest", "Received invalid request: " + std::string(str));
-        server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
-                       "readNextRequest",
-                       "Code " + std::to_string(code) +
-                           " is not mapped to a valid request handler");
+        server_println("Received invalid request: " + std::string(str),
+                       CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                       __func__);
+        server_println("Code " + std::to_string(code) + " is not mapped to a valid request handler",
+                       CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_ERROR,
+                       __func__);
 
         return -1;
     }

--- a/capio/server/src/mpi_backend.cpp
+++ b/capio/server/src/mpi_backend.cpp
@@ -1,4 +1,6 @@
 #include "remote/backend/mpi.hpp"
+#include "utils/capiocl_adapter.hpp"
+#include "utils/server_println.hpp"
 
 MPIBackend::MPIBackend(int argc, char **argv) : Backend(MPI_MAX_PROCESSOR_NAME) {
     int node_name_len, provided;
@@ -20,11 +22,15 @@ MPIBackend::MPIBackend(int argc, char **argv) : Backend(MPI_MAX_PROCESSOR_NAME) 
     nodes.emplace(node_name);
     rank_to_hostname[rank]      = node_name;
     hostname_to_rank[node_name] = rank;
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
+                   "MPIBackend", "initialization completed.");
 }
 
 MPIBackend::~MPIBackend() {
     START_LOG(gettid(), "Call()");
     MPI_Finalize();
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                   "MPIBackend", "teardown completed.");
 }
 
 const std::set<std::string> MPIBackend::get_nodes() { return nodes; }
@@ -117,11 +123,15 @@ void MPIBackend::recv_file(char *shm, const std::string &source, long int bytes_
 MPISYNCBackend::MPISYNCBackend(int argc, char *argv[]) : MPIBackend(argc, argv) {
     START_LOG(gettid(), "call()");
     LOG("Wrapped MPI backend with MPISYC backend");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
+                   "MPISYNCBackend", "initialization completed.");
 }
 
 MPISYNCBackend::~MPISYNCBackend() {
     START_LOG(gettid(), "Call()");
     MPI_Finalize();
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                   "MPISYNCBackend", "teardown completed.");
 }
 
 RemoteRequest MPISYNCBackend::read_next_request() {

--- a/capio/server/src/mpi_backend.cpp
+++ b/capio/server/src/mpi_backend.cpp
@@ -22,15 +22,15 @@ MPIBackend::MPIBackend(int argc, char **argv) : Backend(MPI_MAX_PROCESSOR_NAME) 
     nodes.emplace(node_name);
     rank_to_hostname[rank]      = node_name;
     hostname_to_rank[node_name] = rank;
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
-                   "MPIBackend", "initialization completed.");
+    server_println("initialization completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "MPIBackend");
 }
 
 MPIBackend::~MPIBackend() {
     START_LOG(gettid(), "Call()");
     MPI_Finalize();
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                   "MPIBackend", "teardown completed.");
+    server_println("teardown completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "MPIBackend");
 }
 
 const std::set<std::string> MPIBackend::get_nodes() { return nodes; }
@@ -123,15 +123,15 @@ void MPIBackend::recv_file(char *shm, const std::string &source, long int bytes_
 MPISYNCBackend::MPISYNCBackend(int argc, char *argv[]) : MPIBackend(argc, argv) {
     START_LOG(gettid(), "call()");
     LOG("Wrapped MPI backend with MPISYC backend");
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
-                   "MPISYNCBackend", "initialization completed.");
+    server_println("initialization completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "MPISYNCBackend");
 }
 
 MPISYNCBackend::~MPISYNCBackend() {
     START_LOG(gettid(), "Call()");
     MPI_Finalize();
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                   "MPISYNCBackend", "teardown completed.");
+    server_println("teardown completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "MPISYNCBackend");
 }
 
 RemoteRequest MPISYNCBackend::read_next_request() {

--- a/capio/server/src/none_backend.cpp
+++ b/capio/server/src/none_backend.cpp
@@ -1,9 +1,13 @@
 #include <thread>
 
 #include "remote/backend/none.hpp"
+#include "utils/capiocl_adapter.hpp"
+#include "utils/server_println.hpp"
 
 NoneBackend::NoneBackend(int argc, char **argv) : Backend(HOST_NAME_MAX) {
     START_LOG(gettid(), "call()");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
+                   "NoneBackend", "initialization completed.");
 }
 
 RemoteRequest NoneBackend::read_next_request() {

--- a/capio/server/src/none_backend.cpp
+++ b/capio/server/src/none_backend.cpp
@@ -6,8 +6,8 @@
 
 NoneBackend::NoneBackend(int argc, char **argv) : Backend(HOST_NAME_MAX) {
     START_LOG(gettid(), "call()");
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
-                   "NoneBackend", "initialization completed.");
+    server_println("initialization completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "NoneBackend");
 }
 
 RemoteRequest NoneBackend::read_next_request() {

--- a/capio/server/src/storage_manager.cpp
+++ b/capio/server/src/storage_manager.cpp
@@ -67,8 +67,8 @@ void StorageManager::addDirectoryEntry(const pid_t tid, const std::filesystem::p
     }
 }
 StorageManager::StorageManager() {
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "StorageManager",
-                   "initialization completed.");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
+                   "StorageManager", "initialization completed.");
 }
 
 StorageManager::~StorageManager() {
@@ -83,7 +83,8 @@ StorageManager::~StorageManager() {
             _removeFromTid(tid, fd);
         }
     }
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "StorageManager", "teardown completed.");
+    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
+                   "StorageManager", "teardown completed.");
 }
 
 std::optional<std::reference_wrapper<CapioFile>>

--- a/capio/server/src/storage_manager.cpp
+++ b/capio/server/src/storage_manager.cpp
@@ -67,7 +67,8 @@ void StorageManager::addDirectoryEntry(const pid_t tid, const std::filesystem::p
     }
 }
 StorageManager::StorageManager() {
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "StorageManager", "initialization completed.");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "StorageManager",
+                   "initialization completed.");
 }
 
 StorageManager::~StorageManager() {

--- a/capio/server/src/storage_manager.cpp
+++ b/capio/server/src/storage_manager.cpp
@@ -67,7 +67,7 @@ void StorageManager::addDirectoryEntry(const pid_t tid, const std::filesystem::p
     }
 }
 StorageManager::StorageManager() {
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "StorageManager initialization completed.");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "StorageManager", "initialization completed.");
 }
 
 StorageManager::~StorageManager() {
@@ -82,7 +82,7 @@ StorageManager::~StorageManager() {
             _removeFromTid(tid, fd);
         }
     }
-    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "StorageManager teardown completed.");
+    server_println(CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "StorageManager", "teardown completed.");
 }
 
 std::optional<std::reference_wrapper<CapioFile>>

--- a/capio/server/src/storage_manager.cpp
+++ b/capio/server/src/storage_manager.cpp
@@ -67,8 +67,8 @@ void StorageManager::addDirectoryEntry(const pid_t tid, const std::filesystem::p
     }
 }
 StorageManager::StorageManager() {
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_STATUS,
-                   "StorageManager", "initialization completed.");
+    server_println("initialization completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_STATUS, "StorageManager");
 }
 
 StorageManager::~StorageManager() {
@@ -83,8 +83,8 @@ StorageManager::~StorageManager() {
             _removeFromTid(tid, fd);
         }
     }
-    server_println(CapioCLEngine::get().getWorkflowName(), CAPIO_LOG_SERVER_CLI_LEVEL_INFO,
-                   "StorageManager", "teardown completed.");
+    server_println("teardown completed.", CapioCLEngine::get().getWorkflowName(),
+                   CAPIO_LOG_SERVER_CLI_LEVEL_INFO, "StorageManager");
 }
 
 std::optional<std::reference_wrapper<CapioFile>>

--- a/capio/tests/unit/server/CMakeLists.txt
+++ b/capio/tests/unit/server/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(${TARGET_NAME} PRIVATE
 #####################################
 # Link libraries
 #####################################
-target_link_libraries(${TARGET_NAME} PRIVATE GTest::gtest_main rt libcapio_cl MPI::MPI_CXX)
+target_link_libraries(${TARGET_NAME} PRIVATE GTest::gtest_main rt libcapio_cl MPI::MPI_CXX args)
 
 #####################################
 # Configure tests


### PR DESCRIPTION
This commit cleans up and standardizes the various message prints that the server performs during its execution. It also updates the `parseCLI` method; instead of instantiating objects directly, it now populates a structure that is returned with the parsed parameters. This structure is then used to instantiate objects from the CAPIO server main function.