### PR TITLE
Updated CAPIO-CL dependency

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -119,6 +119,7 @@ jobs:
           - gcc:13
           - gcc:14
           - gcc:15
+          - gcc:16
           - zhongruoyu/llvm-ports:13.0-trixie
           - zhongruoyu/llvm-ports:14.0-trixie
           - zhongruoyu/llvm-ports:15.0-trixie

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ ENDIF (CAPIO_LOG AND CMAKE_BUILD_TYPE STREQUAL "Debug")
 FetchContent_Declare(
         capio_cl
         GIT_REPOSITORY https://github.com/High-Performance-IO/CAPIO-CL.git
-        GIT_TAG v1.4.0
+        GIT_TAG v1.4.1
 )
 
 #####################################


### PR DESCRIPTION
This commit updates the CAPIO-CL dependency to ensure compatibility with GCC 16. It also updates the CI/CD to run tests against the GCC 16 compiler suite.