### PR TITLE
Update CI/CD dropping unmaintained gcc compilers

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -112,9 +112,6 @@ jobs:
           - Debug
           - Release
         compiler:
-          - gcc:9
-          - gcc:10
-          - gcc:11
           - gcc:12
           - gcc:13
           - gcc:14
@@ -140,7 +137,7 @@ jobs:
       - name: "Install gfortran (OpenMPI dependency)"
         if: ${{ startsWith(matrix.compiler, 'gcc:') }}
         run: |
-          apt update
+          apt update -o Acquire::Check-Valid-Until=false
           apt install -y gfortran || true
           update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-* 100
 

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -142,38 +142,48 @@ jobs:
           update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-* 100
 
       - name: "Install packages"
-        run: |
-          apt update
-          apt install -y      \
-            openmpi-bin       \
-            libopenmpi-dev    \
-            ninja-build       \
-            cmake             \
-            make              \
-            sudo              \
-            bash              \
-            git               \
-            jq                \
-            pkg-config        \
-            build-essential   \
-            wget              \
-            tar               \
-            python3           \
-            python3-pip       \
-            python3-venv
+        uses: nick-fields/retry@v3
+        with:
+          command: |
+            apt update
+            apt install -y      \
+              openmpi-bin       \
+              libopenmpi-dev    \
+              ninja-build       \
+              cmake             \
+              make              \
+              sudo              \
+              bash              \
+              git               \
+              jq                \
+              pkg-config        \
+              build-essential   \
+              wget              \
+              tar               \
+              python3           \
+              python3-pip       \
+              python3-venv
+          max_attempts: 3
+          retry_wait_seconds: 10
+          timeout_minutes: 10
 
       - name: "Run CMake"
-        shell: bash
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                -DCAPIO_LOG=${{ matrix.build_type == 'Debug' && 'ON' || 'OFF' }} \
-                -DENABLE_COVERAGE=${{ matrix.build_type == 'Debug' && 'ON' || 'OFF' }} \
-                -DCAPIO_BUILD_TESTS=ON \
-                -G Ninja \
-                -B ../build \
-                -S ${GITHUB_WORKSPACE}
-          cmake --build ../build -j $(nproc)
-          sudo cmake --install ../build --prefix /usr/local
+        uses: nick-fields/retry@v3
+        with:
+          command: |
+            cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                  -DCAPIO_LOG=${{ matrix.build_type == 'Debug' && 'ON' || 'OFF' }} \
+                  -DENABLE_COVERAGE=${{ matrix.build_type == 'Debug' && 'ON' || 'OFF' }} \
+                  -DCAPIO_BUILD_TESTS=ON \
+                  -G Ninja \
+                  -B ../build \
+                  -S ${GITHUB_WORKSPACE}
+            cmake --build ../build -j $(nproc)
+            sudo cmake --install ../build --prefix /usr/local
+          max_attempts: 3
+          retry_wait_seconds: 10
+          timeout_minutes: 30
+
       - name: "Run tests"
         id: run-tests
         shell: bash

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -120,16 +120,17 @@ jobs:
           - gcc:14
           - gcc:15
           - gcc:16
-          - zhongruoyu/llvm-ports:13.0-trixie
-          - zhongruoyu/llvm-ports:14.0-trixie
-          - zhongruoyu/llvm-ports:15.0-trixie
-          - zhongruoyu/llvm-ports:16.0-trixie
-          - zhongruoyu/llvm-ports:17.0-trixie
+          - zhongruoyu/llvm-ports:13-trixie
+          - zhongruoyu/llvm-ports:14-trixie
+          - zhongruoyu/llvm-ports:15-trixie
+          - zhongruoyu/llvm-ports:16-trixie
+          - zhongruoyu/llvm-ports:17-trixie
           - zhongruoyu/llvm-ports:18-trixie
-          - zhongruoyu/llvm-ports:19.1-bullseye
-          - zhongruoyu/llvm-ports:20.1-bullseye
-          - zhongruoyu/llvm-ports:21.1-bullseye
-
+          - zhongruoyu/llvm-ports:19-trixie
+          - zhongruoyu/llvm-ports:20-trixie
+          - zhongruoyu/llvm-ports:21-trixie
+          - zhongruoyu/llvm-ports:22-trixie
+          - zhongruoyu/llvm-ports:23-trixie
     container:
       image: ${{ matrix.compiler }}
 


### PR DESCRIPTION
Refreshes the CI compiler test matrix in `.github/workflows/ci-tests.yaml`, dropping outdated images, fixing a resulting `apt update` failure, and making the build steps resilient to transient failures outside our control.

- Dropped old GCC compilers `gcc:9`–`gcc:11` from the build matrix (kept `gcc:12`–`gcc:16`).
- Re-tagged `zhongruoyu/llvm-ports` from `X.0-trixie`/`X.1-bullseye` to plain `X-trixie` versions (`13`–`21`).
- Added new compilers: `clang 22` and `clang 23` (`zhongruoyu/llvm-ports:22-trixie`, `zhongruoyu/llvm-ports:23-trixie`).
- Added `-o Acquire::Check-Valid-Until=false` to the `apt update` step (gfortran install) to work around expired repo metadata on older base images.
- Wrapped the "Install packages" and "Run CMake" steps in `nick-fields/retry@v3` (3 attempts, 10s wait between retries; 10min timeout for install, 30min timeout for CMake) so transient package-mirror or build-environment failures don't fail CI outright.