### PR TITLE
Fix off-by-one buffer overflow in integration test `mergeFunction`

### DIFF
--- a/capio/tests/integration/src/mapreduce.cpp
+++ b/capio/tests/integration/src/mapreduce.cpp
@@ -222,7 +222,7 @@ int mergeFunction(ssize_t nfiles, char *sourcedir, char *destdir) {
     }
     delete[] filepath;
 
-    auto resultpath = new char[strlen(destdir) + strlen("/result.dat")];
+    auto resultpath = new char[strlen(destdir) + strlen("/result.dat") + 1];
     sprintf(resultpath, "%s/result.dat", destdir);
     FILE *fp = fopen(resultpath, "w");
     EXPECT_TRUE(fp);


### PR DESCRIPTION
The `resultpath` variable was allocated as `strlen(destdir) + strlen("/result.dat")` bytes, but the subsequent `sprintf` writes that many characters plus the terminating `NULL`, overflowing the heap buffer by one byte.

With `_FORTIFY_SOURCE` active (e.g. `-O3` on recent GCC/glibc) the fortified `sprintf` detects the overflow and aborts with `*** buffer overflow detected ***`, crashing the `RunTestSplitMergeAndMapReduceFunction` integration test.

Reserve one extra byte for the `NULL` terminator.